### PR TITLE
Fix version display to use dynamic Bundle value

### DIFF
--- a/Claude Usage.xcodeproj/project.pbxproj
+++ b/Claude Usage.xcodeproj/project.pbxproj
@@ -265,7 +265,7 @@
 					LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "HamedElfayome.Claude-Usage";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -305,7 +305,7 @@
 					LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "HamedElfayome.Claude-Usage";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;

--- a/Claude Usage/Resources/Info.plist
+++ b/Claude Usage/Resources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>CFBundleIconName</key>

--- a/Claude Usage/Views/SettingsView.swift
+++ b/Claude Usage/Views/SettingsView.swift
@@ -541,6 +541,13 @@ struct NotificationsView: View {
 // MARK: - About View
 
 struct AboutView: View {
+    private var appVersion: String {
+        if let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
+            return version
+        }
+        return "Unknown"
+    }
+    
     var body: some View {
         VStack(spacing: 0) {
             VStack(spacing: 28) {
@@ -557,7 +564,7 @@ struct AboutView: View {
                     Text("Claude Usage Tracker")
                         .font(.system(size: 18, weight: .semibold))
 
-                    Text("Version 1.0.0")
+                    Text("Version \(appVersion)")
                         .font(.system(size: 11))
                         .foregroundColor(.secondary)
                 }


### PR DESCRIPTION
## Summary
Fixes the hardcoded version display in Settings → About to dynamically read from the app's Info.plist using the Bundle class.

## Changes
- **AboutView**: Added computed property to fetch version from 
- **Info.plist**: Changed hardcoded  to  variable
- **Project Settings**: Updated  from  to  (matching current release)

## Benefits
- Version automatically syncs across the app without manual updates
- Single source of truth in Xcode project settings
- No more forgetting to update version strings when releasing

## Testing
The version string in Settings → About will now display the correct version from the project configuration.

Fixes #10