### PR TITLE
chore: add CI build workflow with correct Xcode version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,51 @@
+name: Build
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build App
+    runs-on: macos-14
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Show Build Environment
+        run: |
+          xcodebuild -version
+          swift --version
+          echo "macOS: $(sw_vers -productVersion)"
+
+      - name: Build
+        run: |
+          xcodebuild build \
+            -project "Claude Usage.xcodeproj" \
+            -scheme "Claude Usage" \
+            -configuration Release \
+            -derivedDataPath build \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            | xcpretty
+
+      - name: Create App Bundle Artifact
+        run: |
+          mkdir -p artifacts
+          cp -R "build/Build/Products/Release/Claude Usage.app" artifacts/
+
+      - name: Upload Build Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Claude-Usage-${{ github.sha }}
+          path: artifacts/
+          retention-days: 7


### PR DESCRIPTION
## Summary

Re-implements the CI build workflow with the correct Xcode version configuration. This addresses the build failure from the previous attempt.

## What Changed

The previous workflow attempted to use `Xcode_16.0.app` which isn't available on `macos-14` runners. Per [GitHub's runner image documentation](https://github.com/actions/runner-images), `macos-14` runners ship with **Xcode 15.x** (15.4 default), while Xcode 16.x requires `macos-15` runners.

## This Workflow

- **Runner**: `macos-14` (matches app's macOS 14+ deployment target)
- **Xcode**: Default 15.4 (no explicit selection needed)
- **Build**: Release configuration, no code signing
- **Output**: Uploads `.app` bundle as artifact for 7 days
- **Extras**: 
  - `xcpretty` for cleaner build logs
  - Concurrency control to cancel in-progress runs on new pushes
  - 20-minute timeout as safety limit

## Why macos-14 + Xcode 15.4?

Keeping `macos-14` maintains compatibility with the project's `MACOSX_DEPLOYMENT_TARGET = 14.0` and ensures we're building on the same OS version users are running. Xcode 15.4 fully supports Swift 5.0+ and macOS 14 development.

## Testing

This PR will trigger the workflow - build should pass.

Implements #22 (Phase 1), Fixes #24