### PR TITLE
fix: use macos-15 runner for Xcode 16 project format

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   build:
     name: Build App
-    runs-on: macos-14
+    runs-on: macos-15
     timeout-minutes: 20
 
     steps:


### PR DESCRIPTION
## Summary

Fixes the CI build failure introduced in #26. The build fails with:

```
Assertion failed: IDEFileSystemSynchronizedGroupsAreEnabled()
```

## Root Cause

The project uses **PBXFileSystemSynchronizedRootGroup** (File System Synchronized Groups), a feature introduced in **Xcode 16**. This is visible in `project.pbxproj`:

```
/* Begin PBXFileSystemSynchronizedRootGroup section */
05CD2CB42EA985A100004C83 /* Claude Usage */ = {
    isa = PBXFileSystemSynchronizedRootGroup;
    ...
```

The `macos-14` runner only has Xcode 15.4, which doesn't understand this project structure at all.

## Fix

Switch from `macos-14` to `macos-15`, which has **Xcode 16.2** as the default.

| Runner | Default Xcode | Supports Synchronized Groups |
|--------|--------------|------------------------------|
| macos-14 | 15.4 | ❌ |
| macos-15 | 16.2 | ✅ |

## Trade-off

This means CI builds on macOS 15 (Sequoia) rather than macOS 14 (Sonoma). Since the app's deployment target is still macOS 14.0, users on Sonoma can still run it - we're just building on a newer host OS.

## Testing

This PR will trigger a new workflow run. Build should pass with Xcode 16.2.