### PR TITLE
fix: use default Xcode 15.4 on macos-14 runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,51 @@
+name: Build
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build App
+    runs-on: macos-14
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Show Build Environment
+        run: |
+          xcodebuild -version
+          swift --version
+          echo "macOS: $(sw_vers -productVersion)"
+
+      - name: Build
+        run: |
+          xcodebuild build \
+            -project "Claude Usage.xcodeproj" \
+            -scheme "Claude Usage" \
+            -configuration Release \
+            -derivedDataPath build \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            | xcpretty
+
+      - name: Create App Bundle Artifact
+        run: |
+          mkdir -p artifacts
+          cp -R "build/Build/Products/Release/Claude Usage.app" artifacts/
+
+      - name: Upload Build Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Claude-Usage-${{ github.sha }}
+          path: artifacts/
+          retention-days: 7


### PR DESCRIPTION
## Summary

Fixes the CI build failure caused by attempting to use Xcode 16.0 which is not available on `macos-14` runners.

## Changes

- **Remove explicit Xcode 16.0 selection** - The `xcode-select` step was trying to use `/Applications/Xcode_16.0.app` which doesn't exist on `macos-14` runners
- **Use default Xcode 15.4** - This ships with `macos-14` and is compatible with the project's `MACOSX_DEPLOYMENT_TARGET = 14.0`
- **Add xcpretty** - Cleaner build output that's easier to read in CI logs
- **Add concurrency group** - Cancels in-progress runs when new commits are pushed (saves runner minutes)
- **Add timeout** - 20 minute safety limit

## Context

Per [GitHub's runner image documentation](https://github.com/actions/runner-images), `macos-14` runners only have Xcode 15.x versions available. Xcode 16.x requires `macos-15` runners.

Using `macos-14` with Xcode 15.4 maintains compatibility with macOS Sonoma (14.0+) which is the project's minimum deployment target.

## Testing

The workflow will run on this PR - we can verify the build passes before merging.

Fixes #24