### PR TITLE
chore: add CI build workflow (Phase 1)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,48 @@
+name: Build
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    name: Build App
+    runs-on: macos-14
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Select Xcode Version
+        run: sudo xcode-select -s /Applications/Xcode_16.0.app
+
+      - name: Show Build Environment
+        run: |
+          xcodebuild -version
+          swift --version
+          echo "macOS: $(sw_vers -productVersion)"
+
+      - name: Build
+        run: |
+          xcodebuild build \
+            -project "Claude Usage.xcodeproj" \
+            -scheme "Claude Usage" \
+            -configuration Release \
+            -derivedDataPath build \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO
+
+      - name: Create App Bundle Artifact
+        run: |
+          mkdir -p artifacts
+          cp -R "build/Build/Products/Release/Claude Usage.app" artifacts/
+
+      - name: Upload Build Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Claude-Usage-${{ github.sha }}
+          path: artifacts/
+          retention-days: 7


### PR DESCRIPTION
## Summary

Implements Phase 1 of the CI/CD pipeline as proposed in #22.

## Changes

Adds `.github/workflows/build.yml` which:
- **Triggers on**: PRs to main, pushes to main
- **Runs on**: `macos-14` (matches app's macOS 14+ target)
- **Uses**: Xcode 16.0 for reproducible builds
- **Builds**: Release configuration without code signing (appropriate for unsigned FOSS)
- **Uploads**: Build artifacts for 7 days (enables testing PR builds)

## Why This Matters

- ✅ Every PR gets automatically validated before review
- ✅ Catches build failures early
- ✅ Consistent build environment
- ✅ Foundation for future testing infrastructure

## Testing

This PR itself will trigger the workflow, demonstrating it works.

## What's Next (Future PRs)

- Phase 2: Automated release drafts on version tags
- Phase 3: Unit test infrastructure

Closes #22 (Phase 1)