### PR TITLE
Add issue templates for bug reports, feature requests, and documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,57 @@
+name: Bug Report
+description: Report a bug or issue with the app
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! Please fill out the information below.
+  
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened? What did you expect to happen?
+      placeholder: The app crashes when I click...
+    validations:
+      required: true
+  
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: How can we reproduce this issue?
+      placeholder: |
+        1. Open the app
+        2. Click on Settings
+        3. ...
+    validations:
+      required: true
+  
+  - type: input
+    id: version
+    attributes:
+      label: App Version
+      description: What version are you using? (Check Settings → About)
+      placeholder: v1.3.0
+    validations:
+      required: true
+  
+  - type: input
+    id: macos
+    attributes:
+      label: macOS Version
+      description: What version of macOS are you running?
+      placeholder: macOS 14.2 (Sonoma)
+    validations:
+      required: true
+  
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any logs, screenshots, or other relevant information
+      placeholder: Console.app shows...
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Question or Discussion
+    url: https://github.com/hamed-elfayome/Claude-Usage-Tracker/discussions
+    about: For questions or general discussions, please use GitHub Discussions

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,44 @@
+name: Documentation Improvement
+description: Suggest improvements to documentation
+title: "[Docs] "
+labels: ["documentation"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve our documentation!
+  
+  - type: textarea
+    id: issue
+    attributes:
+      label: Documentation Issue
+      description: What's unclear, missing, or incorrect in the documentation?
+      placeholder: The README doesn't explain how to...
+    validations:
+      required: true
+  
+  - type: input
+    id: location
+    attributes:
+      label: Location
+      description: Where is this documentation located?
+      placeholder: README.md, line 245
+    validations:
+      required: false
+  
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested Improvement
+      description: How should we improve this?
+      placeholder: We should add a section that explains...
+    validations:
+      required: true
+  
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any examples or references that might help
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,45 @@
+name: Feature Request
+description: Suggest a new feature or enhancement
+title: "[Feature] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature! Please describe what you'd like to see.
+  
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or Use Case
+      description: What problem would this feature solve? Or what would you like to accomplish?
+      placeholder: I'd like to be able to...
+    validations:
+      required: true
+  
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: How would you like this to work?
+      placeholder: The app could...
+    validations:
+      required: true
+  
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Are there any workarounds or alternative solutions you've thought about?
+      placeholder: I currently work around this by...
+    validations:
+      required: false
+  
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any mockups, examples, or other relevant information
+      placeholder: Here's a screenshot of how it might look...
+    validations:
+      required: false


### PR DESCRIPTION
## Summary
Adds GitHub issue templates to streamline contributions and improve issue quality.

## Changes
- **Bug Report Template**: Essential fields for app version, macOS version, description, and reproduction steps
- **Feature Request Template**: Problem-focused template with proposed solution
- **Documentation Template**: Simple template for doc improvements
- **Template Config**: Directs questions to GitHub Discussions

## Approach
Following the KISS principle - three focused templates covering ~80% of expected issue types:
1. Bug reports (crashes, API issues, UI glitches)
2. Feature requests (new functionality)
3. Documentation improvements

Templates use GitHub's YAML format for a modern form-based experience.

Closes #11