### PR TITLE
fix: Use selected organization for CLI statusline

### DIFF
--- a/Claude Usage/Views/Settings/PersonalUsageView.swift
+++ b/Claude Usage/Views/Settings/PersonalUsageView.swift
@@ -333,12 +333,19 @@ struct ConfirmStep: View {
                     DataStore.shared.saveOrganizationId(selectedOrgId)
                 }
 
+                // Update statusline scripts if key or org changed (only if already installed)
+                let keyChanged = keyHasChanged()
+                let orgChanged = wizardState.selectedOrgId != wizardState.originalOrgId
+                if keyChanged || orgChanged {
+                    try? StatuslineService.shared.updateScriptsIfInstalled()
+                }
+
                 await MainActor.run {
                     // Determine which notification to send
-                    if keyHasChanged() {
+                    if keyChanged {
                         // Key changed - full refresh
                         NotificationCenter.default.post(name: .sessionKeyUpdated, object: nil)
-                    } else if wizardState.selectedOrgId != wizardState.originalOrgId {
+                    } else if orgChanged {
                         // Only org changed - targeted refresh
                         NotificationCenter.default.post(name: .organizationChanged, object: nil)
                     }


### PR DESCRIPTION
## Summary

- Injects the selected organization ID from settings into the statusline script instead of fetching and using the first organization
- Adds `updateScriptsIfInstalled()` to re-inject credentials when session key or organization changes
- Removes the runtime `fetchOrganizationId` API call from the Swift script

Fixes #75