### PR TITLE
ci: add automated release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,68 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    name: Build and Release
+    runs-on: macos-15
+    timeout-minutes: 20
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Show Build Environment
+        run: |
+          xcodebuild -version
+          swift --version
+          echo "macOS: $(sw_vers -productVersion)"
+          echo "Tag: ${{ github.ref_name }}"
+
+      - name: Build Release
+        run: |
+          xcodebuild build \
+            -project "Claude Usage.xcodeproj" \
+            -scheme "Claude Usage" \
+            -configuration Release \
+            -derivedDataPath build \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            | xcpretty
+
+      - name: Create Release Artifact
+        run: |
+          # Create artifacts directory
+          mkdir -p release
+          
+          # Copy app bundle
+          cp -R "build/Build/Products/Release/Claude Usage.app" release/
+          
+          # Create ZIP archive
+          cd release
+          zip -r "Claude-Usage.zip" "Claude Usage.app"
+          
+          # Generate SHA256 checksum
+          shasum -a 256 "Claude-Usage.zip" > "Claude-Usage.zip.sha256"
+          
+          # Display checksum for logs
+          echo "SHA256 Checksum:"
+          cat "Claude-Usage.zip.sha256"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ github.ref_name }}
+          draft: true
+          generate_release_notes: true
+          files: |
+            release/Claude-Usage.zip
+            release/Claude-Usage.zip.sha256
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds automated release workflow that triggers when version tags are pushed.

Closes #31

## What This Does

When a tag like `v1.5.0` is pushed, this workflow automatically:

1. **Builds** the Release configuration (same environment as CI)
2. **Creates** `Claude-Usage.zip` containing the app bundle
3. **Generates** `Claude-Usage.zip.sha256` checksum file
4. **Creates** a draft GitHub Release with both assets attached

## Release Process After Merge

```bash
# 1. Bump version in Xcode (MARKETING_VERSION)
# 2. Commit the change
git commit -am "chore: bump version to 1.5.0"

# 3. Tag and push
git tag v1.5.0
git push origin main --tags

# 4. Workflow runs automatically (~3-5 minutes)
# 5. Review draft release, edit notes if needed, publish
```

## Workflow Details

- **Trigger**: Tags matching `v*`
- **Runner**: `macos-15` (same as CI, has Xcode 16)
- **Timeout**: 20 minutes
- **Output**: Draft release (maintainer reviews before publishing)
- **Assets**: 
  - `Claude-Usage.zip` - App bundle
  - `Claude-Usage.zip.sha256` - Checksum for verification

## Benefits

- ✅ Consistent builds (same CI environment)
- ✅ SHA256 checksums for security verification
- ✅ No manual build/zip/upload steps
- ✅ Release tied directly to tagged commit
- ✅ Draft mode allows review before publishing

## Testing

This workflow can only be fully tested by pushing a tag. The workflow syntax and build steps mirror the existing CI workflow which is proven to work.

After merge, can test with a pre-release tag like `v1.4.1-rc1` if desired.