### PR TITLE
feat: Add color mode support and desktop widgets

### DIFF
--- a/Claude Usage Widget/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Claude Usage Widget/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Claude Usage Widget/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Claude Usage Widget/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,35 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "tinted"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Claude Usage Widget/Assets.xcassets/Contents.json
+++ b/Claude Usage Widget/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Claude Usage Widget/Assets.xcassets/WidgetBackground.colorset/Contents.json
+++ b/Claude Usage Widget/Assets.xcassets/WidgetBackground.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Claude Usage Widget/Claude Usage Widget.entitlements
+++ b/Claude Usage Widget/Claude Usage Widget.entitlements
@@ -2,10 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.security.network.client</key>
-	<true/>
-	<key>com.apple.security.cs.disable-library-validation</key>
-	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.claude-usage</string>

--- a/Claude Usage Widget/ClaudeUsageWidget.swift
+++ b/Claude Usage Widget/ClaudeUsageWidget.swift
@@ -1,0 +1,139 @@
+//
+//  ClaudeUsageWidget.swift
+//  Claude Usage Widget
+//
+//  Main widget configuration and timeline provider
+//
+
+import WidgetKit
+import SwiftUI
+
+struct ClaudeUsageWidget: Widget {
+    let kind: String = "ClaudeUsageWidget"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: UsageTimelineProvider()) { entry in
+            ClaudeUsageWidgetEntryView(entry: entry)
+                .containerBackground(.ultraThinMaterial, for: .widget)
+        }
+        .configurationDisplayName("Claude Usage")
+        .description("Monitor your Claude AI usage at a glance.")
+        .supportedFamilies([.systemSmall, .systemMedium, .systemLarge])
+    }
+}
+
+
+struct UsageTimelineProvider: TimelineProvider {
+    func placeholder(in context: Context) -> UsageEntry {
+        UsageEntry(date: Date(), usage: nil, apiUsage: nil)
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (UsageEntry) -> Void) {
+        let provider = WidgetDataProvider.shared
+        let entry = UsageEntry(
+            date: Date(),
+            usage: provider.loadUsage(),
+            apiUsage: provider.loadAPIUsage(),
+            smallMetric: provider.loadSmallWidgetMetric(),
+            mediumLeftMetric: provider.loadMediumWidgetLeftMetric(),
+            mediumRightMetric: provider.loadMediumWidgetRightMetric(),
+            colorMode: provider.loadWidgetColorMode(),
+            customColorHex: provider.loadWidgetSingleColorHex(),
+            extraUsageFormat: provider.loadExtraUsageDisplayFormat()
+        )
+        completion(entry)
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<UsageEntry>) -> Void) {
+        let currentDate = Date()
+        let provider = WidgetDataProvider.shared
+        let entry = UsageEntry(
+            date: currentDate,
+            usage: provider.loadUsage(),
+            apiUsage: provider.loadAPIUsage(),
+            smallMetric: provider.loadSmallWidgetMetric(),
+            mediumLeftMetric: provider.loadMediumWidgetLeftMetric(),
+            mediumRightMetric: provider.loadMediumWidgetRightMetric(),
+            colorMode: provider.loadWidgetColorMode(),
+            customColorHex: provider.loadWidgetSingleColorHex(),
+            extraUsageFormat: provider.loadExtraUsageDisplayFormat()
+        )
+
+        // Refresh every 15 minutes
+        let refreshDate = Calendar.current.date(byAdding: .minute, value: 15, to: currentDate) ?? currentDate.addingTimeInterval(900)
+        let timeline = Timeline(entries: [entry], policy: .after(refreshDate))
+        completion(timeline)
+    }
+}
+
+struct UsageEntry: TimelineEntry {
+    let date: Date
+    let usage: WidgetUsageData?
+    let apiUsage: WidgetAPIUsageData?
+    let smallMetric: WidgetSmallMetric
+    let mediumLeftMetric: WidgetSmallMetric
+    let mediumRightMetric: WidgetSmallMetric
+    let colorMode: WidgetColorDisplayMode
+    let customColorHex: String
+    let extraUsageFormat: ExtraUsageDisplayFormat
+
+    init(
+        date: Date,
+        usage: WidgetUsageData?,
+        apiUsage: WidgetAPIUsageData?,
+        smallMetric: WidgetSmallMetric = .session,
+        mediumLeftMetric: WidgetSmallMetric = .session,
+        mediumRightMetric: WidgetSmallMetric = .weekly,
+        colorMode: WidgetColorDisplayMode = .multiColor,
+        customColorHex: String = "#00BFFF",
+        extraUsageFormat: ExtraUsageDisplayFormat = .percentage
+    ) {
+        self.date = date
+        self.usage = usage
+        self.apiUsage = apiUsage
+        self.smallMetric = smallMetric
+        self.mediumLeftMetric = mediumLeftMetric
+        self.mediumRightMetric = mediumRightMetric
+        self.colorMode = colorMode
+        self.customColorHex = customColorHex
+        self.extraUsageFormat = extraUsageFormat
+    }
+}
+
+struct ClaudeUsageWidgetEntryView: View {
+    @Environment(\.widgetFamily) var family
+    var entry: UsageEntry
+
+    var body: some View {
+        Group {
+            switch family {
+            case .systemSmall:
+                SmallWidgetView(entry: entry)
+            case .systemMedium:
+                MediumWidgetView(entry: entry)
+            case .systemLarge:
+                LargeWidgetView(entry: entry)
+            default:
+                SmallWidgetView(entry: entry)
+            }
+        }
+    }
+}
+
+#Preview(as: .systemSmall) {
+    ClaudeUsageWidget()
+} timeline: {
+    UsageEntry(date: .now, usage: .preview, apiUsage: .preview)
+}
+
+#Preview(as: .systemMedium) {
+    ClaudeUsageWidget()
+} timeline: {
+    UsageEntry(date: .now, usage: .preview, apiUsage: .preview)
+}
+
+#Preview(as: .systemLarge) {
+    ClaudeUsageWidget()
+} timeline: {
+    UsageEntry(date: .now, usage: .preview, apiUsage: .preview)
+}

--- a/Claude Usage Widget/ClaudeUsageWidget.swift
+++ b/Claude Usage Widget/ClaudeUsageWidget.swift
@@ -38,8 +38,7 @@ struct UsageTimelineProvider: TimelineProvider {
             mediumLeftMetric: provider.loadMediumWidgetLeftMetric(),
             mediumRightMetric: provider.loadMediumWidgetRightMetric(),
             colorMode: provider.loadWidgetColorMode(),
-            customColorHex: provider.loadWidgetSingleColorHex(),
-            extraUsageFormat: provider.loadExtraUsageDisplayFormat()
+            customColorHex: provider.loadWidgetSingleColorHex()
         )
         completion(entry)
     }
@@ -55,8 +54,7 @@ struct UsageTimelineProvider: TimelineProvider {
             mediumLeftMetric: provider.loadMediumWidgetLeftMetric(),
             mediumRightMetric: provider.loadMediumWidgetRightMetric(),
             colorMode: provider.loadWidgetColorMode(),
-            customColorHex: provider.loadWidgetSingleColorHex(),
-            extraUsageFormat: provider.loadExtraUsageDisplayFormat()
+            customColorHex: provider.loadWidgetSingleColorHex()
         )
 
         // Refresh every 15 minutes
@@ -75,7 +73,6 @@ struct UsageEntry: TimelineEntry {
     let mediumRightMetric: WidgetSmallMetric
     let colorMode: WidgetColorDisplayMode
     let customColorHex: String
-    let extraUsageFormat: ExtraUsageDisplayFormat
 
     init(
         date: Date,
@@ -85,8 +82,7 @@ struct UsageEntry: TimelineEntry {
         mediumLeftMetric: WidgetSmallMetric = .session,
         mediumRightMetric: WidgetSmallMetric = .weekly,
         colorMode: WidgetColorDisplayMode = .multiColor,
-        customColorHex: String = "#00BFFF",
-        extraUsageFormat: ExtraUsageDisplayFormat = .percentage
+        customColorHex: String = "#00BFFF"
     ) {
         self.date = date
         self.usage = usage
@@ -96,7 +92,6 @@ struct UsageEntry: TimelineEntry {
         self.mediumRightMetric = mediumRightMetric
         self.colorMode = colorMode
         self.customColorHex = customColorHex
-        self.extraUsageFormat = extraUsageFormat
     }
 }
 

--- a/Claude Usage Widget/ClaudeUsageWidgetBundle.swift
+++ b/Claude Usage Widget/ClaudeUsageWidgetBundle.swift
@@ -1,0 +1,16 @@
+//
+//  ClaudeUsageWidgetBundle.swift
+//  Claude Usage Widget
+//
+//  Widget extension for displaying Claude usage in Notification Center and Desktop
+//
+
+import WidgetKit
+import SwiftUI
+
+@main
+struct ClaudeUsageWidgetBundle: WidgetBundle {
+    var body: some Widget {
+        ClaudeUsageWidget()
+    }
+}

--- a/Claude Usage Widget/Extensions/Color+Extensions.swift
+++ b/Claude Usage Widget/Extensions/Color+Extensions.swift
@@ -1,0 +1,58 @@
+//
+//  Color+Extensions.swift
+//  Claude Usage Widget
+//
+//  Color utilities for hex conversion
+//
+
+import SwiftUI
+
+extension Color {
+    /// Initialize a Color from a hex string (e.g., "#FF5733" or "FF5733")
+    init?(hex: String) {
+        var hexSanitized = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+        hexSanitized = hexSanitized.replacingOccurrences(of: "#", with: "")
+
+        var rgb: UInt64 = 0
+
+        guard Scanner(string: hexSanitized).scanHexInt64(&rgb) else {
+            return nil
+        }
+
+        let length = hexSanitized.count
+
+        switch length {
+        case 6: // RGB (24-bit)
+            self.init(
+                red: Double((rgb & 0xFF0000) >> 16) / 255.0,
+                green: Double((rgb & 0x00FF00) >> 8) / 255.0,
+                blue: Double(rgb & 0x0000FF) / 255.0
+            )
+        case 8: // RGBA (32-bit)
+            self.init(
+                red: Double((rgb & 0xFF000000) >> 24) / 255.0,
+                green: Double((rgb & 0x00FF0000) >> 16) / 255.0,
+                blue: Double((rgb & 0x0000FF00) >> 8) / 255.0,
+                opacity: Double(rgb & 0x000000FF) / 255.0
+            )
+        default:
+            return nil
+        }
+    }
+
+    /// Convert Color to hex string (e.g., "#FF5733")
+    func toHex() -> String? {
+        guard let components = NSColor(self).usingColorSpace(.sRGB)?.cgColor.components else {
+            return nil
+        }
+
+        let r = components.count > 0 ? components[0] : 0
+        let g = components.count > 1 ? components[1] : 0
+        let b = components.count > 2 ? components[2] : 0
+
+        return String(format: "#%02X%02X%02X",
+                      Int(r * 255),
+                      Int(g * 255),
+                      Int(b * 255))
+    }
+}

--- a/Claude Usage Widget/Info.plist
+++ b/Claude Usage Widget/Info.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/Claude Usage Widget/WidgetDataProvider.swift
+++ b/Claude Usage Widget/WidgetDataProvider.swift
@@ -1,0 +1,614 @@
+//
+//  WidgetDataProvider.swift
+//  Claude Usage Widget
+//
+//  Provides data access to the widget from App Groups shared storage
+//
+
+import Foundation
+import SwiftUI
+
+/// Lightweight usage data structure for widget display
+struct WidgetUsageData: Codable {
+    let sessionPercentage: Double
+    let sessionResetTime: Date
+    let weeklyPercentage: Double
+    let weeklyResetTime: Date
+    let opusPercentage: Double
+    let sonnetPercentage: Double
+    let extraPercentage: Double?
+    let extraUsed: Double?
+    let extraLimit: Double?
+    let extraCurrency: String?
+    let lastUpdated: Date
+
+    var statusLevel: WidgetStatusLevel {
+        switch sessionPercentage {
+        case 0..<50:
+            return .safe
+        case 50..<80:
+            return .moderate
+        default:
+            return .critical
+        }
+    }
+
+    var weeklyStatusLevel: WidgetStatusLevel {
+        switch weeklyPercentage {
+        case 0..<50:
+            return .safe
+        case 50..<80:
+            return .moderate
+        default:
+            return .critical
+        }
+    }
+
+    var extraStatusLevel: WidgetStatusLevel {
+        guard let percentage = extraPercentage else { return .safe }
+        switch percentage {
+        case 0..<50:
+            return .safe
+        case 50..<80:
+            return .moderate
+        default:
+            return .critical
+        }
+    }
+
+    var formattedExtraUsed: String? {
+        guard let used = extraUsed, let currency = extraCurrency else { return nil }
+        return formatCurrency(used, currency: currency)
+    }
+
+    var formattedExtraLimit: String? {
+        guard let limit = extraLimit, let currency = extraCurrency else { return nil }
+        return formatCurrency(limit, currency: currency)
+    }
+
+    /// Formats extra usage for display based on format preference
+    func formattedExtraDisplay(format: ExtraUsageDisplayFormat) -> String? {
+        guard let percentage = extraPercentage else { return nil }
+
+        switch format {
+        case .percentage:
+            return "\(Int(percentage.rounded()))%"
+        case .currency:
+            return formattedExtraUsed ?? "$0.00"
+        case .both:
+            let percentStr = "\(Int(percentage.rounded()))%"
+            let currencyStr = formattedExtraUsed ?? "$0.00"
+            return "\(percentStr) • \(currencyStr)"
+        }
+    }
+
+    private func formatCurrency(_ amount: Double, currency: String) -> String {
+        // Convert from cents to dollars
+        let dollars = amount / 100.0
+
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.currencyCode = currency
+        formatter.minimumFractionDigits = 2
+        formatter.maximumFractionDigits = 2
+        return formatter.string(from: NSNumber(value: dollars)) ?? "\(currency) \(String(format: "%.2f", dollars))"
+    }
+
+    static var preview: WidgetUsageData {
+        WidgetUsageData(
+            sessionPercentage: 45.0,
+            sessionResetTime: Date().addingTimeInterval(3600),
+            weeklyPercentage: 32.0,
+            weeklyResetTime: Date().addingTimeInterval(86400 * 3),
+            opusPercentage: 28.0,
+            sonnetPercentage: 35.0,
+            extraPercentage: 22.5,
+            extraUsed: 2.25,
+            extraLimit: 10.0,
+            extraCurrency: "USD",
+            lastUpdated: Date()
+        )
+    }
+}
+
+/// Lightweight API usage data for widget display
+struct WidgetAPIUsageData: Codable {
+    let usedAmount: Double
+    let totalCredits: Double
+    let usagePercentage: Double
+    let currency: String
+    let resetsAt: Date
+
+    var formattedUsed: String {
+        formatCurrency(usedAmount)
+    }
+
+    var formattedTotal: String {
+        formatCurrency(totalCredits)
+    }
+
+    private func formatCurrency(_ amount: Double) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.currencyCode = currency
+        formatter.minimumFractionDigits = 2
+        formatter.maximumFractionDigits = 2
+        return formatter.string(from: NSNumber(value: amount)) ?? "\(currency) \(String(format: "%.2f", amount))"
+    }
+
+    static var preview: WidgetAPIUsageData {
+        WidgetAPIUsageData(
+            usedAmount: 12.50,
+            totalCredits: 100.00,
+            usagePercentage: 12.5,
+            currency: "USD",
+            resetsAt: Date().addingTimeInterval(86400 * 14)
+        )
+    }
+}
+
+enum WidgetStatusLevel {
+    case safe
+    case moderate
+    case critical
+}
+
+/// Widget small metric selection (mirrors main app's SmallWidgetMetric)
+enum WidgetSmallMetric: String {
+    case session = "session"
+    case weekly = "weekly"
+    case opus = "opus"
+    case sonnet = "sonnet"
+    case extra = "extra"
+
+    var displayName: String {
+        switch self {
+        case .session: return "Session"
+        case .weekly: return "Weekly"
+        case .opus: return "Opus"
+        case .sonnet: return "Sonnet"
+        case .extra: return "Extra"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .session: return "clock.fill"
+        case .weekly: return "calendar"
+        case .opus: return "star.fill"
+        case .sonnet: return "bolt.fill"
+        case .extra: return "dollarsign.circle.fill"
+        }
+    }
+}
+
+/// Widget medium layout selection (mirrors main app's MediumWidgetLayout)
+/// Widget color display mode (mirrors main app's WidgetColorMode)
+enum WidgetColorDisplayMode: String {
+    case multiColor = "multiColor"
+    case monochrome = "monochrome"
+    case singleColor = "singleColor"
+}
+
+/// Extra usage display format (mirrors main app's ExtraUsageDisplayFormat)
+enum ExtraUsageDisplayFormat: String {
+    case percentage = "percentage"
+    case currency = "currency"
+    case both = "both"
+}
+
+// MARK: - Widget Date Formatter
+
+/// Helper for formatting dates in widgets - uniform style across all sizes
+enum WidgetDateFormatter {
+    /// Formats reset time for all widgets (uniform style)
+    /// - Today: "7:00PM"
+    /// - Tomorrow: "Tomorrow 7:00PM"
+    /// - Later: "Wednesday 7:00PM"
+    static func resetTimeString(from date: Date, prefix: String = "") -> String {
+        let timeString = formatTime(from: date)
+        return prefix.isEmpty ? timeString : "\(prefix)\(timeString)"
+    }
+
+    /// Formats time as short string for tiles (no prefix) - same format
+    static func shortTimeString(from date: Date) -> String {
+        return formatTime(from: date)
+    }
+
+    /// Compact format - same as regular (uniform across all widgets)
+    static func compactResetTimeString(from date: Date) -> String {
+        return formatTime(from: date)
+    }
+
+    private static func formatTime(from date: Date) -> String {
+        let calendar = Calendar.current
+        let formatter = DateFormatter()
+
+        // Round to nearest minute to prevent pinballing
+        let roundedDate = roundToNearestMinute(date, using: calendar)
+
+        formatter.dateFormat = "h:mma"
+        let timeStr = formatter.string(from: roundedDate)
+
+        if calendar.isDateInToday(roundedDate) {
+            return timeStr
+        } else if calendar.isDateInTomorrow(roundedDate) {
+            return "Tomorrow \(timeStr)"
+        } else {
+            // Use day of week for dates further out
+            formatter.dateFormat = "EEEE"
+            let dayStr = formatter.string(from: roundedDate)
+            return "\(dayStr) \(timeStr)"
+        }
+    }
+
+    /// Rounds the date to the nearest minute
+    private static func roundToNearestMinute(_ date: Date, using calendar: Calendar) -> Date {
+        let components = calendar.dateComponents([.year, .month, .day, .hour, .minute, .second], from: date)
+        let seconds = components.second ?? 0
+
+        // Round: >= 30 seconds rounds up, < 30 seconds rounds down
+        if seconds >= 30 {
+            return calendar.date(byAdding: .minute, value: 1, to: calendar.date(from: DateComponents(
+                year: components.year,
+                month: components.month,
+                day: components.day,
+                hour: components.hour,
+                minute: components.minute
+            ))!) ?? date
+        } else {
+            return calendar.date(from: DateComponents(
+                year: components.year,
+                month: components.month,
+                day: components.day,
+                hour: components.hour,
+                minute: components.minute
+            )) ?? date
+        }
+    }
+}
+
+// MARK: - Widget Design Tokens
+
+/// Centralized design tokens for consistent widget styling per Apple HIG
+enum WidgetDesign {
+    enum Typography {
+        static let percentageLarge: CGFloat = 28    // Primary percentage display
+        static let percentageMedium: CGFloat = 26   // Card percentages
+        static let headerTitle: CGFloat = 14        // Widget header
+        static let cardTitle: CGFloat = 13          // Section/card titles
+        static let subtitle: CGFloat = 11           // Secondary text
+        static let timestamp: CGFloat = 10          // Last updated text
+        static let iconSmall: CGFloat = 11          // Card icons
+        static let iconMedium: CGFloat = 12         // Header icons
+    }
+
+    enum Spacing {
+        static let outerPadding: CGFloat = 8        // All widget outer padding
+        static let cardPadding: CGFloat = 10        // Internal card padding
+        static let cardCornerRadius: CGFloat = 10   // Card corners
+        static let progressHeight: CGFloat = 8     // Progress bar height
+        static let sectionSpacing: CGFloat = 10     // Between sections
+        static let cardSpacing: CGFloat = 10        // Between cards
+    }
+
+    enum Ring {
+        static let lineWidth: CGFloat = 8           // Circular progress ring
+        static let size: CGFloat = 100              // Ring diameter (small widget)
+    }
+
+    enum Colors {
+        // Glass style opacities
+        static let glassCardBg: Double = 0.06
+        static let glassProgressBg: Double = 0.12
+        static let glassSecondaryText: Double = 0.6
+        static let glassDivider: Double = 0.15
+
+        // Standard style opacities
+        static let standardCardBg: Double = 0.08
+        static let standardProgressBg: Double = 0.2
+        static let standardDivider: Double = 0.3
+    }
+
+    enum NoData {
+        // Icon sizes per widget size
+        static let iconSmall: CGFloat = 32
+        static let iconMedium: CGFloat = 36
+        static let iconLarge: CGFloat = 48
+
+        // Title font sizes
+        static let titleSmall: CGFloat = 13
+        static let titleMedium: CGFloat = 14
+        static let titleLarge: CGFloat = 18
+
+        // Subtitle font sizes
+        static let subtitleSmall: CGFloat = 10
+        static let subtitleMedium: CGFloat = 11
+        static let subtitleLarge: CGFloat = 13
+    }
+}
+
+/// Data provider that reads from App Groups shared storage
+class WidgetDataProvider {
+    static let shared = WidgetDataProvider()
+
+    private let appGroupIdentifier = "group.claude-usage"
+    private let defaults: UserDefaults?
+    private let decoder = JSONDecoder()
+
+    private init() {
+        self.defaults = UserDefaults(suiteName: appGroupIdentifier)
+    }
+
+    /// Gets the Group Container URL
+    private var groupContainerURL: URL? {
+        FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroupIdentifier)
+    }
+
+    /// Loads usage data from shared storage
+    func loadUsage() -> WidgetUsageData? {
+        // Try file-based storage first
+        if let data = loadFromFile(filename: "claudeUsageData.json") {
+            #if DEBUG
+            print("Widget: Found file data (\(data.count) bytes)")
+            #endif
+            if let usage = decodeUsage(from: data) {
+                #if DEBUG
+                print("Widget: Successfully decoded usage from file")
+                #endif
+                return usage
+            } else {
+                #if DEBUG
+                print("Widget: Failed to decode usage from file")
+                #endif
+            }
+        } else {
+            #if DEBUG
+            print("Widget: No file data found at container path: \(groupContainerURL?.path ?? "nil")")
+            #endif
+        }
+
+        // Fall back to UserDefaults
+        if let defaults = defaults,
+           let data = defaults.data(forKey: "claudeUsageData") {
+            #if DEBUG
+            print("Widget: Found UserDefaults data (\(data.count) bytes)")
+            #endif
+            if let usage = decodeUsage(from: data) {
+                #if DEBUG
+                print("Widget: Successfully decoded usage from UserDefaults")
+                #endif
+                return usage
+            } else {
+                #if DEBUG
+                print("Widget: Failed to decode usage from UserDefaults")
+                #endif
+            }
+        } else {
+            #if DEBUG
+            print("Widget: No UserDefaults data found (defaults nil: \(defaults == nil))")
+            #endif
+        }
+
+        #if DEBUG
+        print("Widget: Returning nil - no data available")
+        #endif
+        return nil
+    }
+
+    /// Loads data from a file in the group container
+    private func loadFromFile(filename: String) -> Data? {
+        guard let containerURL = groupContainerURL else { return nil }
+        let fileURL = containerURL.appendingPathComponent(filename)
+        return try? Data(contentsOf: fileURL)
+    }
+
+    /// Decodes ClaudeUsage data
+    private func decodeUsage(from data: Data) -> WidgetUsageData? {
+        do {
+            let fullUsage = try decoder.decode(ClaudeUsageCompat.self, from: data)
+
+            // Calculate extra usage percentage if available
+            var extraPercentage: Double? = nil
+            if let used = fullUsage.costUsed, let limit = fullUsage.costLimit, limit > 0 {
+                extraPercentage = (used / limit) * 100.0
+            }
+
+            return WidgetUsageData(
+                sessionPercentage: fullUsage.sessionPercentage,
+                sessionResetTime: fullUsage.sessionResetTime,
+                weeklyPercentage: fullUsage.weeklyPercentage,
+                weeklyResetTime: fullUsage.weeklyResetTime,
+                opusPercentage: fullUsage.opusWeeklyPercentage,
+                sonnetPercentage: fullUsage.sonnetWeeklyPercentage,
+                extraPercentage: extraPercentage,
+                extraUsed: fullUsage.costUsed,
+                extraLimit: fullUsage.costLimit,
+                extraCurrency: fullUsage.costCurrency,
+                lastUpdated: fullUsage.lastUpdated
+            )
+        } catch {
+            #if DEBUG
+            print("Widget: Decode error: \(error)")
+            #endif
+            return nil
+        }
+    }
+
+    /// Loads API usage data from shared storage
+    func loadAPIUsage() -> WidgetAPIUsageData? {
+        guard let defaults = defaults,
+              let data = defaults.data(forKey: "apiUsageData") else {
+            return nil
+        }
+
+        do {
+            let apiUsage = try decoder.decode(APIUsageCompat.self, from: data)
+            let usedAmount = Double(apiUsage.currentSpendCents) / 100.0
+            let remainingAmount = Double(apiUsage.prepaidCreditsCents) / 100.0
+            let totalCredits = usedAmount + remainingAmount
+            let usagePercentage = totalCredits > 0 ? (usedAmount / totalCredits) * 100.0 : 0
+
+            return WidgetAPIUsageData(
+                usedAmount: usedAmount,
+                totalCredits: totalCredits,
+                usagePercentage: usagePercentage,
+                currency: apiUsage.currency,
+                resetsAt: apiUsage.resetsAt
+            )
+        } catch {
+            return nil
+        }
+    }
+
+    /// Loads small widget metric preference from shared storage
+    func loadSmallWidgetMetric() -> WidgetSmallMetric {
+        guard let defaults = defaults,
+              let rawValue = defaults.string(forKey: "smallWidgetMetric"),
+              let metric = WidgetSmallMetric(rawValue: rawValue) else {
+            return .session  // Default to session
+        }
+        return metric
+    }
+
+    /// Loads medium widget left metric preference from shared storage
+    func loadMediumWidgetLeftMetric() -> WidgetSmallMetric {
+        guard let defaults = defaults,
+              let rawValue = defaults.string(forKey: "mediumWidgetLeftMetric"),
+              let metric = WidgetSmallMetric(rawValue: rawValue) else {
+            return .session  // Default left metric
+        }
+        return metric
+    }
+
+    /// Loads medium widget right metric preference from shared storage
+    func loadMediumWidgetRightMetric() -> WidgetSmallMetric {
+        guard let defaults = defaults,
+              let rawValue = defaults.string(forKey: "mediumWidgetRightMetric"),
+              let metric = WidgetSmallMetric(rawValue: rawValue) else {
+            return .weekly  // Default right metric
+        }
+        return metric
+    }
+
+    /// Loads widget color mode preference from shared storage
+    func loadWidgetColorMode() -> WidgetColorDisplayMode {
+        guard let defaults = defaults,
+              let rawValue = defaults.string(forKey: "widgetColorMode"),
+              let mode = WidgetColorDisplayMode(rawValue: rawValue) else {
+            return .multiColor  // Default to threshold-based colors
+        }
+        return mode
+    }
+
+    /// Loads widget single color hex from shared storage
+    func loadWidgetSingleColorHex() -> String {
+        return defaults?.string(forKey: "widgetSingleColorHex") ?? "#00BFFF"  // Default cyan
+    }
+
+    /// Loads extra usage display format from shared storage
+    func loadExtraUsageDisplayFormat() -> ExtraUsageDisplayFormat {
+        guard let defaults = defaults,
+              let rawValue = defaults.string(forKey: "extraUsageDisplayFormat"),
+              let format = ExtraUsageDisplayFormat(rawValue: rawValue) else {
+            return .percentage  // Default to showing percentage
+        }
+        return format
+    }
+
+    /// Returns color for usage percentage based on color mode
+    func colorForUsage(_ percentage: Double, mode: WidgetColorDisplayMode, customColorHex: String) -> Color {
+        switch mode {
+        case .multiColor:
+            // Threshold-based colors (matching menu bar)
+            switch percentage {
+            case 0..<50:
+                return .green    // Safe
+            case 50..<80:
+                return .orange   // Moderate
+            default: // 80%+
+                return .red      // Critical
+            }
+        case .monochrome:
+            return .primary
+        case .singleColor:
+            return hexToColor(customColorHex) ?? .cyan
+        }
+    }
+
+    /// Convert hex string to Color
+    private func hexToColor(_ hex: String) -> Color? {
+        var hexSanitized = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+        hexSanitized = hexSanitized.replacingOccurrences(of: "#", with: "")
+
+        var rgb: UInt64 = 0
+
+        guard Scanner(string: hexSanitized).scanHexInt64(&rgb) else {
+            return nil
+        }
+
+        let length = hexSanitized.count
+
+        switch length {
+        case 6: // RGB (24-bit)
+            return Color(
+                red: Double((rgb & 0xFF0000) >> 16) / 255.0,
+                green: Double((rgb & 0x00FF00) >> 8) / 255.0,
+                blue: Double(rgb & 0x0000FF) / 255.0
+            )
+        case 8: // RGBA (32-bit)
+            return Color(
+                red: Double((rgb & 0xFF000000) >> 24) / 255.0,
+                green: Double((rgb & 0x00FF0000) >> 16) / 255.0,
+                blue: Double((rgb & 0x0000FF00) >> 8) / 255.0,
+                opacity: Double(rgb & 0x000000FF) / 255.0
+            )
+        default:
+            return nil
+        }
+    }
+}
+
+// MARK: - Compatibility Models (for decoding main app data)
+
+/// Compatibility struct for decoding ClaudeUsage from main app
+/// Must match ALL fields from ClaudeUsage.swift for proper decoding
+private struct ClaudeUsageCompat: Codable {
+    // Session data
+    let sessionTokensUsed: Int
+    let sessionLimit: Int
+    let sessionPercentage: Double
+    let sessionResetTime: Date
+
+    // Weekly data (all models)
+    let weeklyTokensUsed: Int
+    let weeklyLimit: Int
+    let weeklyPercentage: Double
+    let weeklyResetTime: Date
+
+    // Weekly data (Opus only)
+    let opusWeeklyTokensUsed: Int
+    let opusWeeklyPercentage: Double
+
+    // Weekly data (Sonnet only)
+    let sonnetWeeklyTokensUsed: Int
+    let sonnetWeeklyPercentage: Double
+    let sonnetWeeklyResetTime: Date?
+
+    // Extra usage data
+    let costUsed: Double?
+    let costLimit: Double?
+    let costCurrency: String?
+
+    // Metadata
+    let lastUpdated: Date
+    let userTimezone: TimeZone
+}
+
+/// Compatibility struct for decoding APIUsage from main app
+private struct APIUsageCompat: Codable {
+    let currentSpendCents: Int
+    let resetsAt: Date
+    let prepaidCreditsCents: Int
+    let currency: String
+}

--- a/Claude Usage Widget/WidgetViews/LargeWidgetView.swift
+++ b/Claude Usage Widget/WidgetViews/LargeWidgetView.swift
@@ -1,0 +1,301 @@
+//
+//  LargeWidgetView.swift
+//  Claude Usage Widget
+//
+//  Large widget showing full dashboard with session, weekly, opus, and API usage
+//
+
+import SwiftUI
+import WidgetKit
+
+struct LargeWidgetView: View {
+    let entry: UsageEntry
+
+    var body: some View {
+        if let usage = entry.usage {
+            VStack(spacing: WidgetDesign.Spacing.sectionSpacing) {
+                // Header
+                HStack {
+                    Image(systemName: "sparkles")
+                        .font(.system(size: WidgetDesign.Typography.headerTitle))
+                        .foregroundColor(.purple)
+                    Text("Claude Usage")
+                        .font(.system(size: 15, weight: .semibold))
+                    Spacer()
+                    Text(lastUpdatedText(usage.lastUpdated))
+                        .font(.system(size: WidgetDesign.Typography.timestamp))
+                        .foregroundColor(secondaryTextColor)
+                }
+
+                Divider()
+                    .background(dividerColor)
+
+                // Main metrics grid - optimized for ~364x364 widget
+                // Show extra usage if any metric is at 0% and extra data is available
+                LazyVGrid(columns: [
+                    GridItem(.flexible(), spacing: WidgetDesign.Spacing.cardSpacing),
+                    GridItem(.flexible(), spacing: WidgetDesign.Spacing.cardSpacing)
+                ], spacing: WidgetDesign.Spacing.cardSpacing) {
+                    // Session Usage
+                    MetricTile(
+                        title: "Session",
+                        percentage: usage.sessionPercentage,
+                        subtitle: WidgetDateFormatter.shortTimeString(from: usage.sessionResetTime),
+                        icon: "clock.fill",
+                        colorMode: entry.colorMode,
+                        customColorHex: entry.customColorHex
+                    )
+
+                    // Weekly Usage
+                    MetricTile(
+                        title: "Weekly",
+                        percentage: usage.weeklyPercentage,
+                        subtitle: WidgetDateFormatter.shortTimeString(from: usage.weeklyResetTime),
+                        icon: "calendar",
+                        colorMode: entry.colorMode,
+                        customColorHex: entry.customColorHex
+                    )
+
+                    // Opus Usage - show Extra if Opus is 0% and extra data exists
+                    if usage.opusPercentage > 0 {
+                        MetricTile(
+                            title: "Opus",
+                            percentage: usage.opusPercentage,
+                            subtitle: WidgetDateFormatter.shortTimeString(from: usage.weeklyResetTime),
+                            icon: "star.fill",
+                                colorMode: entry.colorMode,
+                            customColorHex: entry.customColorHex
+                        )
+                    } else if let extraPercentage = usage.extraPercentage {
+                        MetricTile(
+                            title: "Extra",
+                            percentage: extraPercentage,
+                            subtitle: extraSubtitle(for: usage, format: entry.extraUsageFormat),
+                            icon: "dollarsign.circle.fill",
+                                colorMode: entry.colorMode,
+                            customColorHex: entry.customColorHex
+                        )
+                    } else {
+                        MetricTile(
+                            title: "Opus",
+                            percentage: usage.opusPercentage,
+                            subtitle: WidgetDateFormatter.shortTimeString(from: usage.weeklyResetTime),
+                            icon: "star.fill",
+                                colorMode: entry.colorMode,
+                            customColorHex: entry.customColorHex
+                        )
+                    }
+
+                    // Sonnet Usage - show Extra if Sonnet is 0% and extra data exists (and wasn't shown for Opus)
+                    if usage.sonnetPercentage > 0 {
+                        MetricTile(
+                            title: "Sonnet",
+                            percentage: usage.sonnetPercentage,
+                            subtitle: WidgetDateFormatter.shortTimeString(from: usage.weeklyResetTime),
+                            icon: "bolt.fill",
+                                colorMode: entry.colorMode,
+                            customColorHex: entry.customColorHex
+                        )
+                    } else if let extraPercentage = usage.extraPercentage, usage.opusPercentage > 0 {
+                        // Only show extra here if we didn't already show it for Opus
+                        MetricTile(
+                            title: "Extra",
+                            percentage: extraPercentage,
+                            subtitle: extraSubtitle(for: usage, format: entry.extraUsageFormat),
+                            icon: "dollarsign.circle.fill",
+                                colorMode: entry.colorMode,
+                            customColorHex: entry.customColorHex
+                        )
+                    } else {
+                        MetricTile(
+                            title: "Sonnet",
+                            percentage: usage.sonnetPercentage,
+                            subtitle: WidgetDateFormatter.shortTimeString(from: usage.weeklyResetTime),
+                            icon: "bolt.fill",
+                                colorMode: entry.colorMode,
+                            customColorHex: entry.customColorHex
+                        )
+                    }
+                }
+
+                // API Usage (if available)
+                if let apiUsage = entry.apiUsage {
+                    Divider()
+                        .background(dividerColor)
+
+                    HStack(spacing: 16) {
+                        VStack(alignment: .leading, spacing: 6) {
+                            HStack {
+                                Image(systemName: "creditcard.fill")
+                                    .font(.system(size: WidgetDesign.Typography.iconSmall))
+                                    .foregroundColor(.blue)
+                                Text("API Credits")
+                                    .font(.system(size: WidgetDesign.Typography.iconMedium, weight: .medium))
+                                    .foregroundColor(secondaryTextColor)
+                            }
+
+                            Text("\(apiUsage.formattedUsed) / \(apiUsage.formattedTotal)")
+                                .font(.system(size: 15, weight: .semibold))
+                        }
+
+                        Spacer()
+
+                        // API progress ring
+                        ZStack {
+                            Circle()
+                                .stroke(ringBackgroundColor, lineWidth: 5)
+
+                            Circle()
+                                .trim(from: 0, to: min(apiUsage.usagePercentage / 100, 1.0))
+                                .stroke(Color.blue, style: StrokeStyle(lineWidth: 5, lineCap: .round))
+                                .rotationEffect(.degrees(-90))
+
+                            Text("\(Int(apiUsage.usagePercentage))%")
+                                .font(.system(size: WidgetDesign.Typography.iconMedium, weight: .bold, design: .rounded))
+                        }
+                        .frame(width: 48, height: 48)
+                    }
+                }
+            }
+            .padding(WidgetDesign.Spacing.outerPadding)
+        } else {
+            noDataView
+        }
+    }
+
+    // MARK: - Colors
+
+    private var secondaryTextColor: Color {
+        Color.primary.opacity(WidgetDesign.Colors.glassSecondaryText)
+    }
+
+    private var dividerColor: Color {
+        Color.primary.opacity(WidgetDesign.Colors.glassDivider)
+    }
+
+    private var ringBackgroundColor: Color {
+        Color.white.opacity(0.15)  // Very subtle background for ring track
+    }
+
+    private var noDataView: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "chart.bar.xaxis")
+                .font(.system(size: WidgetDesign.NoData.iconLarge))
+                .foregroundColor(secondaryTextColor)
+
+            Text("No Usage Data")
+                .font(.system(size: WidgetDesign.NoData.titleLarge, weight: .semibold))
+                .foregroundColor(.primary)
+
+            Text("Open the Claude Usage app to sync your data and enable widget display.")
+                .font(.system(size: WidgetDesign.NoData.subtitleLarge))
+                .foregroundColor(secondaryTextColor)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 16)
+        }
+        .padding(WidgetDesign.Spacing.outerPadding)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func lastUpdatedText(_ date: Date) -> String {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return "Updated \(formatter.localizedString(for: date, relativeTo: Date()))"
+    }
+
+    private func statusLevel(for percentage: Double) -> WidgetStatusLevel {
+        switch percentage {
+        case 0..<50:
+            return .safe
+        case 50..<80:
+            return .moderate
+        default:
+            return .critical
+        }
+    }
+
+    private func extraSubtitle(for usage: WidgetUsageData, format: ExtraUsageDisplayFormat) -> String {
+        switch format {
+        case .percentage:
+            // Show reset time when format is percentage (since percentage is already in main display)
+            return WidgetDateFormatter.shortTimeString(from: usage.weeklyResetTime)
+        case .currency:
+            // Show currency amount
+            return usage.formattedExtraUsed ?? "$0.00"
+        case .both:
+            // Show both currency and reset time
+            let currency = usage.formattedExtraUsed ?? "$0.00"
+            let resetTime = WidgetDateFormatter.shortTimeString(from: usage.weeklyResetTime)
+            return "\(currency) • \(resetTime)"
+        }
+    }
+}
+
+struct MetricTile: View {
+    let title: String
+    let percentage: Double
+    let subtitle: String
+    let icon: String
+    let colorMode: WidgetColorDisplayMode
+    let customColorHex: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Image(systemName: icon)
+                    .font(.system(size: WidgetDesign.Typography.iconSmall))
+                    .foregroundColor(statusColor)
+                Text(title)
+                    .font(.system(size: WidgetDesign.Typography.iconMedium, weight: .medium))
+                    .foregroundColor(secondaryTextColor)
+            }
+
+            Text("\(Int(percentage.rounded()))%")
+                .font(.system(size: WidgetDesign.Typography.percentageMedium, weight: .bold, design: .rounded))
+                .foregroundColor(statusColor)
+
+            // Progress bar
+            GeometryReader { geometry in
+                ZStack(alignment: .leading) {
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(progressBackgroundColor)
+
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(statusColor)
+                        .frame(width: geometry.size.width * min(percentage / 100, 1.0))
+                }
+            }
+            .frame(height: WidgetDesign.Spacing.progressHeight)
+
+            Text(subtitle)
+                .font(.system(size: WidgetDesign.Typography.timestamp))
+                .foregroundColor(secondaryTextColor)
+        }
+        .padding(WidgetDesign.Spacing.cardPadding)
+        .background(tileBackground)
+        .cornerRadius(WidgetDesign.Spacing.cardCornerRadius)
+    }
+
+    // MARK: - Colors
+
+    private var tileBackground: some View {
+        // Use very subtle white tint for glass - maintains desktop transparency
+        Color.white.opacity(0.05)
+    }
+
+    private var progressBackgroundColor: Color {
+        Color.white.opacity(0.15)  // Very subtle background for progress track
+    }
+
+    private var secondaryTextColor: Color {
+        Color.primary.opacity(WidgetDesign.Colors.glassSecondaryText)
+    }
+
+    private var statusColor: Color {
+        return WidgetDataProvider.shared.colorForUsage(
+            percentage,
+            mode: colorMode,
+            customColorHex: customColorHex
+        )
+    }
+}

--- a/Claude Usage Widget/WidgetViews/LargeWidgetView.swift
+++ b/Claude Usage Widget/WidgetViews/LargeWidgetView.swift
@@ -70,9 +70,9 @@ struct LargeWidgetView: View {
                         MetricTile(
                             title: "Extra",
                             percentage: extraPercentage,
-                            subtitle: extraSubtitle(for: usage, format: entry.extraUsageFormat),
+                            subtitle: usage.formattedExtraUsed ?? "$0.00",
                             icon: "dollarsign.circle.fill",
-                                colorMode: entry.colorMode,
+                            colorMode: entry.colorMode,
                             customColorHex: entry.customColorHex
                         )
                     } else {
@@ -101,9 +101,9 @@ struct LargeWidgetView: View {
                         MetricTile(
                             title: "Extra",
                             percentage: extraPercentage,
-                            subtitle: extraSubtitle(for: usage, format: entry.extraUsageFormat),
+                            subtitle: usage.formattedExtraUsed ?? "$0.00",
                             icon: "dollarsign.circle.fill",
-                                colorMode: entry.colorMode,
+                            colorMode: entry.colorMode,
                             customColorHex: entry.customColorHex
                         )
                     } else {
@@ -214,21 +214,6 @@ struct LargeWidgetView: View {
         }
     }
 
-    private func extraSubtitle(for usage: WidgetUsageData, format: ExtraUsageDisplayFormat) -> String {
-        switch format {
-        case .percentage:
-            // Show reset time when format is percentage (since percentage is already in main display)
-            return WidgetDateFormatter.shortTimeString(from: usage.weeklyResetTime)
-        case .currency:
-            // Show currency amount
-            return usage.formattedExtraUsed ?? "$0.00"
-        case .both:
-            // Show both currency and reset time
-            let currency = usage.formattedExtraUsed ?? "$0.00"
-            let resetTime = WidgetDateFormatter.shortTimeString(from: usage.weeklyResetTime)
-            return "\(currency) • \(resetTime)"
-        }
-    }
 }
 
 struct MetricTile: View {

--- a/Claude Usage Widget/WidgetViews/MediumWidgetView.swift
+++ b/Claude Usage Widget/WidgetViews/MediumWidgetView.swift
@@ -1,0 +1,246 @@
+//
+//  MediumWidgetView.swift
+//  Claude Usage Widget
+//
+//  Medium widget showing configurable metric pair with progress bars
+//
+
+import SwiftUI
+import WidgetKit
+
+struct MediumWidgetView: View {
+    let entry: UsageEntry
+
+    var body: some View {
+        if let usage = entry.usage {
+            VStack(spacing: WidgetDesign.Spacing.sectionSpacing) {
+                // Header row (per Apple HIG - medium widgets should have headers)
+                HStack {
+                    Image(systemName: "sparkles")
+                        .font(.system(size: WidgetDesign.Typography.iconMedium))
+                        .foregroundColor(.purple)
+                    Text("Claude Usage")
+                        .font(.system(size: WidgetDesign.Typography.headerTitle, weight: .semibold))
+                    Spacer()
+                    Text(lastUpdatedText(usage.lastUpdated))
+                        .font(.system(size: WidgetDesign.Typography.timestamp))
+                        .foregroundColor(secondaryTextColor)
+                }
+
+                // Usage cards with independent metric selection
+                HStack(spacing: WidgetDesign.Spacing.cardSpacing) {
+                    // Left card
+                    UsageCard(
+                        metric: entry.mediumLeftMetric,
+                        usage: usage,
+                        colorMode: entry.colorMode,
+                        customColorHex: entry.customColorHex,
+                        extraUsageFormat: entry.extraUsageFormat
+                    )
+
+                    // Right card
+                    UsageCard(
+                        metric: entry.mediumRightMetric,
+                        usage: usage,
+                        colorMode: entry.colorMode,
+                        customColorHex: entry.customColorHex,
+                        extraUsageFormat: entry.extraUsageFormat
+                    )
+                }
+            }
+            .padding(WidgetDesign.Spacing.outerPadding)
+        } else {
+            noDataView
+        }
+    }
+
+    // MARK: - Helper Methods
+
+    private func lastUpdatedText(_ date: Date) -> String {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return "Updated \(formatter.localizedString(for: date, relativeTo: Date()))"
+    }
+
+    // MARK: - Colors
+
+    private var secondaryTextColor: Color {
+        Color.primary.opacity(WidgetDesign.Colors.glassSecondaryText)
+    }
+
+    private var noDataView: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "chart.bar.xaxis")
+                .font(.system(size: WidgetDesign.NoData.iconMedium))
+                .foregroundColor(secondaryTextColor)
+
+            Text("No Data Available")
+                .font(.system(size: WidgetDesign.NoData.titleMedium, weight: .medium))
+                .foregroundColor(secondaryTextColor)
+
+            Text("Open Claude Usage app to sync data")
+                .font(.system(size: WidgetDesign.NoData.subtitleMedium))
+                .foregroundColor(secondaryTextColor)
+                .multilineTextAlignment(.center)
+        }
+        .padding(WidgetDesign.Spacing.outerPadding)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+// MARK: - Usage Card (Configurable)
+
+struct UsageCard: View {
+    let metric: WidgetSmallMetric
+    let usage: WidgetUsageData
+    let colorMode: WidgetColorDisplayMode
+    let customColorHex: String
+    let extraUsageFormat: ExtraUsageDisplayFormat
+
+    private var metricData: MetricDisplayData {
+        getMetricData(for: metric, usage: usage)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            // Header with icon
+            HStack {
+                Image(systemName: metric.icon)
+                    .font(.system(size: WidgetDesign.Typography.iconSmall))
+                    .foregroundColor(statusColor)
+                Text(metric.displayName)
+                    .font(.system(size: WidgetDesign.Typography.cardTitle, weight: .medium))
+                    .foregroundColor(secondaryTextColor)
+                Spacer()
+            }
+
+            // Percentage
+            Text("\(Int(metricData.percentage.rounded()))%")
+                .font(.system(size: WidgetDesign.Typography.percentageMedium, weight: .bold, design: .rounded))
+                .foregroundColor(statusColor)
+
+            // Progress bar
+            GeometryReader { geometry in
+                ZStack(alignment: .leading) {
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(progressBackgroundColor)
+
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(statusColor)
+                        .frame(width: geometry.size.width * min(metricData.percentage / 100, 1.0))
+                }
+            }
+            .frame(height: WidgetDesign.Spacing.progressHeight)
+
+            // Reset time or extra usage info (based on metric and format)
+            Text(subtitleText(for: metric, metricData: metricData, usage: usage, format: extraUsageFormat))
+                .font(.system(size: WidgetDesign.Typography.timestamp, weight: .medium))
+                .foregroundColor(secondaryTextColor)
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
+        }
+        .padding(WidgetDesign.Spacing.cardPadding)
+        .background(cardBackground)
+        .cornerRadius(WidgetDesign.Spacing.cardCornerRadius)
+        .frame(maxWidth: .infinity)
+    }
+
+    // MARK: - Metric Data Helper
+
+    private struct MetricDisplayData {
+        let percentage: Double
+        let resetTime: Date
+        let status: WidgetStatusLevel
+    }
+
+    private func getMetricData(for metric: WidgetSmallMetric, usage: WidgetUsageData) -> MetricDisplayData {
+        switch metric {
+        case .session:
+            return MetricDisplayData(
+                percentage: usage.sessionPercentage,
+                resetTime: usage.sessionResetTime,
+                status: usage.statusLevel
+            )
+        case .weekly:
+            return MetricDisplayData(
+                percentage: usage.weeklyPercentage,
+                resetTime: usage.weeklyResetTime,
+                status: usage.weeklyStatusLevel
+            )
+        case .opus:
+            return MetricDisplayData(
+                percentage: usage.opusPercentage,
+                resetTime: usage.weeklyResetTime,
+                status: statusLevel(for: usage.opusPercentage)
+            )
+        case .sonnet:
+            return MetricDisplayData(
+                percentage: usage.sonnetPercentage,
+                resetTime: usage.weeklyResetTime,
+                status: statusLevel(for: usage.sonnetPercentage)
+            )
+        case .extra:
+            return MetricDisplayData(
+                percentage: usage.extraPercentage ?? 0.0,
+                resetTime: usage.weeklyResetTime,  // Extra usage typically resets weekly
+                status: usage.extraStatusLevel
+            )
+        }
+    }
+
+    private func statusLevel(for percentage: Double) -> WidgetStatusLevel {
+        switch percentage {
+        case 0..<50:
+            return .safe
+        case 50..<80:
+            return .moderate
+        default:
+            return .critical
+        }
+    }
+
+    // MARK: - Colors
+
+    private var cardBackground: some View {
+        // Use very subtle white tint for glass - maintains desktop transparency
+        Color.white.opacity(0.05)
+    }
+
+    private var progressBackgroundColor: Color {
+        Color.white.opacity(0.15)  // Very subtle background for progress track
+    }
+
+    private var secondaryTextColor: Color {
+        Color.primary.opacity(WidgetDesign.Colors.glassSecondaryText)
+    }
+
+    private var statusColor: Color {
+        return WidgetDataProvider.shared.colorForUsage(
+            metricData.percentage,
+            mode: colorMode,
+            customColorHex: customColorHex
+        )
+    }
+
+    private func subtitleText(for metric: WidgetSmallMetric, metricData: MetricDisplayData, usage: WidgetUsageData, format: ExtraUsageDisplayFormat) -> String {
+        // For non-extra metrics, always show reset time
+        guard metric == .extra else {
+            return WidgetDateFormatter.resetTimeString(from: metricData.resetTime)
+        }
+
+        // For extra usage, customize based on format preference
+        switch format {
+        case .percentage:
+            // Show reset time (percentage already in main display)
+            return WidgetDateFormatter.resetTimeString(from: metricData.resetTime)
+        case .currency:
+            // Show currency amount
+            return usage.formattedExtraUsed ?? "$0.00"
+        case .both:
+            // Show both currency and reset time
+            let currency = usage.formattedExtraUsed ?? "$0.00"
+            let resetTime = WidgetDateFormatter.resetTimeString(from: metricData.resetTime)
+            return "\(currency) • \(resetTime)"
+        }
+    }
+}

--- a/Claude Usage Widget/WidgetViews/MediumWidgetView.swift
+++ b/Claude Usage Widget/WidgetViews/MediumWidgetView.swift
@@ -34,8 +34,7 @@ struct MediumWidgetView: View {
                         metric: entry.mediumLeftMetric,
                         usage: usage,
                         colorMode: entry.colorMode,
-                        customColorHex: entry.customColorHex,
-                        extraUsageFormat: entry.extraUsageFormat
+                        customColorHex: entry.customColorHex
                     )
 
                     // Right card
@@ -43,8 +42,7 @@ struct MediumWidgetView: View {
                         metric: entry.mediumRightMetric,
                         usage: usage,
                         colorMode: entry.colorMode,
-                        customColorHex: entry.customColorHex,
-                        extraUsageFormat: entry.extraUsageFormat
+                        customColorHex: entry.customColorHex
                     )
                 }
             }
@@ -95,7 +93,6 @@ struct UsageCard: View {
     let usage: WidgetUsageData
     let colorMode: WidgetColorDisplayMode
     let customColorHex: String
-    let extraUsageFormat: ExtraUsageDisplayFormat
 
     private var metricData: MetricDisplayData {
         getMetricData(for: metric, usage: usage)
@@ -132,8 +129,8 @@ struct UsageCard: View {
             }
             .frame(height: WidgetDesign.Spacing.progressHeight)
 
-            // Reset time or extra usage info (based on metric and format)
-            Text(subtitleText(for: metric, metricData: metricData, usage: usage, format: extraUsageFormat))
+            // Reset time or cost (for extra metric)
+            Text(subtitleText(for: metric, metricData: metricData, usage: usage))
                 .font(.system(size: WidgetDesign.Typography.timestamp, weight: .medium))
                 .foregroundColor(secondaryTextColor)
                 .lineLimit(1)
@@ -222,25 +219,12 @@ struct UsageCard: View {
         )
     }
 
-    private func subtitleText(for metric: WidgetSmallMetric, metricData: MetricDisplayData, usage: WidgetUsageData, format: ExtraUsageDisplayFormat) -> String {
-        // For non-extra metrics, always show reset time
-        guard metric == .extra else {
-            return WidgetDateFormatter.resetTimeString(from: metricData.resetTime)
-        }
-
-        // For extra usage, customize based on format preference
-        switch format {
-        case .percentage:
-            // Show reset time (percentage already in main display)
-            return WidgetDateFormatter.resetTimeString(from: metricData.resetTime)
-        case .currency:
-            // Show currency amount
+    private func subtitleText(for metric: WidgetSmallMetric, metricData: MetricDisplayData, usage: WidgetUsageData) -> String {
+        // For extra metric, show cost amount
+        if metric == .extra {
             return usage.formattedExtraUsed ?? "$0.00"
-        case .both:
-            // Show both currency and reset time
-            let currency = usage.formattedExtraUsed ?? "$0.00"
-            let resetTime = WidgetDateFormatter.resetTimeString(from: metricData.resetTime)
-            return "\(currency) • \(resetTime)"
         }
+        // For all other metrics, show reset time
+        return WidgetDateFormatter.resetTimeString(from: metricData.resetTime)
     }
 }

--- a/Claude Usage Widget/WidgetViews/SmallWidgetView.swift
+++ b/Claude Usage Widget/WidgetViews/SmallWidgetView.swift
@@ -42,8 +42,8 @@ struct SmallWidgetView: View {
                 }
                 .frame(width: WidgetDesign.Ring.size, height: WidgetDesign.Ring.size)
 
-                // Reset time or extra usage info (based on metric and format)
-                Text(subtitleText(for: entry.smallMetric, metricData: metricData, usage: usage, format: entry.extraUsageFormat))
+                // Reset time or cost (for extra metric)
+                Text(subtitleText(for: entry.smallMetric, metricData: metricData, usage: usage))
                     .font(.system(size: WidgetDesign.Typography.subtitle, weight: .medium))
                     .foregroundColor(secondaryTextColor)
                     .lineLimit(1)
@@ -116,25 +116,13 @@ struct SmallWidgetView: View {
         }
     }
 
-    private func subtitleText(for metric: WidgetSmallMetric, metricData: MetricDisplayData, usage: WidgetUsageData, format: ExtraUsageDisplayFormat) -> String {
-        // For non-extra metrics, always show reset time
-        guard metric == .extra else {
-            return WidgetDateFormatter.resetTimeString(from: metricData.resetTime)
-        }
-
-        // For extra usage, customize based on format preference
-        switch format {
-        case .percentage:
-            // Show reset time (percentage already in main display)
-            return WidgetDateFormatter.resetTimeString(from: metricData.resetTime)
-        case .currency:
-            // Show currency amount
+    private func subtitleText(for metric: WidgetSmallMetric, metricData: MetricDisplayData, usage: WidgetUsageData) -> String {
+        // For extra metric, show cost amount
+        if metric == .extra {
             return usage.formattedExtraUsed ?? "$0.00"
-        case .both:
-            // Show both currency and reset time
-            let currency = usage.formattedExtraUsed ?? "$0.00"
-            return currency  // Simplified for small widget (limited space)
         }
+        // For all other metrics, show reset time
+        return WidgetDateFormatter.resetTimeString(from: metricData.resetTime)
     }
 
     // MARK: - No Data View

--- a/Claude Usage Widget/WidgetViews/SmallWidgetView.swift
+++ b/Claude Usage Widget/WidgetViews/SmallWidgetView.swift
@@ -1,0 +1,178 @@
+//
+//  SmallWidgetView.swift
+//  Claude Usage Widget
+//
+//  Compact widget showing single configurable metric with circular progress
+//
+
+import SwiftUI
+import WidgetKit
+
+struct SmallWidgetView: View {
+    let entry: UsageEntry
+
+    var body: some View {
+        if let usage = entry.usage {
+            let metricData = getMetricData(for: entry.smallMetric, usage: usage)
+
+            VStack(spacing: 10) {
+                // Circular progress indicator - sized for ~170x170 widget
+                ZStack {
+                    Circle()
+                        .stroke(ringBackgroundColor, lineWidth: WidgetDesign.Ring.lineWidth)
+
+                    Circle()
+                        .trim(from: 0, to: min(metricData.percentage / 100, 1.0))
+                        .stroke(
+                            statusColor(for: metricData.percentage),
+                            style: StrokeStyle(lineWidth: WidgetDesign.Ring.lineWidth, lineCap: .round)
+                        )
+                        .rotationEffect(.degrees(-90))
+                        .animation(.easeInOut, value: metricData.percentage)
+
+                    VStack(spacing: 0) {
+                        Text("\(Int(metricData.percentage.rounded()))%")
+                            .font(.system(size: WidgetDesign.Typography.percentageLarge, weight: .bold, design: .rounded))
+                            .foregroundColor(statusColor(for: metricData.percentage))
+
+                        Text(metricData.label)
+                            .font(.system(size: WidgetDesign.Typography.subtitle, weight: .medium))
+                            .foregroundColor(secondaryTextColor)
+                    }
+                }
+                .frame(width: WidgetDesign.Ring.size, height: WidgetDesign.Ring.size)
+
+                // Reset time or extra usage info (based on metric and format)
+                Text(subtitleText(for: entry.smallMetric, metricData: metricData, usage: usage, format: entry.extraUsageFormat))
+                    .font(.system(size: WidgetDesign.Typography.subtitle, weight: .medium))
+                    .foregroundColor(secondaryTextColor)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
+            }
+            .padding(WidgetDesign.Spacing.outerPadding)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            noDataView
+        }
+    }
+
+    // MARK: - Metric Data Helper
+
+    private struct MetricDisplayData {
+        let percentage: Double
+        let resetTime: Date
+        let status: WidgetStatusLevel
+        let label: String
+    }
+
+    private func getMetricData(for metric: WidgetSmallMetric, usage: WidgetUsageData) -> MetricDisplayData {
+        switch metric {
+        case .session:
+            return MetricDisplayData(
+                percentage: usage.sessionPercentage,
+                resetTime: usage.sessionResetTime,
+                status: usage.statusLevel,
+                label: "Session"
+            )
+        case .weekly:
+            return MetricDisplayData(
+                percentage: usage.weeklyPercentage,
+                resetTime: usage.weeklyResetTime,
+                status: usage.weeklyStatusLevel,
+                label: "Weekly"
+            )
+        case .opus:
+            return MetricDisplayData(
+                percentage: usage.opusPercentage,
+                resetTime: usage.weeklyResetTime,
+                status: statusLevel(for: usage.opusPercentage),
+                label: "Opus"
+            )
+        case .sonnet:
+            return MetricDisplayData(
+                percentage: usage.sonnetPercentage,
+                resetTime: usage.weeklyResetTime,
+                status: statusLevel(for: usage.sonnetPercentage),
+                label: "Sonnet"
+            )
+        case .extra:
+            return MetricDisplayData(
+                percentage: usage.extraPercentage ?? 0.0,
+                resetTime: usage.weeklyResetTime,  // Extra usage typically resets weekly
+                status: usage.extraStatusLevel,
+                label: "Extra"
+            )
+        }
+    }
+
+    private func statusLevel(for percentage: Double) -> WidgetStatusLevel {
+        switch percentage {
+        case 0..<50:
+            return .safe
+        case 50..<80:
+            return .moderate
+        default:
+            return .critical
+        }
+    }
+
+    private func subtitleText(for metric: WidgetSmallMetric, metricData: MetricDisplayData, usage: WidgetUsageData, format: ExtraUsageDisplayFormat) -> String {
+        // For non-extra metrics, always show reset time (compact for small widget)
+        guard metric == .extra else {
+            return WidgetDateFormatter.compactResetTimeString(from: metricData.resetTime)
+        }
+
+        // For extra usage, customize based on format preference
+        switch format {
+        case .percentage:
+            // Show reset time (percentage already in main display)
+            return WidgetDateFormatter.compactResetTimeString(from: metricData.resetTime)
+        case .currency:
+            // Show currency amount
+            return usage.formattedExtraUsed ?? "$0.00"
+        case .both:
+            // Show both currency and reset time
+            let currency = usage.formattedExtraUsed ?? "$0.00"
+            return currency  // Simplified for small widget (limited space)
+        }
+    }
+
+    // MARK: - No Data View
+
+    private var noDataView: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "chart.bar.xaxis")
+                .font(.system(size: WidgetDesign.NoData.iconSmall))
+                .foregroundColor(secondaryTextColor)
+
+            Text("No Data")
+                .font(.system(size: WidgetDesign.NoData.titleSmall, weight: .medium))
+                .foregroundColor(secondaryTextColor)
+
+            Text("Open app to sync")
+                .font(.system(size: WidgetDesign.NoData.subtitleSmall))
+                .foregroundColor(secondaryTextColor)
+                .multilineTextAlignment(.center)
+        }
+        .padding(WidgetDesign.Spacing.outerPadding)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Style-dependent colors
+
+    private var ringBackgroundColor: Color {
+        Color.white.opacity(0.15)  // Very subtle background for ring track
+    }
+
+    private var secondaryTextColor: Color {
+        Color.primary.opacity(WidgetDesign.Colors.glassSecondaryText)
+    }
+
+    private func statusColor(for percentage: Double) -> Color {
+        return WidgetDataProvider.shared.colorForUsage(
+            percentage,
+            mode: entry.colorMode,
+            customColorHex: entry.customColorHex
+        )
+    }
+}

--- a/Claude Usage Widget/WidgetViews/SmallWidgetView.swift
+++ b/Claude Usage Widget/WidgetViews/SmallWidgetView.swift
@@ -117,16 +117,16 @@ struct SmallWidgetView: View {
     }
 
     private func subtitleText(for metric: WidgetSmallMetric, metricData: MetricDisplayData, usage: WidgetUsageData, format: ExtraUsageDisplayFormat) -> String {
-        // For non-extra metrics, always show reset time (compact for small widget)
+        // For non-extra metrics, always show reset time
         guard metric == .extra else {
-            return WidgetDateFormatter.compactResetTimeString(from: metricData.resetTime)
+            return WidgetDateFormatter.resetTimeString(from: metricData.resetTime)
         }
 
         // For extra usage, customize based on format preference
         switch format {
         case .percentage:
             // Show reset time (percentage already in main display)
-            return WidgetDateFormatter.compactResetTimeString(from: metricData.resetTime)
+            return WidgetDateFormatter.resetTimeString(from: metricData.resetTime)
         case .currency:
             // Show currency amount
             return usage.formattedExtraUsed ?? "$0.00"

--- a/Claude Usage Widget/WidgetViews/SmallWidgetView.swift
+++ b/Claude Usage Widget/WidgetViews/SmallWidgetView.swift
@@ -15,7 +15,7 @@ struct SmallWidgetView: View {
         if let usage = entry.usage {
             let metricData = getMetricData(for: entry.smallMetric, usage: usage)
 
-            VStack(spacing: 10) {
+            VStack(spacing: 14) {
                 // Circular progress indicator - sized for ~170x170 widget
                 ZStack {
                     Circle()

--- a/Claude Usage WidgetExtension.entitlements
+++ b/Claude Usage WidgetExtension.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.claude-usage</string>
+	</array>
+</dict>
+</plist>

--- a/Claude Usage.xcodeproj/project.pbxproj
+++ b/Claude Usage.xcodeproj/project.pbxproj
@@ -8,6 +8,9 @@
 
 /* Begin PBXBuildFile section */
 		056C52802F017E50007E2A48 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = SPARKLE_PRODUCT_DEP /* Sparkle */; };
+		FCDCC0FF2F23420100E5B9C6 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FCDCC0FE2F23420100E5B9C6 /* WidgetKit.framework */; };
+		FCDCC1012F23420100E5B9C6 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FCDCC1002F23420100E5B9C6 /* SwiftUI.framework */; };
+		FCDCC10C2F23420200E5B9C6 /* Claude Usage WidgetExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = FCDCC0FC2F23420100E5B9C6 /* Claude Usage WidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -18,22 +21,75 @@
 			remoteGlobalIDString = 05CD2CB12EA985A100004C83;
 			remoteInfo = "Claude Usage";
 		};
+		FCDCC10A2F23420200E5B9C6 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 05CD2CAA2EA985A100004C83 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FCDCC0FB2F23420100E5B9C6;
+			remoteInfo = "Claude Usage WidgetExtension";
+		};
 /* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		FCDCC10D2F23420200E5B9C6 /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				FCDCC10C2F23420200E5B9C6 /* Claude Usage WidgetExtension.appex in Embed Foundation Extensions */,
+			);
+			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		05CD2CB22EA985A100004C83 /* Claude Usage.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Claude Usage.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		05CD2CC02EA985A100004C83 /* Claude UsageTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Claude UsageTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FCDCC0FC2F23420100E5B9C6 /* Claude Usage WidgetExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "Claude Usage WidgetExtension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FCDCC0FE2F23420100E5B9C6 /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
+		FCDCC1002F23420100E5B9C6 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
+		FCDCC1382F23430F00E5B9C6 /* Claude Usage WidgetExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Claude Usage WidgetExtension.entitlements"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		FCDCC1392F23443400E5B9C6 /* Exceptions for "Claude Usage" folder in "Claude Usage" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Resources/Info.plist,
+			);
+			target = 05CD2CB12EA985A100004C83 /* Claude Usage */;
+		};
+		FCDCC13A2F23443800E5B9C6 /* Exceptions for "Claude Usage Widget" folder in "Claude Usage WidgetExtension" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = FCDCC0FB2F23420100E5B9C6 /* Claude Usage WidgetExtension */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		05CD2CB42EA985A100004C83 /* Claude Usage */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				FCDCC1392F23443400E5B9C6 /* Exceptions for "Claude Usage" folder in "Claude Usage" target */,
+			);
 			path = "Claude Usage";
 			sourceTree = "<group>";
 		};
 		05CD2CC12EA985A100004C83 /* Claude UsageTests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = "Claude UsageTests";
+			sourceTree = "<group>";
+		};
+		FCDCC1022F23420100E5B9C6 /* Claude Usage Widget */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				FCDCC13A2F23443800E5B9C6 /* Exceptions for "Claude Usage Widget" folder in "Claude Usage WidgetExtension" target */,
+			);
+			path = "Claude Usage Widget";
 			sourceTree = "<group>";
 		};
 /* End PBXFileSystemSynchronizedRootGroup section */
@@ -54,14 +110,26 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		FCDCC0F92F23420100E5B9C6 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FCDCC1012F23420100E5B9C6 /* SwiftUI.framework in Frameworks */,
+				FCDCC0FF2F23420100E5B9C6 /* WidgetKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
 		05CD2CA92EA985A100004C83 = {
 			isa = PBXGroup;
 			children = (
+				FCDCC1382F23430F00E5B9C6 /* Claude Usage WidgetExtension.entitlements */,
 				05CD2CB42EA985A100004C83 /* Claude Usage */,
 				05CD2CC12EA985A100004C83 /* Claude UsageTests */,
+				FCDCC1022F23420100E5B9C6 /* Claude Usage Widget */,
+				FCDCC0FD2F23420100E5B9C6 /* Frameworks */,
 				05CD2CB32EA985A100004C83 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -71,8 +139,18 @@
 			children = (
 				05CD2CB22EA985A100004C83 /* Claude Usage.app */,
 				05CD2CC02EA985A100004C83 /* Claude UsageTests.xctest */,
+				FCDCC0FC2F23420100E5B9C6 /* Claude Usage WidgetExtension.appex */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		FCDCC0FD2F23420100E5B9C6 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				FCDCC0FE2F23420100E5B9C6 /* WidgetKit.framework */,
+				FCDCC1002F23420100E5B9C6 /* SwiftUI.framework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -85,10 +163,12 @@
 				05CD2CAE2EA985A100004C83 /* Sources */,
 				05CD2CAF2EA985A100004C83 /* Frameworks */,
 				05CD2CB02EA985A100004C83 /* Resources */,
+				FCDCC10D2F23420200E5B9C6 /* Embed Foundation Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				FCDCC10B2F23420200E5B9C6 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				05CD2CB42EA985A100004C83 /* Claude Usage */,
@@ -124,6 +204,28 @@
 			productReference = 05CD2CC02EA985A100004C83 /* Claude UsageTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		FCDCC0FB2F23420100E5B9C6 /* Claude Usage WidgetExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FCDCC1112F23420200E5B9C6 /* Build configuration list for PBXNativeTarget "Claude Usage WidgetExtension" */;
+			buildPhases = (
+				FCDCC0F82F23420100E5B9C6 /* Sources */,
+				FCDCC0F92F23420100E5B9C6 /* Frameworks */,
+				FCDCC0FA2F23420100E5B9C6 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				FCDCC1022F23420100E5B9C6 /* Claude Usage Widget */,
+			);
+			name = "Claude Usage WidgetExtension";
+			packageProductDependencies = (
+			);
+			productName = "Claude Usage WidgetExtension";
+			productReference = FCDCC0FC2F23420100E5B9C6 /* Claude Usage WidgetExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -131,7 +233,7 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 2600;
+				LastSwiftUpdateCheck = 2620;
 				LastUpgradeCheck = 2620;
 				TargetAttributes = {
 					05CD2CB12EA985A100004C83 = {
@@ -140,6 +242,9 @@
 					05CD2CC52EA985A100004C83 = {
 						CreatedOnToolsVersion = 16.0;
 						TestTargetID = 05CD2CB12EA985A100004C83;
+					};
+					FCDCC0FB2F23420100E5B9C6 = {
+						CreatedOnToolsVersion = 26.2;
 					};
 				};
 			};
@@ -169,6 +274,7 @@
 			targets = (
 				05CD2CB12EA985A100004C83 /* Claude Usage */,
 				05CD2CC52EA985A100004C83 /* Claude UsageTests */,
+				FCDCC0FB2F23420100E5B9C6 /* Claude Usage WidgetExtension */,
 			);
 		};
 /* End PBXProject section */
@@ -182,6 +288,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		05CD2CC42EA985A100004C83 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FCDCC0FA2F23420100E5B9C6 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -205,6 +318,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		FCDCC0F82F23420100E5B9C6 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -212,6 +332,11 @@
 			isa = PBXTargetDependency;
 			target = 05CD2CB12EA985A100004C83 /* Claude Usage */;
 			targetProxy = 05CD2CC72EA985A100004C83 /* PBXContainerItemProxy */;
+		};
+		FCDCC10B2F23420200E5B9C6 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = FCDCC0FB2F23420100E5B9C6 /* Claude Usage WidgetExtension */;
+			targetProxy = FCDCC10A2F23420200E5B9C6 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -341,9 +466,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 9;
 				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_TEAM = 7GSPYYN5X8;
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SELECTED_FILES = readonly;
@@ -391,7 +518,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 9;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = T77ZWDC739;
+				DEVELOPMENT_TEAM = 7GSPYYN5X8;
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
@@ -484,6 +611,81 @@
 			};
 			name = Release;
 		};
+		FCDCC10E2F23420200E5B9C6 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CODE_SIGN_ENTITLEMENTS = "Claude Usage WidgetExtension.entitlements";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 9;
+				DEVELOPMENT_TEAM = 7GSPYYN5X8;
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "Claude Usage Widget/Info.plist";
+				INFOPLIST_KEY_CFBundleDisplayName = "Claude Usage Widget";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@executable_path/../../../../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 26.2;
+				MARKETING_VERSION = 2.3.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "HamedElfayome.Claude-Usage.Claude-Usage-Widget";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		FCDCC10F2F23420200E5B9C6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CODE_SIGN_ENTITLEMENTS = "Claude Usage WidgetExtension.entitlements";
+				CODE_SIGN_IDENTITY = "-";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 9;
+				DEVELOPMENT_TEAM = 7GSPYYN5X8;
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "Claude Usage Widget/Info.plist";
+				INFOPLIST_KEY_CFBundleDisplayName = "Claude Usage Widget";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@executable_path/../../../../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 26.2;
+				MARKETING_VERSION = 2.3.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "HamedElfayome.Claude-Usage.Claude-Usage-Widget";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -510,6 +712,15 @@
 			buildConfigurations = (
 				05CD2CC82EA985A100004C83 /* Debug */,
 				05CD2CC92EA985A100004C83 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		FCDCC1112F23420200E5B9C6 /* Build configuration list for PBXNativeTarget "Claude Usage WidgetExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FCDCC10E2F23420200E5B9C6 /* Debug */,
+				FCDCC10F2F23420200E5B9C6 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Claude Usage/ClaudeUsageTracker.entitlements
+++ b/Claude Usage/ClaudeUsageTracker.entitlements
@@ -10,5 +10,9 @@
 	<true/>
 	<key>com.apple.security.cs.disable-library-validation</key>
 	<true/>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.claude-usage</string>
+	</array>
 </dict>
 </plist>

--- a/Claude Usage/MenuBar/MenuBarIconRenderer.swift
+++ b/Claude Usage/MenuBar/MenuBarIconRenderer.swift
@@ -20,7 +20,8 @@ final class MenuBarIconRenderer {
         usage: ClaudeUsage,
         apiUsage: APIUsage?,
         isDarkMode: Bool,
-        monochromeMode: Bool,
+        colorMode: MenuBarColorMode,
+        singleColorHex: String,
         showIconName: Bool,
         showNextSessionTime: Bool
     ) -> NSImage {
@@ -38,7 +39,8 @@ final class MenuBarIconRenderer {
             return createAPITextStyle(
                 metricData: metricData,
                 isDarkMode: isDarkMode,
-                monochromeMode: monochromeMode,
+                colorMode: colorMode,
+                singleColorHex: singleColorHex,
                 showIconName: showIconName
             )
         }
@@ -50,7 +52,8 @@ final class MenuBarIconRenderer {
                 metricType: metricType,
                 metricData: metricData,
                 isDarkMode: isDarkMode,
-                monochromeMode: monochromeMode,
+                colorMode: colorMode,
+                singleColorHex: singleColorHex,
                 showIconName: showIconName,
                 showNextSessionTime: showNextSessionTime,
                 usage: usage
@@ -60,7 +63,8 @@ final class MenuBarIconRenderer {
                 metricType: metricType,
                 metricData: metricData,
                 isDarkMode: isDarkMode,
-                monochromeMode: monochromeMode,
+                colorMode: colorMode,
+                singleColorHex: singleColorHex,
                 showIconName: showIconName,
                 showNextSessionTime: showNextSessionTime,
                 usage: usage
@@ -70,7 +74,8 @@ final class MenuBarIconRenderer {
                 metricType: metricType,
                 metricData: metricData,
                 isDarkMode: isDarkMode,
-                monochromeMode: monochromeMode,
+                colorMode: colorMode,
+                singleColorHex: singleColorHex,
                 showIconName: showIconName
             )
         case .icon:
@@ -78,7 +83,8 @@ final class MenuBarIconRenderer {
                 metricType: metricType,
                 metricData: metricData,
                 isDarkMode: isDarkMode,
-                monochromeMode: monochromeMode,
+                colorMode: colorMode,
+                singleColorHex: singleColorHex,
                 showIconName: showIconName
             )
         case .compact:
@@ -86,7 +92,8 @@ final class MenuBarIconRenderer {
                 metricType: metricType,
                 metricData: metricData,
                 isDarkMode: isDarkMode,
-                monochromeMode: monochromeMode,
+                colorMode: colorMode,
+                singleColorHex: singleColorHex,
                 showIconName: showIconName
             )
         }
@@ -198,7 +205,8 @@ final class MenuBarIconRenderer {
         metricType: MenuBarMetricType,
         metricData: MetricData,
         isDarkMode: Bool,
-        monochromeMode: Bool,
+        colorMode: MenuBarColorMode,
+        singleColorHex: String,
         showIconName: Bool,
         showNextSessionTime: Bool,
         usage: ClaudeUsage
@@ -220,7 +228,7 @@ final class MenuBarIconRenderer {
         let foregroundColor = menuBarForegroundColor(isDarkMode: isDarkMode)
         let outlineColor: NSColor = foregroundColor
         let textColor: NSColor = foregroundColor
-        let fillColor: NSColor = monochromeMode ? foregroundColor : getColorForStatusLevel(metricData.statusLevel)
+        let fillColor: NSColor = getColorForMode(colorMode, statusLevel: metricData.statusLevel, singleColorHex: singleColorHex, isDarkMode: isDarkMode)
 
         let xOffset: CGFloat = 0
 
@@ -292,7 +300,8 @@ final class MenuBarIconRenderer {
         metricType: MenuBarMetricType,
         metricData: MetricData,
         isDarkMode: Bool,
-        monochromeMode: Bool,
+        colorMode: MenuBarColorMode,
+        singleColorHex: String,
         showIconName: Bool,
         showNextSessionTime: Bool,
         usage: ClaudeUsage
@@ -312,7 +321,7 @@ final class MenuBarIconRenderer {
         // Use isDarkMode to determine correct foreground color for menu bar
         let foregroundColor = menuBarForegroundColor(isDarkMode: isDarkMode)
         let textColor: NSColor = foregroundColor
-        let fillColor: NSColor = monochromeMode ? foregroundColor : getColorForStatusLevel(metricData.statusLevel)
+        let fillColor: NSColor = getColorForMode(colorMode, statusLevel: metricData.statusLevel, singleColorHex: singleColorHex, isDarkMode: isDarkMode)
         let backgroundColor: NSColor = foregroundColor.withAlphaComponent(0.2)
 
         var xOffset: CGFloat = 1
@@ -383,14 +392,12 @@ final class MenuBarIconRenderer {
         metricType: MenuBarMetricType,
         metricData: MetricData,
         isDarkMode: Bool,
-        monochromeMode: Bool,
+        colorMode: MenuBarColorMode,
+        singleColorHex: String,
         showIconName: Bool
     ) -> NSImage {
         let font = NSFont.monospacedDigitSystemFont(ofSize: 12, weight: .semibold)  // Larger font
-
-        // Use isDarkMode to determine correct foreground color for menu bar
-        let foregroundColor = menuBarForegroundColor(isDarkMode: isDarkMode)
-        let fillColor: NSColor = monochromeMode ? foregroundColor : getColorForStatusLevel(metricData.statusLevel)
+        let fillColor: NSColor = getColorForMode(colorMode, statusLevel: metricData.statusLevel, singleColorHex: singleColorHex, isDarkMode: isDarkMode)
 
         var fullText = ""
 
@@ -421,7 +428,8 @@ final class MenuBarIconRenderer {
         metricType: MenuBarMetricType,
         metricData: MetricData,
         isDarkMode: Bool,
-        monochromeMode: Bool,
+        colorMode: MenuBarColorMode,
+        singleColorHex: String,
         showIconName: Bool
     ) -> NSImage {
         // For circle: make it bigger to fit S/W in center
@@ -437,7 +445,7 @@ final class MenuBarIconRenderer {
         // Use isDarkMode to determine correct foreground color for menu bar
         let foregroundColor = menuBarForegroundColor(isDarkMode: isDarkMode)
         let textColor: NSColor = foregroundColor
-        let fillColor: NSColor = monochromeMode ? foregroundColor : getColorForStatusLevel(metricData.statusLevel)
+        let fillColor: NSColor = getColorForMode(colorMode, statusLevel: metricData.statusLevel, singleColorHex: singleColorHex, isDarkMode: isDarkMode)
 
         let xOffset: CGFloat = 1
 
@@ -499,7 +507,8 @@ final class MenuBarIconRenderer {
         metricType: MenuBarMetricType,
         metricData: MetricData,
         isDarkMode: Bool,
-        monochromeMode: Bool,
+        colorMode: MenuBarColorMode,
+        singleColorHex: String,
         showIconName: Bool
     ) -> NSImage {
         let prefixWidth: CGFloat = showIconName ? 16 : 0
@@ -516,7 +525,7 @@ final class MenuBarIconRenderer {
         // Use isDarkMode to determine correct foreground color for menu bar
         let foregroundColor = menuBarForegroundColor(isDarkMode: isDarkMode)
         let textColor: NSColor = foregroundColor
-        let fillColor: NSColor = monochromeMode ? foregroundColor : getColorForStatusLevel(metricData.statusLevel)
+        let fillColor: NSColor = getColorForMode(colorMode, statusLevel: metricData.statusLevel, singleColorHex: singleColorHex, isDarkMode: isDarkMode)
 
         var xOffset: CGFloat = 1
 
@@ -550,7 +559,8 @@ final class MenuBarIconRenderer {
     private func createAPITextStyle(
         metricData: MetricData,
         isDarkMode: Bool,
-        monochromeMode: Bool,
+        colorMode: MenuBarColorMode,
+        singleColorHex: String,
         showIconName: Bool
     ) -> NSImage {
         let font = NSFont.systemFont(ofSize: 11, weight: .medium)
@@ -1007,6 +1017,24 @@ final class MenuBarIconRenderer {
             return NSColor.systemOrange
         case .critical:
             return NSColor.systemRed
+        }
+    }
+
+    /// Returns the appropriate color based on the color mode setting
+    /// - Parameters:
+    ///   - colorMode: The color mode to use
+    ///   - statusLevel: The usage status level (for multi-color mode)
+    ///   - singleColorHex: The custom hex color (for single color mode)
+    ///   - isDarkMode: Whether the menu bar is in dark mode
+    /// - Returns: The color to use for rendering
+    private func getColorForMode(_ colorMode: MenuBarColorMode, statusLevel: UsageStatusLevel, singleColorHex: String, isDarkMode: Bool) -> NSColor {
+        switch colorMode {
+        case .multiColor:
+            return getColorForStatusLevel(statusLevel)
+        case .monochrome:
+            return menuBarForegroundColor(isDarkMode: isDarkMode)
+        case .singleColor:
+            return NSColor(hex: singleColorHex) ?? NSColor.systemBlue
         }
     }
 

--- a/Claude Usage/MenuBar/MenuBarManager.swift
+++ b/Claude Usage/MenuBar/MenuBarManager.swift
@@ -68,6 +68,9 @@ class MenuBarManager: NSObject, ObservableObject {
     // Observer for display mode changes (single/multi profile)
     private var displayModeObserver: NSObjectProtocol?
 
+    // Observer for session reset events
+    private var sessionResetObserver: NSObjectProtocol?
+
     // MARK: - Image Caching (CPU Optimization)
     private var cachedImage: NSImage?
     private var cachedImageKey: String = ""
@@ -184,6 +187,9 @@ class MenuBarManager: NSObject, ObservableObject {
 
         // Observe display mode changes (single/multi profile)
         observeDisplayModeChanges()
+
+        // Observe session reset events for immediate UI updates
+        observeSessionResetEvents()
     }
 
     func cleanup() {
@@ -211,6 +217,10 @@ class MenuBarManager: NSObject, ObservableObject {
         if let displayModeObserver = displayModeObserver {
             NotificationCenter.default.removeObserver(displayModeObserver)
             self.displayModeObserver = nil
+        }
+        if let sessionResetObserver = sessionResetObserver {
+            NotificationCenter.default.removeObserver(sessionResetObserver)
+            self.sessionResetObserver = nil
         }
         if let monitor = eventMonitor {
             NSEvent.removeMonitor(monitor)
@@ -698,6 +708,43 @@ class MenuBarManager: NSObject, ObservableObject {
         }
     }
 
+    private func observeSessionResetEvents() {
+        // Observe session reset events for immediate UI updates
+        sessionResetObserver = NotificationCenter.default.addObserver(
+            forName: .sessionDidReset,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            guard let self = self else { return }
+
+            // Extract the profile ID and usage from the notification
+            guard let userInfo = notification.userInfo,
+                  let profileId = userInfo["profileId"] as? UUID,
+                  let newUsage = userInfo["usage"] as? ClaudeUsage else {
+                return
+            }
+
+            LoggingService.shared.logInfo("MenuBarManager: Session reset detected for profile \(profileId)")
+
+            // Update UI based on display mode
+            if self.profileManager.displayMode == .single {
+                // Single profile mode - update only if this is the active profile
+                if profileId == self.profileManager.activeProfile?.id {
+                    self.usage = newUsage
+                    self.updateAllStatusBarIcons()
+                }
+            } else {
+                // Multi-profile mode - update all icons since any selected profile may have reset
+                self.updateAllStatusBarIcons()
+            }
+
+            // Recreate popover if it's currently showing to display fresh data
+            if self.popover?.isShown == true {
+                self.recreatePopover()
+            }
+        }
+    }
+
     private func setupMultiProfileMode() {
         let selectedProfiles = profileManager.getSelectedProfiles()
         let config = profileManager.multiProfileConfig
@@ -756,6 +803,15 @@ class MenuBarManager: NSObject, ObservableObject {
                         // Save to profile
                         self.profileManager.saveClaudeUsage(newUsage, for: profile.id)
                         LoggingService.shared.log("MenuBarManager: Saved usage for profile '\(profile.name)' - session: \(newUsage.sessionPercentage)%")
+
+                        // CRITICAL: Check for notifications/resets for EACH profile, not just active
+                        // This ensures reset detection works in multi-profile mode
+                        NotificationManager.shared.checkAndNotify(
+                            usage: newUsage,
+                            profileId: profile.id,
+                            profileName: profile.name,
+                            settings: profile.notificationSettings
+                        )
 
                         // If this is the active profile, also update the manager's usage
                         if profile.id == self.profileManager.activeProfile?.id {
@@ -880,6 +936,7 @@ class MenuBarManager: NSObject, ObservableObject {
                     if let profile = self.profileManager.activeProfile {
                         NotificationManager.shared.checkAndNotify(
                             usage: newUsage,
+                            profileId: profile.id,
                             profileName: profile.name,
                             settings: profile.notificationSettings
                         )

--- a/Claude Usage/MenuBar/MenuBarManager.swift
+++ b/Claude Usage/MenuBar/MenuBarManager.swift
@@ -98,7 +98,8 @@ class MenuBarManager: NSObject, ObservableObject {
             let displayConfig: MenuBarIconConfiguration
             if !hasUsageCredentials {
                 displayConfig = MenuBarIconConfiguration(
-                    monochromeMode: config.monochromeMode,
+                    colorMode: config.colorMode,
+                    singleColorHex: config.singleColorHex,
                     showIconNames: config.showIconNames,
                     metrics: config.metrics.map { metric in
                         var updatedMetric = metric
@@ -339,7 +340,8 @@ class MenuBarManager: NSObject, ObservableObject {
         if !hasUsageCredentials {
             // Create config with no enabled metrics (will trigger default logo)
             displayConfig = MenuBarIconConfiguration(
-                monochromeMode: config.monochromeMode,
+                colorMode: config.colorMode,
+                singleColorHex: config.singleColorHex,
                 showIconNames: config.showIconNames,
                 metrics: config.metrics.map { metric in
                     var updatedMetric = metric
@@ -801,7 +803,8 @@ class MenuBarManager: NSObject, ObservableObject {
         let displayConfig: MenuBarIconConfiguration
         if !hasUsageCredentials {
             displayConfig = MenuBarIconConfiguration(
-                monochromeMode: config.monochromeMode,
+                colorMode: config.colorMode,
+                singleColorHex: config.singleColorHex,
                 showIconNames: config.showIconNames,
                 metrics: config.metrics.map { metric in
                     var updatedMetric = metric

--- a/Claude Usage/MenuBar/MenuBarManager.swift
+++ b/Claude Usage/MenuBar/MenuBarManager.swift
@@ -450,9 +450,13 @@ class MenuBarManager: NSObject, ObservableObject {
                     stopMonitoringForOutsideClicks()
                     // Update content view controller for new profile data
                     popover.contentViewController = createContentViewController()
-                    popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
-                    currentPopoverButton = button
-                    startMonitoringForOutsideClicks()
+                    // Wrap in async to prevent layout recursion warning
+                    DispatchQueue.main.async { [weak self] in
+                        guard let self = self else { return }
+                        popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+                        self.currentPopoverButton = button
+                        self.startMonitoringForOutsideClicks()
+                    }
                 }
             } else {
                 // Popover not shown - show it
@@ -460,9 +464,13 @@ class MenuBarManager: NSObject, ObservableObject {
                 stopMonitoringForOutsideClicks()
                 // Update content view controller for current profile data
                 popover.contentViewController = createContentViewController()
-                popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
-                currentPopoverButton = button
-                startMonitoringForOutsideClicks()
+                // Wrap in async to prevent layout recursion warning
+                DispatchQueue.main.async { [weak self] in
+                    guard let self = self else { return }
+                    popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+                    self.currentPopoverButton = button
+                    self.startMonitoringForOutsideClicks()
+                }
             }
         }
     }

--- a/Claude Usage/MenuBar/StatusBarUIManager.swift
+++ b/Claude Usage/MenuBar/StatusBarUIManager.swift
@@ -363,7 +363,8 @@ final class StatusBarUIManager {
                 usage: usage,
                 apiUsage: apiUsage,
                 isDarkMode: menuBarIsDark,
-                monochromeMode: config.monochromeMode,
+                colorMode: config.colorMode,
+                singleColorHex: config.singleColorHex,
                 showIconName: config.showIconNames,
                 showNextSessionTime: metricConfig.showNextSessionTime
             )
@@ -371,7 +372,7 @@ final class StatusBarUIManager {
             button.image = image
             // Template mode only for monochrome (lets macOS handle color adaptation)
             // Non-monochrome needs explicit colors for status indicators
-            button.image?.isTemplate = config.monochromeMode
+            button.image?.isTemplate = config.colorMode == .monochrome
         }
     }
 
@@ -403,7 +404,8 @@ final class StatusBarUIManager {
             usage: usage,
             apiUsage: apiUsage,
             isDarkMode: menuBarIsDark,
-            monochromeMode: config.monochromeMode,
+            colorMode: config.colorMode,
+            singleColorHex: config.singleColorHex,
             showIconName: config.showIconNames,
             showNextSessionTime: metricConfig.showNextSessionTime
         )
@@ -411,7 +413,7 @@ final class StatusBarUIManager {
         button.image = image
         // Template mode only for monochrome (lets macOS handle color adaptation)
         // Non-monochrome needs explicit colors for status indicators
-        button.image?.isTemplate = config.monochromeMode
+        button.image?.isTemplate = config.colorMode == .monochrome
     }
 
     /// Get button for a specific metric (used for popover positioning)

--- a/Claude Usage/MenuBar/WindowCoordinator.swift
+++ b/Claude Usage/MenuBar/WindowCoordinator.swift
@@ -110,8 +110,9 @@ final class WindowCoordinator: NSObject {
 
         // If settings window already exists, just bring it to front
         if let existingWindow = settingsWindow, existingWindow.isVisible {
+            NSApp.setActivationPolicy(.regular)
+            NSRunningApplication.current.activate()
             existingWindow.makeKeyAndOrderFront(nil)
-            NSApp.activate(ignoringOtherApps: true)
             LoggingService.shared.logWindowEvent("Settings window brought to front")
             return
         }
@@ -119,7 +120,6 @@ final class WindowCoordinator: NSObject {
         // Create settings window
         DispatchQueue.main.asyncAfter(deadline: .now() + Constants.UITiming.popoverCloseDelay) {
             NSApp.setActivationPolicy(.regular)
-            NSApp.activate(ignoringOtherApps: true)
 
             let settingsView = SettingsView()
             let hostingController = NSHostingController(rootView: settingsView)
@@ -134,10 +134,14 @@ final class WindowCoordinator: NSObject {
             window.contentViewController = hostingController
             window.center()
             window.isRestorable = false
-            window.makeKeyAndOrderFront(nil)
             window.delegate = self
 
             self.settingsWindow = window
+
+            // Bring window to front and make app active
+            window.makeKeyAndOrderFront(nil)
+            NSRunningApplication.current.activate()
+
             LoggingService.shared.logWindowEvent("Settings window opened")
         }
     }
@@ -148,12 +152,11 @@ final class WindowCoordinator: NSObject {
         // If prompt window already exists, just bring it to front
         if let existingWindow = githubPromptWindow, existingWindow.isVisible {
             existingWindow.makeKeyAndOrderFront(nil)
-            NSApp.activate(ignoringOtherApps: true)
+            NSApp.activate()
             return
         }
 
         NSApp.setActivationPolicy(.regular)
-        NSApp.activate(ignoringOtherApps: true)
 
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 500, height: 300),
@@ -165,10 +168,14 @@ final class WindowCoordinator: NSObject {
         window.contentViewController = promptView
         window.center()
         window.isRestorable = false
-        window.makeKeyAndOrderFront(nil)
         window.delegate = self
 
         githubPromptWindow = window
+
+        // Bring window to front after it's fully configured
+        window.makeKeyAndOrderFront(nil)
+        NSApp.activate()
+
         LoggingService.shared.logWindowEvent("GitHub prompt opened")
     }
 

--- a/Claude Usage/Resources/en.lproj/Localizable.strings
+++ b/Claude Usage/Resources/en.lproj/Localizable.strings
@@ -345,11 +345,11 @@
 "claudecode.component_progressbar" = "Progress bar";
 "claudecode.component_resettime" = "Reset time";
 "claudecode.requirement_sessionkey" = "• Session key configured in Credentials → Claude.ai tab";
-"claudecode.requirement_restart" = "• Restart Claude CLI after applying changes";
+"claudecode.requirement_restart" = "• Changes appear after 1-2 prompts, or restart Claude Code";
 "claudecode.error_no_components" = "Please select at least one component to display";
 "claudecode.error_no_sessionkey" = "Session key not configured. Please set it in the Personal Usage tab first.";
-"claudecode.success_applied" = "Configuration applied! Restart Claude CLI to see changes.";
-"claudecode.success_disabled" = "Statusline disabled. Restart Claude CLI.";
+"claudecode.success_applied" = "Configuration applied! Changes appear after 1-2 prompts.";
+"claudecode.success_disabled" = "Statusline disabled. Changes appear after 1-2 prompts.";
 "claudecode.preview_no_components" = "No components selected";
 
 /* ==================== */
@@ -427,6 +427,7 @@
 "appearance.multiprofile_locked_title" = "Appearance Settings Locked";
 "appearance.multiprofile_locked_description" = "These settings are disabled while Multi-Profile Display is active. Each profile uses its own appearance in multi-profile mode.";
 "appearance.disable_multiprofile" = "Turn Off Multi-Profile Display";
+"appearance.color_mode" = "Color Mode";
 
 /* ==================== */
 /* MARK: - Setup Wizard (Additional) */

--- a/Claude Usage/Shared/Extensions/Color+Extensions.swift
+++ b/Claude Usage/Shared/Extensions/Color+Extensions.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Cocoa
 
 extension Color {
     /// Initialize a Color from a hex string (e.g., "#FF5733" or "FF5733")
@@ -41,6 +42,22 @@ extension Color {
     }
 
     /// Convert Color to hex string (e.g., "#FF5733")
+    var hexString: String {
+        guard let components = NSColor(self).usingColorSpace(.sRGB)?.cgColor.components else {
+            return "#000000"
+        }
+
+        let r = components.count > 0 ? components[0] : 0
+        let g = components.count > 1 ? components[1] : 0
+        let b = components.count > 2 ? components[2] : 0
+
+        return String(format: "#%02X%02X%02X",
+                      Int(r * 255),
+                      Int(g * 255),
+                      Int(b * 255))
+    }
+
+    /// Convert Color to hex string (e.g., "#FF5733") - method variant for compatibility
     func toHex() -> String? {
         guard let components = NSColor(self).usingColorSpace(.sRGB)?.cgColor.components else {
             return nil
@@ -54,5 +71,42 @@ extension Color {
                       Int(r * 255),
                       Int(g * 255),
                       Int(b * 255))
+    }
+}
+
+// MARK: - NSColor Hex Extension
+
+extension NSColor {
+    /// Initialize an NSColor from a hex string (e.g., "#FF5733" or "FF5733")
+    convenience init?(hex: String) {
+        var hexSanitized = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+        hexSanitized = hexSanitized.replacingOccurrences(of: "#", with: "")
+
+        var rgb: UInt64 = 0
+
+        guard Scanner(string: hexSanitized).scanHexInt64(&rgb) else {
+            return nil
+        }
+
+        let length = hexSanitized.count
+
+        switch length {
+        case 6: // RGB (24-bit)
+            self.init(
+                red: CGFloat((rgb & 0xFF0000) >> 16) / 255.0,
+                green: CGFloat((rgb & 0x00FF00) >> 8) / 255.0,
+                blue: CGFloat(rgb & 0x0000FF) / 255.0,
+                alpha: 1.0
+            )
+        case 8: // RGBA (32-bit)
+            self.init(
+                red: CGFloat((rgb & 0xFF000000) >> 24) / 255.0,
+                green: CGFloat((rgb & 0x00FF0000) >> 16) / 255.0,
+                blue: CGFloat((rgb & 0x0000FF00) >> 8) / 255.0,
+                alpha: CGFloat(rgb & 0x000000FF) / 255.0
+            )
+        default:
+            return nil
+        }
     }
 }

--- a/Claude Usage/Shared/Extensions/Color+Extensions.swift
+++ b/Claude Usage/Shared/Extensions/Color+Extensions.swift
@@ -1,0 +1,58 @@
+//
+//  Color+Extensions.swift
+//  Claude Usage
+//
+//  Color utilities for hex conversion
+//
+
+import SwiftUI
+
+extension Color {
+    /// Initialize a Color from a hex string (e.g., "#FF5733" or "FF5733")
+    init?(hex: String) {
+        var hexSanitized = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+        hexSanitized = hexSanitized.replacingOccurrences(of: "#", with: "")
+
+        var rgb: UInt64 = 0
+
+        guard Scanner(string: hexSanitized).scanHexInt64(&rgb) else {
+            return nil
+        }
+
+        let length = hexSanitized.count
+
+        switch length {
+        case 6: // RGB (24-bit)
+            self.init(
+                red: Double((rgb & 0xFF0000) >> 16) / 255.0,
+                green: Double((rgb & 0x00FF00) >> 8) / 255.0,
+                blue: Double(rgb & 0x0000FF) / 255.0
+            )
+        case 8: // RGBA (32-bit)
+            self.init(
+                red: Double((rgb & 0xFF000000) >> 24) / 255.0,
+                green: Double((rgb & 0x00FF0000) >> 16) / 255.0,
+                blue: Double((rgb & 0x0000FF00) >> 8) / 255.0,
+                opacity: Double(rgb & 0x000000FF) / 255.0
+            )
+        default:
+            return nil
+        }
+    }
+
+    /// Convert Color to hex string (e.g., "#FF5733")
+    func toHex() -> String? {
+        guard let components = NSColor(self).usingColorSpace(.sRGB)?.cgColor.components else {
+            return nil
+        }
+
+        let r = components.count > 0 ? components[0] : 0
+        let g = components.count > 1 ? components[1] : 0
+        let b = components.count > 2 ? components[2] : 0
+
+        return String(format: "#%02X%02X%02X",
+                      Int(r * 255),
+                      Int(g * 255),
+                      Int(b * 255))
+    }
+}

--- a/Claude Usage/Shared/Extensions/Date+Extensions.swift
+++ b/Claude Usage/Shared/Extensions/Date+Extensions.swift
@@ -55,13 +55,16 @@ extension Date {
 
     /// Returns a formatted reset time string (e.g., "Today, 3:59AM" or "Wednesday, 7:00PM")
     func resetTimeString(from now: Date = Date(), timezone: TimeZone = .current) -> String {
+        // Round to nearest minute to prevent display flickering (e.g., 6:59 vs 7:00)
+        let roundedDate = self.roundedToNearestMinute()
+
         let calendar = Calendar.current
         let formatter = DateFormatter()
         formatter.timeZone = timezone
 
-        if calendar.isDateInToday(self) {
+        if calendar.isDateInToday(roundedDate) {
             formatter.dateFormat = "'Today,' h:mma"
-        } else if calendar.isDateInTomorrow(self) {
+        } else if calendar.isDateInTomorrow(roundedDate) {
             formatter.dateFormat = "'Tomorrow,' h:mma"
         } else {
             // Show day name (e.g., "Wednesday, 7:00PM")
@@ -69,7 +72,7 @@ extension Date {
         }
 
         // Convert am/pm to uppercase AM/PM
-        return formatter.string(from: self)
+        return formatter.string(from: roundedDate)
             .replacingOccurrences(of: "am", with: "AM")
             .replacingOccurrences(of: "pm", with: "PM")
     }

--- a/Claude Usage/Shared/Extensions/Date+Extensions.swift
+++ b/Claude Usage/Shared/Extensions/Date+Extensions.swift
@@ -53,21 +53,25 @@ extension Date {
         }
     }
 
-    /// Returns a formatted reset time string (e.g., "Today 3:59am" or "Oct 28, 12:59pm")
+    /// Returns a formatted reset time string (e.g., "Today, 3:59AM" or "Wednesday, 7:00PM")
     func resetTimeString(from now: Date = Date(), timezone: TimeZone = .current) -> String {
         let calendar = Calendar.current
         let formatter = DateFormatter()
         formatter.timeZone = timezone
 
         if calendar.isDateInToday(self) {
-            formatter.dateFormat = "'Today' h:mma"
+            formatter.dateFormat = "'Today,' h:mma"
         } else if calendar.isDateInTomorrow(self) {
-            formatter.dateFormat = "'Tomorrow' h:mma"
+            formatter.dateFormat = "'Tomorrow,' h:mma"
         } else {
-            formatter.dateFormat = "MMM d, h:mma"
+            // Show day name (e.g., "Wednesday, 7:00PM")
+            formatter.dateFormat = "EEEE',' h:mma"
         }
 
+        // Convert am/pm to uppercase AM/PM
         return formatter.string(from: self)
+            .replacingOccurrences(of: "am", with: "AM")
+            .replacingOccurrences(of: "pm", with: "PM")
     }
 
     /// Returns time remaining rounded to full hours (e.g., "→2H", "→1H", "→<1H")
@@ -85,5 +89,12 @@ extension Date {
 
         let hours = Int(ceil(interval / 3600))  // Round up to next hour
         return "→\(hours)H"
+    }
+
+    /// Returns the date rounded to the nearest minute
+    func roundedToNearestMinute() -> Date {
+        let calendar = Calendar.current
+        let components = calendar.dateComponents([.year, .month, .day, .hour, .minute], from: self)
+        return calendar.date(from: components) ?? self
     }
 }

--- a/Claude Usage/Shared/Extensions/Notification+Extensions.swift
+++ b/Claude Usage/Shared/Extensions/Notification+Extensions.swift
@@ -19,4 +19,8 @@ extension Notification.Name {
 
     /// Posted when the display mode changes (single/multi profile)
     static let displayModeChanged = Notification.Name("displayModeChanged")
+
+    /// Posted when a session reset is detected (5-hour window expired)
+    /// userInfo contains: ["profileId": UUID, "usage": ClaudeUsage]
+    static let sessionDidReset = Notification.Name("sessionDidReset")
 }

--- a/Claude Usage/Shared/Models/WidgetStyle.swift
+++ b/Claude Usage/Shared/Models/WidgetStyle.swift
@@ -1,0 +1,175 @@
+//
+//  WidgetStyle.swift
+//  Claude Usage
+//
+//  Widget and statusline appearance style options
+//
+
+import Foundation
+
+// MARK: - Statusline Color Mode
+
+/// Statusline color mode for Claude Code integration
+enum StatuslineColorMode: String, Codable, CaseIterable {
+    /// Multi-colored elements (default terminal colors)
+    case colored = "colored"
+
+    /// Monochrome/adaptive (uses terminal's default text color)
+    case monochrome = "monochrome"
+
+    /// Single user-selected color for all elements
+    case singleColor = "singleColor"
+
+    var displayName: String {
+        switch self {
+        case .colored:
+            return "Multi-Color"
+        case .monochrome:
+            return "Monochrome"
+        case .singleColor:
+            return "Single Color"
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .colored:
+            return "Threshold-based colors by usage level"
+        case .monochrome:
+            return "Adapts to system theme"
+        case .singleColor:
+            return "Custom color for all elements"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .colored:
+            return "paintpalette.fill"
+        case .monochrome:
+            return "circle.lefthalf.filled"
+        case .singleColor:
+            return "eyedropper.halffull"
+        }
+    }
+}
+
+// MARK: - Widget Color Mode
+
+/// Widget color display mode
+enum WidgetColorMode: String, Codable, CaseIterable {
+    /// Multi-colored elements (threshold-based)
+    case multiColor = "multiColor"
+
+    /// Monochrome/adaptive (uses system theme)
+    case monochrome = "monochrome"
+
+    /// Single user-selected color for all elements
+    case singleColor = "singleColor"
+
+    var displayName: String {
+        switch self {
+        case .multiColor:
+            return "Multi-Color"
+        case .monochrome:
+            return "Monochrome"
+        case .singleColor:
+            return "Single Color"
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .multiColor:
+            return "Threshold-based colors by usage level"
+        case .monochrome:
+            return "Adapts to system theme"
+        case .singleColor:
+            return "Custom color for all elements"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .multiColor:
+            return "paintpalette.fill"
+        case .monochrome:
+            return "circle.lefthalf.filled"
+        case .singleColor:
+            return "eyedropper.halffull"
+        }
+    }
+}
+
+// MARK: - Small Widget Metric
+
+/// Small widget metric selection - determines which single metric is displayed
+enum SmallWidgetMetric: String, Codable, CaseIterable {
+    case session = "session"
+    case weekly = "weekly"
+    case opus = "opus"
+    case sonnet = "sonnet"
+    case extra = "extra"
+
+    var displayName: String {
+        switch self {
+        case .session:
+            return "Session"
+        case .weekly:
+            return "Weekly"
+        case .opus:
+            return "Opus"
+        case .sonnet:
+            return "Sonnet"
+        case .extra:
+            return "Extra"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .session:
+            return "clock.fill"
+        case .weekly:
+            return "calendar"
+        case .opus:
+            return "star.fill"
+        case .sonnet:
+            return "bolt.fill"
+        case .extra:
+            return "dollarsign.circle.fill"
+        }
+    }
+}
+
+// MARK: - Extra Usage Display Format
+
+/// Extra usage display format - determines how extra usage is shown
+enum ExtraUsageDisplayFormat: String, Codable, CaseIterable {
+    case percentage = "percentage"
+    case currency = "currency"
+    case both = "both"
+
+    var displayName: String {
+        switch self {
+        case .percentage:
+            return "Percentage"
+        case .currency:
+            return "Currency Amount"
+        case .both:
+            return "Both"
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .percentage:
+            return "Show as percentage (e.g., 22%)"
+        case .currency:
+            return "Show as currency amount (e.g., $2.25)"
+        case .both:
+            return "Show both values"
+        }
+    }
+}
+

--- a/Claude Usage/Shared/Services/AutoStartSessionService.swift
+++ b/Claude Usage/Shared/Services/AutoStartSessionService.swift
@@ -147,6 +147,16 @@ final class AutoStartSessionService {
 
             let currentPercentage = usage.sessionPercentage
 
+            // CRITICAL: Notify about usage changes and detect session resets BEFORE auto-start check
+            // This ensures reset detection happens even if AutoStartSessionService detects the reset
+            // before MenuBarManager's refresh cycle
+            notificationManager.checkAndNotify(
+                usage: usage,
+                profileId: profile.id,
+                profileName: profile.name,
+                settings: profile.notificationSettings
+            )
+
             // Simple logic (like v1.1.0): If session is at 0%, start it
             // The initialization message will bring usage above 0%, preventing repeated starts
             if currentPercentage == 0.0 {

--- a/Claude Usage/Shared/Services/ProfileManager.swift
+++ b/Claude Usage/Shared/Services/ProfileManager.swift
@@ -21,7 +21,6 @@ class ProfileManager: ObservableObject {
 
     private let profileStore = ProfileStore.shared
     private let cliSyncService = ClaudeCodeSyncService.shared
-    private let appGroupIdentifier = "group.claude-usage"
 
     private var switchingSemaphore = false
 
@@ -56,6 +55,9 @@ class ProfileManager: ObservableObject {
         displayMode = profileStore.loadDisplayMode()
         multiProfileConfig = profileStore.loadMultiProfileConfig()
 
+        // Sync existing data to App Groups for widget access
+        syncExistingDataToWidget()
+
         LoggingService.shared.log("ProfileManager: Loaded \(profiles.count) profile(s), active: \(activeProfile?.name ?? "none")")
     }
 
@@ -82,6 +84,15 @@ class ProfileManager: ObservableObject {
 
         LoggingService.shared.log("Created new profile: \(newProfile.name)")
         return newProfile
+    }
+
+    func updateMultiProfileConfig(_ config: MultiProfileDisplayConfig) {
+        // Use async to avoid "Publishing changes from within view updates" warning
+        DispatchQueue.main.async { [weak self] in
+            self?.multiProfileConfig = config
+            self?.profileStore.saveMultiProfileConfig(config)
+            LoggingService.shared.log("Updated multi-profile config: style=\(config.iconStyle.rawValue), showWeek=\(config.showWeek)")
+        }
     }
 
     func updateProfile(_ profile: Profile) {
@@ -127,17 +138,17 @@ class ProfileManager: ObservableObject {
         }
 
         profileStore.saveProfiles(profiles)
+
+        // Refresh widget with updated profile data
+        syncExistingDataToWidget()
+
         LoggingService.shared.log("Deleted profile: \(profileName)")
     }
 
     func toggleProfileSelection(_ id: UUID) {
-        // Use async to avoid "Publishing changes from within view updates" warning
-        DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
-            if let index = self.profiles.firstIndex(where: { $0.id == id }) {
-                self.profiles[index].isSelectedForDisplay.toggle()
-                self.profileStore.saveProfiles(self.profiles)
-            }
+        if let index = profiles.firstIndex(where: { $0.id == id }) {
+            profiles[index].isSelectedForDisplay.toggle()
+            profileStore.saveProfiles(profiles)
         }
     }
 
@@ -148,21 +159,15 @@ class ProfileManager: ObservableObject {
     }
 
     func updateDisplayMode(_ mode: ProfileDisplayMode) {
-        // Use async to avoid "Publishing changes from within view updates" warning
-        DispatchQueue.main.async { [weak self] in
-            self?.displayMode = mode
-            self?.profileStore.saveDisplayMode(mode)
-            LoggingService.shared.log("Updated display mode to: \(mode.rawValue)")
-        }
-    }
+        displayMode = mode
+        profileStore.saveDisplayMode(mode)
 
-    func updateMultiProfileConfig(_ config: MultiProfileDisplayConfig) {
-        // Use async to avoid "Publishing changes from within view updates" warning
-        DispatchQueue.main.async { [weak self] in
-            self?.multiProfileConfig = config
-            self?.profileStore.saveMultiProfileConfig(config)
-            LoggingService.shared.log("Updated multi-profile config: style=\(config.iconStyle.rawValue), showWeek=\(config.showWeek)")
+        // Refresh widget when switching between single/multi profile display
+        if #available(macOS 14.0, *) {
+            WidgetCenter.shared.reloadAllTimelines()
         }
+
+        LoggingService.shared.log("Updated display mode to: \(mode.rawValue)")
     }
 
     // MARK: - Profile Activation (Centralized)
@@ -249,6 +254,9 @@ class ProfileManager: ObservableObject {
 
         switchingSemaphore = false
         isSwitchingProfile = false
+
+        // Sync new profile's data to widget
+        syncExistingDataToWidget()
 
         LoggingService.shared.log("Successfully activated profile: \(updatedProfile.name)")
     }
@@ -344,15 +352,52 @@ class ProfileManager: ObservableObject {
         // Update activeProfile reference if it's the same profile
         if activeProfile?.id == profileId {
             activeProfile = profiles[index]
+            // Sync to App Groups for widget access
+            syncUsageToWidgetStorage(usage)
         }
 
         // Save to persistent storage
         profileStore.saveProfiles(profiles)
         LoggingService.shared.log("Saved Claude usage for profile: \(profiles[index].name)")
+    }
 
-        // Sync to widget if this is the active profile
-        if activeProfile?.id == profileId {
-            syncWidgetData(usage)
+    /// Syncs usage data to App Groups container for widget access
+    private func syncUsageToWidgetStorage(_ usage: ClaudeUsage) {
+        let encoder = JSONEncoder()
+
+        // Try UserDefaults first
+        if let groupDefaults = UserDefaults(suiteName: Constants.appGroupIdentifier) {
+            do {
+                let data = try encoder.encode(usage)
+                groupDefaults.set(data, forKey: Constants.UserDefaultsKeys.claudeUsageData)
+                groupDefaults.synchronize()
+                LoggingService.shared.log("ProfileManager: Synced usage to widget (UserDefaults)")
+            } catch {
+                LoggingService.shared.logError("ProfileManager: UserDefaults encode failed: \(error)")
+            }
+        }
+
+        // Also write to file directly using proper App Groups API
+        guard let groupContainerURL = FileManager.default.containerURL(
+            forSecurityApplicationGroupIdentifier: Constants.appGroupIdentifier
+        ) else {
+            LoggingService.shared.logError("ProfileManager: App Group container not available for file write")
+            return
+        }
+
+        do {
+            try FileManager.default.createDirectory(at: groupContainerURL, withIntermediateDirectories: true)
+            let fileURL = groupContainerURL.appendingPathComponent("claudeUsageData.json")
+            let data = try encoder.encode(usage)
+            try data.write(to: fileURL)
+            LoggingService.shared.log("ProfileManager: Synced usage to widget (file)")
+        } catch {
+            LoggingService.shared.logError("ProfileManager: File write failed: \(error)")
+        }
+
+        // Trigger widget refresh
+        if #available(macOS 14.0, *) {
+            WidgetCenter.shared.reloadAllTimelines()
         }
     }
 
@@ -373,11 +418,50 @@ class ProfileManager: ObservableObject {
         // Update activeProfile reference if it's the same profile
         if activeProfile?.id == profileId {
             activeProfile = profiles[index]
+            // Sync to App Groups for widget access
+            syncAPIUsageToWidgetStorage(usage)
         }
 
         // Save to persistent storage
         profileStore.saveProfiles(profiles)
         LoggingService.shared.log("Saved API usage for profile: \(profiles[index].name)")
+    }
+
+    /// Syncs API usage data to App Groups container for widget access
+    private func syncAPIUsageToWidgetStorage(_ usage: APIUsage) {
+        guard let groupDefaults = UserDefaults(suiteName: Constants.appGroupIdentifier) else {
+            return
+        }
+
+        do {
+            let encoder = JSONEncoder()
+            let data = try encoder.encode(usage)
+            groupDefaults.set(data, forKey: Constants.UserDefaultsKeys.apiUsageData)
+
+            // Trigger widget refresh
+            if #available(macOS 14.0, *) {
+                WidgetCenter.shared.reloadAllTimelines()
+            }
+        } catch {
+            LoggingService.shared.logError("ProfileManager: Failed to sync API usage to widget: \(error.localizedDescription)")
+        }
+    }
+
+    /// Syncs existing profile data to App Groups container (called on app launch)
+    private func syncExistingDataToWidget() {
+        guard let profile = activeProfile else { return }
+
+        // Sync Claude usage if available
+        if let usage = profile.claudeUsage {
+            syncUsageToWidgetStorage(usage)
+            LoggingService.shared.log("ProfileManager: Synced existing Claude usage to widget on launch")
+        }
+
+        // Sync API usage if available
+        if let apiUsage = profile.apiUsage {
+            syncAPIUsageToWidgetStorage(apiUsage)
+            LoggingService.shared.log("ProfileManager: Synced existing API usage to widget on launch")
+        }
     }
 
     /// Loads API usage data for a specific profile
@@ -525,39 +609,6 @@ class ProfileManager: ObservableObject {
             checkOverageLimitEnabled: true,
             notificationSettings: NotificationSettings()
         )
-    }
-
-    // MARK: - Widget Data Sync
-
-    /// Syncs Claude usage data to the widget via App Groups shared storage
-    private func syncWidgetData(_ usage: ClaudeUsage) {
-        guard let containerURL = FileManager.default.containerURL(
-            forSecurityApplicationGroupIdentifier: appGroupIdentifier
-        ) else {
-            LoggingService.shared.logError("Widget sync: Failed to access App Groups container")
-            return
-        }
-
-        do {
-            let encoder = JSONEncoder()
-            let data = try encoder.encode(usage)
-
-            // Write to file (primary method for widget)
-            let fileURL = containerURL.appendingPathComponent("claudeUsageData.json")
-            try data.write(to: fileURL)
-
-            // Also write to UserDefaults as backup
-            if let defaults = UserDefaults(suiteName: appGroupIdentifier) {
-                defaults.set(data, forKey: "claudeUsageData")
-            }
-
-            // Refresh widgets
-            WidgetCenter.shared.reloadAllTimelines()
-
-            LoggingService.shared.log("Widget sync: Successfully updated widget data")
-        } catch {
-            LoggingService.shared.logError("Widget sync failed", error: error)
-        }
     }
 
 }

--- a/Claude Usage/Shared/Services/ProfileManager.swift
+++ b/Claude Usage/Shared/Services/ProfileManager.swift
@@ -404,7 +404,10 @@ class ProfileManager: ObservableObject {
         }
 
         do {
-            try FileManager.default.createDirectory(at: groupContainerURL, withIntermediateDirectories: true)
+            // Only create directory if it doesn't exist (avoids repeated file access prompts)
+            if !FileManager.default.fileExists(atPath: groupContainerURL.path) {
+                try FileManager.default.createDirectory(at: groupContainerURL, withIntermediateDirectories: true)
+            }
             let fileURL = groupContainerURL.appendingPathComponent("claudeUsageData.json")
             let data = try encoder.encode(usage)
             try data.write(to: fileURL)

--- a/Claude Usage/Shared/Storage/DataStore.swift
+++ b/Claude Usage/Shared/Storage/DataStore.swift
@@ -430,8 +430,8 @@ class DataStore: StorageProvider {
     private func migrateFromLegacySettings() -> MenuBarIconConfiguration {
         var config = MenuBarIconConfiguration.default
 
-        // Migrate monochrome mode
-        config.monochromeMode = loadMonochromeMode()
+        // Migrate monochrome mode to color mode
+        config.colorMode = loadMonochromeMode() ? .monochrome : .multiColor
 
         // Migrate icon style for session (was the only option before)
         let legacyStyle = loadMenuBarIconStyle()

--- a/Claude Usage/Shared/Storage/SharedDataStore.swift
+++ b/Claude Usage/Shared/Storage/SharedDataStore.swift
@@ -23,6 +23,19 @@ class SharedDataStore {
         static let statuslineShowUsage = "statuslineShowUsage"
         static let statuslineShowProgressBar = "statuslineShowProgressBar"
         static let statuslineShowResetTime = "statuslineShowResetTime"
+        static let statuslineUse24HourTime = "statuslineUse24HourTime"
+        static let statuslineShowUsageLabel = "statuslineShowUsageLabel"
+        static let statuslineShowResetLabel = "statuslineShowResetLabel"
+        static let statuslineColorMode = "statuslineColorMode"
+        static let statuslineSingleColorHex = "statuslineSingleColorHex"
+
+        // Widget Settings
+        static let smallWidgetMetric = "smallWidgetMetric"
+        static let mediumWidgetLeftMetric = "mediumWidgetLeftMetric"
+        static let mediumWidgetRightMetric = "mediumWidgetRightMetric"
+        static let widgetColorMode = "widgetColorMode"
+        static let widgetSingleColorHex = "widgetSingleColorHex"
+        static let extraUsageDisplayFormat = "extraUsageDisplayFormat"
 
         // Setup State
         static let hasCompletedSetup = "hasCompletedSetup"
@@ -39,9 +52,14 @@ class SharedDataStore {
     }
 
     init() {
-        // Use standard UserDefaults (app container)
-        self.defaults = UserDefaults.standard
-        LoggingService.shared.log("SharedDataStore: Using standard app container storage")
+        // Use App Groups UserDefaults for sharing data with widgets
+        if let groupDefaults = UserDefaults(suiteName: Constants.appGroupIdentifier) {
+            self.defaults = groupDefaults
+            LoggingService.shared.log("SharedDataStore: Using App Groups shared container")
+        } else {
+            self.defaults = UserDefaults.standard
+            LoggingService.shared.log("SharedDataStore: Fallback to standard app container (App Groups unavailable)")
+        }
     }
 
     // MARK: - Language & Localization
@@ -109,6 +127,135 @@ class SharedDataStore {
             return true
         }
         return defaults.bool(forKey: Keys.statuslineShowResetTime)
+    }
+
+    func saveStatuslineUse24HourTime(_ use24Hour: Bool) {
+        defaults.set(use24Hour, forKey: Keys.statuslineUse24HourTime)
+    }
+
+    func loadStatuslineUse24HourTime() -> Bool {
+        if defaults.object(forKey: Keys.statuslineUse24HourTime) == nil {
+            return false  // Default to 12-hour (matches system default)
+        }
+        return defaults.bool(forKey: Keys.statuslineUse24HourTime)
+    }
+
+    func saveStatuslineShowUsageLabel(_ show: Bool) {
+        defaults.set(show, forKey: Keys.statuslineShowUsageLabel)
+    }
+
+    func loadStatuslineShowUsageLabel() -> Bool {
+        if defaults.object(forKey: Keys.statuslineShowUsageLabel) == nil {
+            return true  // Default to showing labels
+        }
+        return defaults.bool(forKey: Keys.statuslineShowUsageLabel)
+    }
+
+    func saveStatuslineShowResetLabel(_ show: Bool) {
+        defaults.set(show, forKey: Keys.statuslineShowResetLabel)
+    }
+
+    func loadStatuslineShowResetLabel() -> Bool {
+        if defaults.object(forKey: Keys.statuslineShowResetLabel) == nil {
+            return true  // Default to showing labels
+        }
+        return defaults.bool(forKey: Keys.statuslineShowResetLabel)
+    }
+
+    func saveStatuslineColorMode(_ mode: StatuslineColorMode) {
+        defaults.set(mode.rawValue, forKey: Keys.statuslineColorMode)
+    }
+
+    func loadStatuslineColorMode() -> StatuslineColorMode {
+        guard let rawValue = defaults.string(forKey: Keys.statuslineColorMode),
+              let mode = StatuslineColorMode(rawValue: rawValue) else {
+            return .colored  // Default to colored
+        }
+        return mode
+    }
+
+    func saveStatuslineSingleColorHex(_ hex: String) {
+        defaults.set(hex, forKey: Keys.statuslineSingleColorHex)
+    }
+
+    func loadStatuslineSingleColorHex() -> String {
+        return defaults.string(forKey: Keys.statuslineSingleColorHex) ?? "#00BFFF"  // Default cyan
+    }
+
+    // MARK: - Widget Settings
+
+    func saveSmallWidgetMetric(_ metric: SmallWidgetMetric) {
+        defaults.set(metric.rawValue, forKey: Keys.smallWidgetMetric)
+        defaults.synchronize()  // Force sync before widget reads
+    }
+
+    func loadSmallWidgetMetric() -> SmallWidgetMetric {
+        guard let rawValue = defaults.string(forKey: Keys.smallWidgetMetric),
+              let metric = SmallWidgetMetric(rawValue: rawValue) else {
+            return .session  // Default to session
+        }
+        return metric
+    }
+
+    func saveMediumWidgetLeftMetric(_ metric: SmallWidgetMetric) {
+        defaults.set(metric.rawValue, forKey: Keys.mediumWidgetLeftMetric)
+        defaults.synchronize()  // Force sync before widget reads
+    }
+
+    func loadMediumWidgetLeftMetric() -> SmallWidgetMetric {
+        guard let rawValue = defaults.string(forKey: Keys.mediumWidgetLeftMetric),
+              let metric = SmallWidgetMetric(rawValue: rawValue) else {
+            return .session  // Default left metric
+        }
+        return metric
+    }
+
+    func saveMediumWidgetRightMetric(_ metric: SmallWidgetMetric) {
+        defaults.set(metric.rawValue, forKey: Keys.mediumWidgetRightMetric)
+        defaults.synchronize()  // Force sync before widget reads
+    }
+
+    func loadMediumWidgetRightMetric() -> SmallWidgetMetric {
+        guard let rawValue = defaults.string(forKey: Keys.mediumWidgetRightMetric),
+              let metric = SmallWidgetMetric(rawValue: rawValue) else {
+            return .weekly  // Default right metric
+        }
+        return metric
+    }
+
+    func saveWidgetColorMode(_ mode: WidgetColorMode) {
+        defaults.set(mode.rawValue, forKey: Keys.widgetColorMode)
+        defaults.synchronize()  // Force sync before widget reads
+    }
+
+    func loadWidgetColorMode() -> WidgetColorMode {
+        guard let rawValue = defaults.string(forKey: Keys.widgetColorMode),
+              let mode = WidgetColorMode(rawValue: rawValue) else {
+            return .multiColor  // Default to threshold-based colors
+        }
+        return mode
+    }
+
+    func saveWidgetSingleColorHex(_ hex: String) {
+        defaults.set(hex, forKey: Keys.widgetSingleColorHex)
+        defaults.synchronize()  // Force sync before widget reads
+    }
+
+    func loadWidgetSingleColorHex() -> String {
+        return defaults.string(forKey: Keys.widgetSingleColorHex) ?? "#00BFFF"  // Default cyan
+    }
+
+    func saveExtraUsageDisplayFormat(_ format: ExtraUsageDisplayFormat) {
+        defaults.set(format.rawValue, forKey: Keys.extraUsageDisplayFormat)
+        defaults.synchronize()  // Force sync before widget reads
+    }
+
+    func loadExtraUsageDisplayFormat() -> ExtraUsageDisplayFormat {
+        guard let rawValue = defaults.string(forKey: Keys.extraUsageDisplayFormat),
+              let format = ExtraUsageDisplayFormat(rawValue: rawValue) else {
+            return .percentage  // Default to showing percentage
+        }
+        return format
     }
 
     // MARK: - Setup State

--- a/Claude Usage/Shared/Utilities/Constants.swift
+++ b/Claude Usage/Shared/Utilities/Constants.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Application-wide constants
 enum Constants {
     // App Group identifier for sharing data between app and widgets
-    static let appGroupIdentifier = "group.com.claudeusagetracker.shared"
+    static let appGroupIdentifier = "group.claude-usage"
 
     // UserDefaults keys
     enum UserDefaultsKeys {
@@ -62,12 +62,16 @@ enum Constants {
     enum ClaudePaths {
         /// Get the REAL user home directory (not sandboxed container)
         static var homeDirectory: URL {
-            // Try to get real home from environment variable
-            if let home = ProcessInfo.processInfo.environment["HOME"] {
-                return URL(fileURLWithPath: home)
+            // Get real home directory using passwd database (works even in sandbox)
+            let pw = getpwuid(getuid())
+            if let home = pw?.pointee.pw_dir {
+                let homePath = String(cString: home)
+                return URL(fileURLWithPath: homePath)
             }
-            // Fallback to FileManager (might be sandboxed)
-            return FileManager.default.homeDirectoryForCurrentUser
+
+            // Fallback: construct from username
+            let username = NSUserName()
+            return URL(fileURLWithPath: "/Users/\(username)")
         }
 
         static var claudeDirectory: URL {

--- a/Claude Usage/Views/Settings/App/ClaudeCodeView.swift
+++ b/Claude Usage/Views/Settings/App/ClaudeCodeView.swift
@@ -9,12 +9,21 @@ import SwiftUI
 
 /// Claude Code statusline integration settings
 struct ClaudeCodeView: View {
+    @ObservedObject private var profileManager = ProfileManager.shared
+
     // Component visibility settings
     @State private var showDirectory: Bool = SharedDataStore.shared.loadStatuslineShowDirectory()
     @State private var showBranch: Bool = SharedDataStore.shared.loadStatuslineShowBranch()
     @State private var showUsage: Bool = SharedDataStore.shared.loadStatuslineShowUsage()
     @State private var showProgressBar: Bool = SharedDataStore.shared.loadStatuslineShowProgressBar()
     @State private var showResetTime: Bool = SharedDataStore.shared.loadStatuslineShowResetTime()
+    @State private var use24HourTime: Bool = SharedDataStore.shared.loadStatuslineUse24HourTime()
+    @State private var showUsageLabel: Bool = SharedDataStore.shared.loadStatuslineShowUsageLabel()
+    @State private var showResetLabel: Bool = SharedDataStore.shared.loadStatuslineShowResetLabel()
+
+    // Appearance settings
+    @State private var colorMode: StatuslineColorMode = SharedDataStore.shared.loadStatuslineColorMode()
+    @State private var singleColor: Color = Color(hex: SharedDataStore.shared.loadStatuslineSingleColorHex()) ?? .cyan
 
     // Status feedback
     @State private var statusMessage: String?
@@ -44,17 +53,15 @@ struct ClaudeCodeView: View {
                 }
 
                 VStack(alignment: .leading, spacing: DesignTokens.Spacing.small) {
-                    Text(generatePreview())
-                        .font(DesignTokens.Typography.monospaced)
-                        .foregroundColor(.accentColor)
+                    previewView
                         .padding(DesignTokens.Spacing.medium)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .background(
                             RoundedRectangle(cornerRadius: DesignTokens.Radius.small)
-                                .fill(Color.accentColor.opacity(0.05))
+                                .fill(previewBackgroundColor)
                                 .overlay(
                                     RoundedRectangle(cornerRadius: DesignTokens.Radius.small)
-                                        .strokeBorder(Color.accentColor.opacity(0.2), lineWidth: 1)
+                                        .strokeBorder(previewBorderColor, lineWidth: 1)
                                 )
                         )
 
@@ -69,37 +76,134 @@ struct ClaudeCodeView: View {
                     .fill(DesignTokens.Colors.cardBackground)
             )
 
-            // Components - Simple and clean
-            VStack(alignment: .leading, spacing: DesignTokens.Spacing.medium) {
-                Text("ui.display_components".localized)
-                    .font(DesignTokens.Typography.sectionTitle)
+            // Two-column layout: Components | Colors
+            HStack(alignment: .top, spacing: 16) {
+                // Left: Display Components
+                SettingsSectionCard(
+                    title: "ui.display_components".localized,
+                    subtitle: "Choose which elements to display"
+                ) {
+                    VStack(alignment: .leading, spacing: DesignTokens.Spacing.small) {
+                        Toggle("claudecode.component_directory".localized, isOn: $showDirectory)
+                            .font(DesignTokens.Typography.body)
 
-                VStack(alignment: .leading, spacing: DesignTokens.Spacing.small) {
-                    Toggle("claudecode.component_directory".localized, isOn: $showDirectory)
-                        .font(DesignTokens.Typography.body)
+                        Toggle("claudecode.component_branch".localized, isOn: $showBranch)
+                            .font(DesignTokens.Typography.body)
 
-                    Toggle("claudecode.component_branch".localized, isOn: $showBranch)
-                        .font(DesignTokens.Typography.body)
+                        Toggle("claudecode.component_usage".localized, isOn: $showUsage)
+                            .font(DesignTokens.Typography.body)
 
-                    Toggle("claudecode.component_usage".localized, isOn: $showUsage)
-                        .font(DesignTokens.Typography.body)
+                        if showUsage {
+                            // Components
+                            HStack(spacing: 0) {
+                                Spacer().frame(width: 20)
+                                Toggle("claudecode.component_progressbar".localized, isOn: $showProgressBar)
+                                    .font(DesignTokens.Typography.caption)
+                                    .foregroundColor(.secondary)
+                            }
 
-                    if showUsage {
-                        HStack(spacing: 0) {
-                            Spacer().frame(width: 20)
-                            Toggle("claudecode.component_progressbar".localized, isOn: $showProgressBar)
-                                .font(DesignTokens.Typography.caption)
-                                .foregroundColor(.secondary)
-                        }
+                            HStack(spacing: 0) {
+                                Spacer().frame(width: 20)
+                                Toggle("claudecode.component_resettime".localized, isOn: $showResetTime)
+                                    .font(DesignTokens.Typography.caption)
+                                    .foregroundColor(.secondary)
+                            }
 
-                        HStack(spacing: 0) {
-                            Spacer().frame(width: 20)
-                            Toggle("claudecode.component_resettime".localized, isOn: $showResetTime)
-                                .font(DesignTokens.Typography.caption)
-                                .foregroundColor(.secondary)
+                            if showResetTime {
+                                HStack(spacing: 0) {
+                                    Spacer().frame(width: 40)
+                                    Toggle("24-hour time format", isOn: $use24HourTime)
+                                        .font(.system(size: 11))
+                                        .foregroundColor(.secondary)
+                                }
+                            }
+
+                            // Divider
+                            Divider()
+                                .padding(.leading, 20)
+                                .padding(.vertical, 4)
+
+                            HStack(spacing: 0) {
+                                Spacer().frame(width: 20)
+                                Toggle("Show \"Usage:\" label", isOn: $showUsageLabel)
+                                    .font(DesignTokens.Typography.caption)
+                                    .foregroundColor(.secondary)
+                            }
+
+                            if showResetTime {
+                                HStack(spacing: 0) {
+                                    Spacer().frame(width: 20)
+                                    Toggle("Show \"Reset:\" label", isOn: $showResetLabel)
+                                        .font(DesignTokens.Typography.caption)
+                                        .foregroundColor(.secondary)
+                                }
+                            }
                         }
                     }
                 }
+                .frame(maxWidth: .infinity)
+
+                // Right: Color Mode Settings
+                SettingsSectionCard(
+                    title: "Statusline Colors",
+                    subtitle: "Choose color display mode"
+                ) {
+                    VStack(alignment: .leading, spacing: DesignTokens.Spacing.small) {
+                        ForEach([StatuslineColorMode.colored, .monochrome, .singleColor], id: \.self) { mode in
+                            Button {
+                                colorMode = mode
+                                SharedDataStore.shared.saveStatuslineColorMode(mode)
+                            } label: {
+                                HStack {
+                                    Image(systemName: colorMode == mode ? "checkmark.circle.fill" : "circle")
+                                        .foregroundColor(colorMode == mode ? .accentColor : .secondary)
+
+                                    Image(systemName: mode.icon)
+                                        .font(.system(size: 14))
+                                        .foregroundColor(iconColorForMode(mode))
+                                        .frame(width: 20)
+
+                                    VStack(alignment: .leading, spacing: 2) {
+                                        Text(mode.displayName)
+                                            .font(DesignTokens.Typography.body)
+                                            .foregroundColor(.primary)
+
+                                        Text(mode.description)
+                                            .font(DesignTokens.Typography.caption)
+                                            .foregroundColor(.secondary)
+                                    }
+
+                                    Spacer()
+                                }
+                                .padding(.vertical, 6)
+                            }
+                            .buttonStyle(.plain)
+                        }
+
+                        if colorMode == .singleColor {
+                            HStack {
+                                Spacer().frame(width: 20)
+
+                                ColorPicker("Choose Color", selection: Binding(
+                                    get: { singleColor },
+                                    set: { newColor in
+                                        singleColor = newColor
+                                        SharedDataStore.shared.saveStatuslineSingleColorHex(newColor.toHex() ?? "#00BFFF")
+                                    }
+                                ))
+                                .labelsHidden()
+
+                                Text("Custom statusline color")
+                                    .font(DesignTokens.Typography.caption)
+                                    .foregroundColor(.secondary)
+
+                                Spacer()
+                            }
+                            .padding(.vertical, 4)
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity)
             }
 
             // Action buttons - compact
@@ -163,6 +267,155 @@ struct ClaudeCodeView: View {
         }
     }
 
+    // MARK: - Computed Properties
+
+    /// Color used for preview based on selected color mode (from Menu Bar Settings)
+    private var previewColor: Color {
+        let colorMode = SharedDataStore.shared.loadStatuslineColorMode()
+        switch colorMode {
+        case .colored:
+            return .accentColor
+        case .monochrome:
+            return .primary
+        case .singleColor:
+            let hex = SharedDataStore.shared.loadStatuslineSingleColorHex()
+            return Color(hex: hex) ?? .cyan
+        }
+    }
+
+    /// Background color for preview card
+    private var previewBackgroundColor: Color {
+        let colorMode = SharedDataStore.shared.loadStatuslineColorMode()
+        switch colorMode {
+        case .colored:
+            return Color.purple.opacity(0.05)
+        case .monochrome:
+            return previewColor.opacity(0.05)
+        case .singleColor:
+            return previewColor.opacity(0.05)
+        }
+    }
+
+    /// Border color for preview card
+    private var previewBorderColor: Color {
+        let colorMode = SharedDataStore.shared.loadStatuslineColorMode()
+        switch colorMode {
+        case .colored:
+            return Color.purple.opacity(0.2)
+        case .monochrome:
+            return previewColor.opacity(0.2)
+        case .singleColor:
+            return previewColor.opacity(0.2)
+        }
+    }
+
+    /// Preview view showing statusline with appropriate colors
+    @ViewBuilder
+    private var previewView: some View {
+        let colorMode = SharedDataStore.shared.loadStatuslineColorMode()
+
+        if colorMode == .colored {
+            // Multi-color preview - each element gets its own color
+            multiColorPreview
+        } else {
+            // Single color preview (monochrome or single color)
+            Text(generatePreview())
+                .font(.system(size: 11, design: .monospaced))
+                .foregroundColor(previewColor)
+                .lineLimit(1)
+                .truncationMode(.tail)
+        }
+    }
+
+    /// Multi-color preview showing each element in different colors
+    private var multiColorPreview: some View {
+        let usage = profileManager.activeProfile?.claudeUsage
+        let percentage = usage != nil ? Int(usage!.sessionPercentage) : 29
+        let usageColor = colorForPercentage(Double(percentage))
+
+        return HStack(spacing: 0) {
+            if showDirectory {
+                Text("claude-usage")
+                    .foregroundColor(.cyan)
+                if showBranch || showUsage {
+                    Text(" │ ").foregroundColor(.secondary)
+                }
+            }
+
+            if showBranch {
+                Text("⎇ main")
+                    .foregroundColor(.green)
+                if showUsage {
+                    Text(" │ ").foregroundColor(.secondary)
+                }
+            }
+
+            if showUsage {
+                let usagePrefix = showUsageLabel ? "Usage: " : ""
+                Text(usagePrefix + "\(percentage)%")
+                    .foregroundColor(usageColor)
+
+                if showProgressBar {
+                    let filledBlocks = max(0, min(10, (percentage + 5) / 10))
+                    let emptyBlocks = 10 - filledBlocks
+                    let bar = String(repeating: "▓", count: filledBlocks) + String(repeating: "░", count: emptyBlocks)
+                    Text(" \(bar)")
+                        .foregroundColor(usageColor)
+                }
+
+                if showResetTime {
+                    let resetTimeString = formatResetTime(usage?.sessionResetTime)
+                    let resetPrefix = showResetLabel ? " → Reset: " : " → "
+                    Text(resetPrefix + resetTimeString)
+                        .foregroundColor(usageColor)
+                }
+            }
+
+            if !showDirectory && !showBranch && !showUsage {
+                Text("claudecode.preview_no_components".localized)
+                    .foregroundColor(.secondary)
+            }
+        }
+        .font(.system(size: 11, design: .monospaced))
+        .lineLimit(1)
+        .truncationMode(.tail)
+    }
+
+    /// Returns the appropriate color for usage percentage based on thresholds
+    private func colorForPercentage(_ percentage: Double) -> Color {
+        switch percentage {
+        case 0..<50:
+            return SettingsColors.usageLow       // Green
+        case 50..<80:
+            return SettingsColors.usageHigh      // Orange
+        default: // 80%+
+            return SettingsColors.usageCritical  // Red
+        }
+    }
+
+    /// Formats reset time for preview display
+    /// Rounds to nearest minute to prevent display flickering
+    private func formatResetTime(_ date: Date?) -> String {
+        guard let date = date else {
+            return "--:--"
+        }
+        let formatter = DateFormatter()
+        formatter.dateFormat = use24HourTime ? "HH:mm" : "h:mm a"
+        return formatter.string(from: date.roundedToNearestMinute())
+    }
+
+    /// Returns the appropriate icon color for each color mode
+    private func iconColorForMode(_ mode: StatuslineColorMode) -> Color {
+        switch mode {
+        case .colored:
+            return .purple
+        case .monochrome:
+            return .primary
+        case .singleColor:
+            return singleColor
+        }
+    }
+
     // MARK: - Actions
 
     /// Applies the current configuration to Claude Code statusline.
@@ -182,12 +435,19 @@ struct ClaudeCodeView: View {
             return
         }
 
+        // Load color settings from SharedDataStore (configured in Menu Bar Settings)
+        let colorMode = SharedDataStore.shared.loadStatuslineColorMode()
+        let singleColorHex = SharedDataStore.shared.loadStatuslineSingleColorHex()
+
         // Save user preferences
         SharedDataStore.shared.saveStatuslineShowDirectory(showDirectory)
         SharedDataStore.shared.saveStatuslineShowBranch(showBranch)
         SharedDataStore.shared.saveStatuslineShowUsage(showUsage)
         SharedDataStore.shared.saveStatuslineShowProgressBar(showProgressBar)
         SharedDataStore.shared.saveStatuslineShowResetTime(showResetTime)
+        SharedDataStore.shared.saveStatuslineUse24HourTime(use24HourTime)
+        SharedDataStore.shared.saveStatuslineShowUsageLabel(showUsageLabel)
+        SharedDataStore.shared.saveStatuslineShowResetLabel(showResetLabel)
 
         do {
             // Install scripts to ~/.claude/
@@ -199,7 +459,12 @@ struct ClaudeCodeView: View {
                 showBranch: showBranch,
                 showUsage: showUsage,
                 showProgressBar: showProgressBar,
-                showResetTime: showResetTime
+                showResetTime: showResetTime,
+                use24HourTime: use24HourTime,
+                showUsageLabel: showUsageLabel,
+                showResetLabel: showResetLabel,
+                colorMode: colorMode,
+                singleColorHex: singleColorHex
             )
 
             // Update Claude CLI settings.json
@@ -238,13 +503,31 @@ struct ClaudeCodeView: View {
         }
 
         if showUsage {
-            var usageText = "Usage: 29%"
+            // Use real usage data if available
+            let usage = profileManager.activeProfile?.claudeUsage
+            let percentage = usage != nil ? Int(usage!.sessionPercentage) : 29
+
+            var usageText = showUsageLabel ? "Usage: \(percentage)%" : "\(percentage)%"
+
             if showProgressBar {
-                usageText += " ▓▓▓░░░░░░░"
+                let filledBlocks = max(0, min(10, (percentage + 5) / 10))
+                let emptyBlocks = 10 - filledBlocks
+                let bar = String(repeating: "▓", count: filledBlocks) + String(repeating: "░", count: emptyBlocks)
+                usageText += " \(bar)"
             }
+
             if showResetTime {
-                usageText += " → Reset: 14:30"
+                if let resetTime = usage?.sessionResetTime {
+                    let formatter = DateFormatter()
+                    formatter.dateFormat = use24HourTime ? "HH:mm" : "h:mm a"
+                    let resetPrefix = showResetLabel ? " → Reset: " : " → "
+                    usageText += "\(resetPrefix)\(formatter.string(from: resetTime.roundedToNearestMinute()))"
+                } else {
+                    let resetPrefix = showResetLabel ? " → Reset: " : " → "
+                    usageText += "\(resetPrefix)--:--"
+                }
             }
+
             parts.append(usageText)
         }
 

--- a/Claude Usage/Views/Settings/App/ManageProfilesView.swift
+++ b/Claude Usage/Views/Settings/App/ManageProfilesView.swift
@@ -116,15 +116,7 @@ struct ManageProfilesView: View {
                                     .font(DesignTokens.Typography.caption)
                                     .foregroundColor(.secondary)
 
-                                Picker("", selection: Binding(
-                                    get: { profileManager.multiProfileConfig.iconStyle },
-                                    set: { newStyle in
-                                        var config = profileManager.multiProfileConfig
-                                        config.iconStyle = newStyle
-                                        profileManager.updateMultiProfileConfig(config)
-                                        NotificationCenter.default.post(name: .displayModeChanged, object: nil)
-                                    }
-                                )) {
+                                Picker("", selection: iconStyleBinding) {
                                     ForEach(MultiProfileIconStyle.allCases, id: \.self) { style in
                                         Text(style.displayName).tag(style)
                                     }
@@ -138,45 +130,21 @@ struct ManageProfilesView: View {
                             SettingToggle(
                                 title: "multiprofile.show_week".localized,
                                 description: "multiprofile.show_week_description".localized,
-                                isOn: Binding(
-                                    get: { profileManager.multiProfileConfig.showWeek },
-                                    set: { showWeek in
-                                        var config = profileManager.multiProfileConfig
-                                        config.showWeek = showWeek
-                                        profileManager.updateMultiProfileConfig(config)
-                                        NotificationCenter.default.post(name: .displayModeChanged, object: nil)
-                                    }
-                                )
+                                isOn: showWeekBinding
                             )
 
                             // Show Profile Label Toggle
                             SettingToggle(
                                 title: "multiprofile.show_label".localized,
                                 description: "multiprofile.show_label_description".localized,
-                                isOn: Binding(
-                                    get: { profileManager.multiProfileConfig.showProfileLabel },
-                                    set: { showLabel in
-                                        var config = profileManager.multiProfileConfig
-                                        config.showProfileLabel = showLabel
-                                        profileManager.updateMultiProfileConfig(config)
-                                        NotificationCenter.default.post(name: .displayModeChanged, object: nil)
-                                    }
-                                )
+                                isOn: showProfileLabelBinding
                             )
 
                             // Use System Color Toggle
                             SettingToggle(
                                 title: "multiprofile.use_system_color".localized,
                                 description: "multiprofile.use_system_color_description".localized,
-                                isOn: Binding(
-                                    get: { profileManager.multiProfileConfig.useSystemColor },
-                                    set: { useSystemColor in
-                                        var config = profileManager.multiProfileConfig
-                                        config.useSystemColor = useSystemColor
-                                        profileManager.updateMultiProfileConfig(config)
-                                        NotificationCenter.default.post(name: .displayModeChanged, object: nil)
-                                    }
-                                )
+                                isOn: useSystemColorBinding
                             )
 
                             // Info message
@@ -242,6 +210,56 @@ struct ManageProfilesView: View {
                 }
             )
         }
+    }
+
+    // MARK: - Multi-Profile Config Bindings
+
+    private var iconStyleBinding: Binding<MultiProfileIconStyle> {
+        Binding(
+            get: { self.profileManager.multiProfileConfig.iconStyle },
+            set: { newStyle in
+                var config = self.profileManager.multiProfileConfig
+                config.iconStyle = newStyle
+                self.profileManager.updateMultiProfileConfig(config)
+                NotificationCenter.default.post(name: .displayModeChanged, object: nil)
+            }
+        )
+    }
+
+    private var showWeekBinding: Binding<Bool> {
+        Binding(
+            get: { self.profileManager.multiProfileConfig.showWeek },
+            set: { showWeek in
+                var config = self.profileManager.multiProfileConfig
+                config.showWeek = showWeek
+                self.profileManager.updateMultiProfileConfig(config)
+                NotificationCenter.default.post(name: .displayModeChanged, object: nil)
+            }
+        )
+    }
+
+    private var showProfileLabelBinding: Binding<Bool> {
+        Binding(
+            get: { self.profileManager.multiProfileConfig.showProfileLabel },
+            set: { showLabel in
+                var config = self.profileManager.multiProfileConfig
+                config.showProfileLabel = showLabel
+                self.profileManager.updateMultiProfileConfig(config)
+                NotificationCenter.default.post(name: .displayModeChanged, object: nil)
+            }
+        )
+    }
+
+    private var useSystemColorBinding: Binding<Bool> {
+        Binding(
+            get: { self.profileManager.multiProfileConfig.useSystemColor },
+            set: { useSystemColor in
+                var config = self.profileManager.multiProfileConfig
+                config.useSystemColor = useSystemColor
+                self.profileManager.updateMultiProfileConfig(config)
+                NotificationCenter.default.post(name: .displayModeChanged, object: nil)
+            }
+        )
     }
 
     private func createNewProfile() {

--- a/Claude Usage/Views/Settings/App/WidgetSettingsView.swift
+++ b/Claude Usage/Views/Settings/App/WidgetSettingsView.swift
@@ -1,0 +1,769 @@
+//
+//  WidgetSettingsView.swift
+//  Claude Usage - Widget Appearance Settings
+//
+//  Configure desktop widget appearance including glass/standard styles
+//  and content customization
+//
+
+import SwiftUI
+import WidgetKit
+
+// MARK: - Widget Preview Design Tokens
+
+/// Design tokens for widget previews (mirrors WidgetDesign in widget extension)
+private enum PreviewDesign {
+    enum Typography {
+        static let percentageLarge: CGFloat = 28
+        static let percentageMedium: CGFloat = 26
+        static let headerTitle: CGFloat = 14
+        static let cardTitle: CGFloat = 13
+        static let subtitle: CGFloat = 11
+        static let timestamp: CGFloat = 10
+        static let iconSmall: CGFloat = 11
+        static let iconMedium: CGFloat = 12
+    }
+
+    enum Spacing {
+        static let outerPadding: CGFloat = 8
+        static let cardPadding: CGFloat = 10
+        static let cardCornerRadius: CGFloat = 10
+        static let progressHeight: CGFloat = 8
+        static let sectionSpacing: CGFloat = 10
+        static let cardSpacing: CGFloat = 10
+    }
+
+    enum Ring {
+        static let lineWidth: CGFloat = 8
+        static let size: CGFloat = 80  // Scaled down for preview
+    }
+
+    enum Colors {
+        static let glassCardBg: Double = 0.06
+        static let glassProgressBg: Double = 0.12
+        static let glassSecondaryText: Double = 0.6
+        static let standardCardBg: Double = 0.08
+        static let standardProgressBg: Double = 0.2
+    }
+}
+
+/// Widget appearance and style settings
+struct WidgetSettingsView: View {
+    @ObservedObject private var profileManager = ProfileManager.shared
+    @State private var selectedSmallMetric: SmallWidgetMetric = SharedDataStore.shared.loadSmallWidgetMetric()
+    @State private var selectedColorMode: WidgetColorMode = SharedDataStore.shared.loadWidgetColorMode()
+    @State private var singleColor: Color = Color(hex: SharedDataStore.shared.loadWidgetSingleColorHex()) ?? .cyan
+    @State private var extraUsageFormat: ExtraUsageDisplayFormat = SharedDataStore.shared.loadExtraUsageDisplayFormat()
+
+    // Medium widget individual metric selection
+    @State private var mediumLeftMetric: SmallWidgetMetric = SharedDataStore.shared.loadMediumWidgetLeftMetric()
+    @State private var mediumRightMetric: SmallWidgetMetric = SharedDataStore.shared.loadMediumWidgetRightMetric()
+
+    // Actual usage data for previews
+    @State private var previewUsage: ClaudeUsage?
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                // Page Header
+                SettingsPageHeader(
+                    title: "Widgets",
+                    subtitle: "Customize the appearance and content of your desktop widgets"
+                )
+
+                formatAndColorSection
+                smallWidgetSection
+                mediumWidgetSection
+                aboutWidgetsSection
+
+                Spacer()
+            }
+            .padding()
+        }
+        .onAppear {
+            // Load actual usage data for previews
+            if let activeProfile = profileManager.activeProfile {
+                previewUsage = activeProfile.claudeUsage
+            }
+        }
+        .onChange(of: profileManager.activeProfile?.claudeUsage) { _, newUsage in
+            // Update preview when usage changes
+            previewUsage = newUsage
+        }
+    }
+
+    // MARK: - View Sections
+
+    private var formatAndColorSection: some View {
+        LazyVGrid(columns: [
+            GridItem(.flexible(), spacing: 16),
+            GridItem(.flexible(), spacing: 16)
+        ], spacing: 16) {
+            extraUsageFormatCard
+            widgetColorsCard
+        }
+    }
+
+    private var extraUsageFormatCard: some View {
+        SettingsSectionCard(
+            title: "Extra Usage Format",
+            subtitle: "Choose how to display cost-based usage"
+        ) {
+            VStack(alignment: .leading, spacing: 4) {
+                ForEach([ExtraUsageDisplayFormat.percentage, .currency, .both], id: \.self) { format in
+                    Button {
+                        extraUsageFormat = format
+                        saveExtraUsageFormat(format)
+                    } label: {
+                        HStack {
+                            Image(systemName: extraUsageFormat == format ? "checkmark.circle.fill" : "circle")
+                                .foregroundColor(extraUsageFormat == format ? .accentColor : .secondary)
+
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(format.displayName)
+                                    .font(.system(size: 13, weight: .medium))
+                                    .foregroundColor(.primary)
+
+                                Text(format.description)
+                                    .font(.system(size: 11))
+                                    .foregroundColor(.secondary)
+                            }
+
+                            Spacer()
+                        }
+                        .padding(.vertical, 6)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+    }
+
+    private var widgetColorsCard: some View {
+        SettingsSectionCard(
+            title: "Widget Colors",
+            subtitle: "Choose color display mode"
+        ) {
+            VStack(alignment: .leading, spacing: 8) {
+                ForEach([WidgetColorMode.multiColor, .monochrome, .singleColor], id: \.self) { mode in
+                    Button {
+                        selectedColorMode = mode
+                        saveColorMode(mode)
+                    } label: {
+                        HStack {
+                            Image(systemName: selectedColorMode == mode ? "checkmark.circle.fill" : "circle")
+                                .foregroundColor(selectedColorMode == mode ? .accentColor : .secondary)
+
+                            Image(systemName: mode.icon)
+                                .font(.system(size: 14))
+                                .foregroundColor(iconColorForMode(mode))
+                                .frame(width: 20)
+
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(mode.displayName)
+                                    .font(.system(size: 12))
+                                    .foregroundColor(.primary)
+
+                                Text(mode.description)
+                                    .font(.system(size: 11))
+                                    .foregroundColor(.secondary)
+                            }
+
+                            Spacer()
+                        }
+                        .padding(.vertical, 6)
+                    }
+                    .buttonStyle(.plain)
+                }
+
+                if selectedColorMode == .singleColor {
+                    colorPickerRow
+                }
+            }
+        }
+    }
+
+    private var colorPickerRow: some View {
+        HStack {
+            Spacer().frame(width: 20)
+
+            ColorPicker("Choose Color", selection: Binding(
+                get: { singleColor },
+                set: { newColor in
+                    singleColor = newColor
+                    SharedDataStore.shared.saveWidgetSingleColorHex(newColor.toHex() ?? "#00BFFF")
+                    refreshWidgets()
+                }
+            ))
+            .labelsHidden()
+
+            Text("Custom widget color")
+                .font(.system(size: 11))
+                .foregroundColor(.secondary)
+
+            Spacer()
+        }
+        .padding(.vertical, 4)
+    }
+
+    private var smallWidgetSection: some View {
+        SettingsSectionCard(
+            title: "Small Widget",
+            subtitle: "Choose which metric to display"
+        ) {
+            HStack(alignment: .top, spacing: 16) {
+                SmallWidgetPreview(
+                    metric: selectedSmallMetric,
+                    colorMode: selectedColorMode,
+                    customColor: singleColor,
+                    usage: previewUsage
+                )
+
+                VStack(alignment: .leading, spacing: 4) {
+                    ForEach(SmallWidgetMetric.allCases, id: \.self) { metric in
+                        MetricOptionRow(
+                            metric: metric,
+                            isSelected: selectedSmallMetric == metric,
+                            onSelect: {
+                                selectedSmallMetric = metric
+                                saveSmallMetric(metric)
+                            }
+                        )
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+    }
+
+    private var mediumWidgetSection: some View {
+        SettingsSectionCard(
+            title: "Medium Widget",
+            subtitle: "Choose which two metrics to display"
+        ) {
+            VStack(alignment: .leading, spacing: 12) {
+                MediumWidgetPreview(
+                    leftMetric: mediumLeftMetric,
+                    rightMetric: mediumRightMetric,
+                    colorMode: selectedColorMode,
+                    customColor: singleColor,
+                    usage: previewUsage
+                )
+                .frame(maxWidth: .infinity)
+
+                mediumMetricPickers
+            }
+        }
+    }
+
+    private var mediumMetricPickers: some View {
+        HStack(spacing: 12) {
+            metricPicker(
+                title: "Left Metric",
+                selectedMetric: mediumLeftMetric,
+                onSelect: { metric in
+                    mediumLeftMetric = metric
+                    updateMediumLayout()
+                }
+            )
+
+            metricPicker(
+                title: "Right Metric",
+                selectedMetric: mediumRightMetric,
+                onSelect: { metric in
+                    mediumRightMetric = metric
+                    updateMediumLayout()
+                }
+            )
+        }
+    }
+
+    private func metricPicker(title: String, selectedMetric: SmallWidgetMetric, onSelect: @escaping (SmallWidgetMetric) -> Void) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(.secondary)
+
+            Menu {
+                ForEach(SmallWidgetMetric.allCases, id: \.self) { metric in
+                    Button {
+                        onSelect(metric)
+                    } label: {
+                        HStack {
+                            Image(systemName: metric.icon)
+                            Text(metric.displayName)
+                            if selectedMetric == metric {
+                                Image(systemName: "checkmark")
+                            }
+                        }
+                    }
+                }
+            } label: {
+                HStack {
+                    Image(systemName: selectedMetric.icon)
+                        .font(.system(size: 12))
+                        .foregroundColor(metricColor(selectedMetric))
+                        .frame(width: 16)
+                    Text(selectedMetric.displayName)
+                        .font(.system(size: 13))
+                    Spacer()
+                    Image(systemName: "chevron.up.chevron.down")
+                        .font(.system(size: 10))
+                        .foregroundColor(.secondary)
+                }
+                .padding(8)
+                .background(Color.gray.opacity(0.1))
+                .cornerRadius(6)
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    private var aboutWidgetsSection: some View {
+        SettingsSectionCard(
+            title: "About Widgets",
+            subtitle: "How to add widgets to your desktop"
+        ) {
+            VStack(alignment: .leading, spacing: 8) {
+                InfoRow(
+                    icon: "plus.rectangle.on.rectangle",
+                    title: "Add Widget",
+                    description: "Right-click on your desktop and select \"Edit Widgets\" to add Claude Usage widgets"
+                )
+
+                Divider()
+
+                InfoRow(
+                    icon: "square.resize",
+                    title: "Widget Sizes",
+                    description: "Available in small (single metric), medium (two metrics), and large (full dashboard) sizes"
+                )
+
+                Divider()
+
+                InfoRow(
+                    icon: "arrow.clockwise",
+                    title: "Refresh Rate",
+                    description: "Widgets refresh instantly when the app is active, or automatically every 15 minutes when the app is closed"
+                )
+            }
+        }
+    }
+
+    // MARK: - Save Methods
+
+    private func saveSmallMetric(_ metric: SmallWidgetMetric) {
+        SharedDataStore.shared.saveSmallWidgetMetric(metric)
+        refreshWidgets()
+        LoggingService.shared.log("Small widget metric changed to: \(metric.displayName)")
+    }
+
+    private func saveColorMode(_ mode: WidgetColorMode) {
+        SharedDataStore.shared.saveWidgetColorMode(mode)
+        refreshWidgets()
+        LoggingService.shared.log("Widget color mode changed to: \(mode.displayName)")
+    }
+
+    private func saveExtraUsageFormat(_ format: ExtraUsageDisplayFormat) {
+        SharedDataStore.shared.saveExtraUsageDisplayFormat(format)
+        refreshWidgets()
+        LoggingService.shared.log("Extra usage format changed to: \(format.displayName)")
+    }
+
+    private func iconColorForMode(_ mode: WidgetColorMode) -> Color {
+        switch mode {
+        case .multiColor:
+            return .purple
+        case .monochrome:
+            return .primary
+        case .singleColor:
+            return singleColor
+        }
+    }
+
+    /// Returns color for a given metric
+    private func metricColor(_ metric: SmallWidgetMetric) -> Color {
+        switch metric {
+        case .session:
+            return .green
+        case .weekly:
+            return .blue
+        case .opus:
+            return .purple
+        case .sonnet:
+            return .orange
+        case .extra:
+            return .cyan
+        }
+    }
+
+    /// Saves medium widget metrics when selection changes
+    private func updateMediumLayout() {
+        SharedDataStore.shared.saveMediumWidgetLeftMetric(mediumLeftMetric)
+        SharedDataStore.shared.saveMediumWidgetRightMetric(mediumRightMetric)
+        refreshWidgets()
+        LoggingService.shared.log("Medium widget metrics changed to: \(mediumLeftMetric.displayName) + \(mediumRightMetric.displayName)")
+    }
+
+    private func refreshWidgets() {
+        if #available(macOS 14.0, *) {
+            // Small delay to ensure UserDefaults sync propagates across processes
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                WidgetCenter.shared.reloadAllTimelines()
+            }
+        }
+    }
+}
+
+// MARK: - Metric Option Row (Compact)
+
+private struct MetricOptionRow: View {
+    let metric: SmallWidgetMetric
+    let isSelected: Bool
+    let onSelect: () -> Void
+
+    var body: some View {
+        Button(action: onSelect) {
+            HStack(spacing: 10) {
+                Image(systemName: metric.icon)
+                    .font(.system(size: 14))
+                    .foregroundColor(metricColor)
+                    .frame(width: 20)
+
+                Text(metric.displayName)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundColor(.primary)
+
+                Spacer()
+
+                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                    .font(.system(size: 16))
+                    .foregroundColor(isSelected ? .accentColor : .secondary.opacity(0.5))
+            }
+            .padding(.vertical, 6)
+            .padding(.horizontal, 8)
+            .background(
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(isSelected ? Color.accentColor.opacity(0.1) : Color.clear)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var metricColor: Color {
+        switch metric {
+        case .session:
+            return .green
+        case .weekly:
+            return .blue
+        case .opus:
+            return .purple
+        case .sonnet:
+            return .orange
+        case .extra:
+            return .cyan
+        }
+    }
+}
+
+// MARK: - Info Row
+
+private struct InfoRow: View {
+    let icon: String
+    let title: String
+    let description: String
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: icon)
+                .font(.system(size: 16))
+                .foregroundColor(.accentColor)
+                .frame(width: 24)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(.primary)
+
+                Text(description)
+                    .font(.system(size: 11))
+                    .foregroundColor(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+// MARK: - Small Widget Preview
+
+private struct SmallWidgetPreview: View {
+    let metric: SmallWidgetMetric
+    let colorMode: WidgetColorMode
+    let customColor: Color
+    let usage: ClaudeUsage?
+
+    // Computed data from real usage or fallback to sample
+    private var previewPercentage: Double {
+        guard let usage = usage else { return 45.0 }
+        switch metric {
+        case .session: return usage.sessionPercentage
+        case .weekly: return usage.weeklyPercentage
+        case .opus: return usage.opusWeeklyPercentage
+        case .sonnet: return usage.sonnetWeeklyPercentage
+        case .extra:
+            if let used = usage.costUsed, let limit = usage.costLimit, limit > 0 {
+                return (used / limit) * 100.0
+            }
+            return 0.0
+        }
+    }
+
+    private var previewResetTime: Date {
+        guard let usage = usage else { return Date().addingTimeInterval(3600 * 2) }
+        switch metric {
+        case .session: return usage.sessionResetTime
+        case .weekly, .opus, .sonnet, .extra: return usage.weeklyResetTime
+        }
+    }
+
+    var body: some View {
+        VStack(spacing: 10) {
+            // Circular progress indicator
+            ZStack {
+                Circle()
+                    .stroke(ringBackgroundColor, lineWidth: 8)
+
+                Circle()
+                    .trim(from: 0, to: previewPercentage / 100)
+                    .stroke(
+                        statusColor,
+                        style: StrokeStyle(lineWidth: 8, lineCap: .round)
+                    )
+                    .rotationEffect(.degrees(-90))
+
+                VStack(spacing: 0) {
+                    Text("\(Int(previewPercentage))%")
+                        .font(.system(size: 28, weight: .bold, design: .rounded))
+                        .foregroundColor(statusColor)
+
+                    Text(metric.displayName)
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundColor(secondaryTextColor)
+                }
+            }
+            .frame(width: 100, height: 100)
+
+            // Reset time
+            Text(formatResetTime(previewResetTime))
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(secondaryTextColor)
+                .lineLimit(1)
+        }
+        .padding(12)
+        .frame(width: 155, height: 155)  // Close to actual macOS small widget size
+        .background(previewBackground)
+        .cornerRadius(20)
+    }
+
+    private var ringBackgroundColor: Color {
+        Color.primary.opacity(PreviewDesign.Colors.glassProgressBg)
+    }
+
+    private var secondaryTextColor: Color {
+        Color.primary.opacity(PreviewDesign.Colors.glassSecondaryText)
+    }
+
+    private var statusColor: Color {
+        colorForUsage(previewPercentage, mode: colorMode, customColor: customColor)
+    }
+
+    private var previewBackground: some View {
+        RoundedRectangle(cornerRadius: 16)
+            .fill(.ultraThinMaterial)
+    }
+
+    private func formatResetTime(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "'Resets Today' h:mma"
+        return formatter.string(from: date.roundedToNearestMinute())
+    }
+}
+
+// MARK: - Medium Widget Preview
+
+private struct MediumWidgetPreview: View {
+    let leftMetric: SmallWidgetMetric
+    let rightMetric: SmallWidgetMetric
+    let colorMode: WidgetColorMode
+    let customColor: Color
+    let usage: ClaudeUsage?
+
+    var body: some View {
+        VStack(spacing: 10) {
+            // Header row
+            HStack {
+                Image(systemName: "sparkles")
+                    .font(.system(size: 12))
+                    .foregroundColor(.purple)
+                Text("Claude Usage")
+                    .font(.system(size: 14, weight: .semibold))
+                Spacer()
+                Text("Updated 5m ago")
+                    .font(.system(size: 10))
+                    .foregroundColor(secondaryTextColor)
+            }
+
+            // Usage cards
+            HStack(spacing: 10) {
+                PreviewUsageCard(
+                    metric: leftMetric,
+                    percentage: percentageFor(leftMetric),
+                    colorMode: colorMode,
+                    customColor: customColor
+                )
+                PreviewUsageCard(
+                    metric: rightMetric,
+                    percentage: percentageFor(rightMetric),
+                    colorMode: colorMode,
+                    customColor: customColor
+                )
+            }
+        }
+        .padding(12)
+        .frame(width: 329, height: 155)  // Actual macOS medium widget size
+        .background(previewBackground)
+        .cornerRadius(20)
+    }
+
+    private func percentageFor(_ metric: SmallWidgetMetric) -> Double {
+        guard let usage = usage else {
+            // Fallback to sample data
+            switch metric {
+            case .session: return 45.0
+            case .weekly: return 32.0
+            case .opus: return 28.0
+            case .sonnet: return 35.0
+            case .extra: return 22.5
+            }
+        }
+
+        // Use real data
+        switch metric {
+        case .session: return usage.sessionPercentage
+        case .weekly: return usage.weeklyPercentage
+        case .opus: return usage.opusWeeklyPercentage
+        case .sonnet: return usage.sonnetWeeklyPercentage
+        case .extra:
+            if let used = usage.costUsed, let limit = usage.costLimit, limit > 0 {
+                return (used / limit) * 100.0
+            }
+            return 0.0
+        }
+    }
+
+    private var secondaryTextColor: Color {
+        Color.primary.opacity(PreviewDesign.Colors.glassSecondaryText)
+    }
+
+    private var previewBackground: some View {
+        RoundedRectangle(cornerRadius: 16)
+            .fill(.ultraThinMaterial)
+    }
+}
+
+// MARK: - Preview Usage Card
+
+private struct PreviewUsageCard: View {
+    let metric: SmallWidgetMetric
+    let percentage: Double
+    let colorMode: WidgetColorMode
+    let customColor: Color
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            // Header with icon
+            HStack(spacing: 4) {
+                Image(systemName: metric.icon)
+                    .font(.system(size: 11))
+                    .foregroundColor(statusColor)
+                Text(metric.displayName)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundColor(secondaryTextColor)
+            }
+
+            // Percentage
+            Text("\(Int(percentage))%")
+                .font(.system(size: 26, weight: .bold, design: .rounded))
+                .foregroundColor(statusColor)
+
+            // Progress bar
+            GeometryReader { geometry in
+                ZStack(alignment: .leading) {
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(progressBackgroundColor)
+
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(statusColor)
+                        .frame(width: geometry.size.width * (percentage / 100))
+                }
+            }
+            .frame(height: 8)
+
+            // Reset time
+            Text("Resets Today 4PM")
+                .font(.system(size: 10, weight: .medium))
+                .foregroundColor(secondaryTextColor)
+                .lineLimit(1)
+        }
+        .padding(10)
+        .background(cardBackgroundColor)
+        .cornerRadius(10)
+        .frame(maxWidth: .infinity)
+    }
+
+    private var cardBackgroundColor: Color {
+        Color.primary.opacity(PreviewDesign.Colors.glassCardBg)
+    }
+
+    private var progressBackgroundColor: Color {
+        Color.primary.opacity(PreviewDesign.Colors.glassProgressBg)
+    }
+
+    private var secondaryTextColor: Color {
+        Color.primary.opacity(PreviewDesign.Colors.glassSecondaryText)
+    }
+
+    private var statusColor: Color {
+        colorForUsage(percentage, mode: colorMode, customColor: customColor)
+    }
+}
+
+// MARK: - Color Helpers
+
+/// Returns color for usage percentage based on color mode
+private func colorForUsage(_ percentage: Double, mode: WidgetColorMode, customColor: Color) -> Color {
+    switch mode {
+    case .multiColor:
+        // Threshold-based colors (matching menu bar)
+        switch percentage {
+        case 0..<50:
+            return SettingsColors.usageLow       // Green
+        case 50..<80:
+            return SettingsColors.usageHigh      // Orange
+        default: // 80%+
+            return SettingsColors.usageCritical  // Red
+        }
+    case .monochrome:
+        return .primary  // Adaptive to system theme
+    case .singleColor:
+        return customColor
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    WidgetSettingsView()
+        .frame(width: 520, height: 900)
+}

--- a/Claude Usage/Views/Settings/Components/ColorModeSelector.swift
+++ b/Claude Usage/Views/Settings/Components/ColorModeSelector.swift
@@ -1,0 +1,115 @@
+//
+//  ColorModeSelector.swift
+//  Claude Usage
+//
+//  Reusable color mode selection component for menu bar appearance settings
+//
+
+import SwiftUI
+
+/// Reusable color mode selection component
+struct ColorModeSelector: View {
+    @Binding var colorMode: MenuBarColorMode
+    @Binding var singleColorHex: String
+    let onConfigChanged: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("appearance.color_mode".localized)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundColor(.primary)
+
+            HStack(spacing: 12) {
+                ForEach(MenuBarColorMode.allCases, id: \.rawValue) { mode in
+                    ColorModeButton(
+                        mode: mode,
+                        isSelected: colorMode == mode,
+                        customColor: mode == .singleColor ? Color(hex: singleColorHex) : nil,
+                        action: {
+                            colorMode = mode
+                            onConfigChanged()
+                        }
+                    )
+                }
+
+                // Color picker (separate, always visible)
+                ColorPicker(
+                    "",
+                    selection: Binding(
+                        get: { Color(hex: singleColorHex) ?? .blue },
+                        set: { newColor in
+                            singleColorHex = newColor.hexString
+                            if colorMode != .singleColor {
+                                colorMode = .singleColor
+                            }
+                            onConfigChanged()
+                        }
+                    ),
+                    supportsOpacity: false
+                )
+                .labelsHidden()
+                .frame(width: 28, height: 28)
+
+                Spacer()
+            }
+        }
+    }
+}
+
+// MARK: - Color Mode Button
+
+struct ColorModeButton: View {
+    let mode: MenuBarColorMode
+    let isSelected: Bool
+    var customColor: Color? = nil
+    let action: () -> Void
+
+    private var iconColor: Color {
+        switch mode {
+        case .multiColor:
+            return .green
+        case .monochrome:
+            return .secondary
+        case .singleColor:
+            return customColor ?? .cyan
+        }
+    }
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 5) {
+                Image(systemName: mode.icon)
+                    .font(.system(size: 10))
+                    .foregroundColor(iconColor)
+
+                Text(mode.displayName)
+                    .font(.system(size: 10, weight: isSelected ? .medium : .regular))
+                    .foregroundColor(.primary)
+                    .lineLimit(1)
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 5)
+            .background(
+                RoundedRectangle(cornerRadius: 5)
+                    .fill(isSelected ? Color.accentColor.opacity(0.12) : Color.clear)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 5)
+                    .stroke(isSelected ? Color.accentColor : Color.secondary.opacity(0.2), lineWidth: isSelected ? 1.5 : 1)
+            )
+        }
+        .buttonStyle(.plain)
+        .help(mode.description)
+    }
+}
+
+// MARK: - Previews
+
+#Preview {
+    ColorModeSelector(
+        colorMode: .constant(.multiColor),
+        singleColorHex: .constant("#00BFFF"),
+        onConfigChanged: {}
+    )
+    .padding()
+}

--- a/Claude Usage/Views/Settings/Profile/AppearanceSettingsView.swift
+++ b/Claude Usage/Views/Settings/Profile/AppearanceSettingsView.swift
@@ -42,17 +42,13 @@ struct AppearanceSettingsView: View {
                     subtitle: "appearance.global_subtitle".localized
                 ) {
                     VStack(alignment: .leading, spacing: DesignTokens.Spacing.cardPadding) {
-                        SettingToggle(
-                            title: "appearance.monochrome_title".localized,
-                            description: "appearance.monochrome_description".localized,
-                            isOn: Binding(
-                                get: { configuration.monochromeMode },
-                                set: { newValue in
-                                    configuration.monochromeMode = newValue
-                                    saveConfiguration()
-                                }
-                            )
+                        ColorModeSelector(
+                            colorMode: $configuration.colorMode,
+                            singleColorHex: $configuration.singleColorHex,
+                            onConfigChanged: saveConfiguration
                         )
+
+                        Divider()
 
                         SettingToggle(
                             title: "appearance.show_labels_title".localized,

--- a/Claude Usage/Views/Settings/Profile/MenuBarSettingsView.swift
+++ b/Claude Usage/Views/Settings/Profile/MenuBarSettingsView.swift
@@ -10,129 +10,123 @@ import SwiftUI
 /// Menu bar metrics configuration
 struct MenuBarSettingsView: View {
     @ObservedObject private var profileManager = ProfileManager.shared
-    @State private var configuration: MenuBarIconConfiguration?
+    @State private var configuration: MenuBarIconConfiguration = .default
 
     var body: some View {
         ScrollView {
-            if let config = configuration {
-                VStack(alignment: .leading, spacing: DesignTokens.Spacing.section) {
-                    // Page Header
-                    SettingsPageHeader(
-                        title: "Menu Bar",
-                        subtitle: "Configure which metrics appear in your menu bar"
-                    )
+            VStack(alignment: .leading, spacing: DesignTokens.Spacing.section) {
+                // Page Header
+                SettingsPageHeader(
+                    title: "Menu Bar",
+                    subtitle: "Configure which metrics appear in your menu bar"
+                )
 
-                    // Menu Bar Appearance
-                    SettingsSectionCard(
-                        title: "Appearance Style",
-                        subtitle: "Choose appearance settings for the menu bar"
-                    ) {
-                        VStack(alignment: .leading, spacing: DesignTokens.Spacing.cardPadding) {
-                            SettingToggle(
-                                title: "appearance.monochrome_title".localized,
-                                description: "appearance.monochrome_description".localized,
-                                isOn: Binding(
-                                    get: { config.monochromeMode },
-                                    set: { newValue in
-                                        configuration?.monochromeMode = newValue
-                                        saveConfiguration()
-                                    }
-                                )
-                            )
+                // Menu Bar Appearance
+                SettingsSectionCard(
+                    title: "Appearance Style",
+                    subtitle: "Choose appearance settings for the menu bar"
+                ) {
+                    VStack(alignment: .leading, spacing: DesignTokens.Spacing.cardPadding) {
+                        ColorModeSelector(
+                            colorMode: $configuration.colorMode,
+                            singleColorHex: $configuration.singleColorHex,
+                            onConfigChanged: saveConfiguration
+                        )
 
-                            SettingToggle(
-                                title: "appearance.show_labels_title".localized,
-                                description: "appearance.show_labels_description".localized,
-                                isOn: Binding(
-                                    get: { config.showIconNames },
-                                    set: { newValue in
-                                        configuration?.showIconNames = newValue
-                                        saveConfiguration()
-                                    }
-                                )
-                            )
-                        }
-                    }
+                        Divider()
 
-                    // Metrics Configuration
-                    SettingsSectionCard(
-                        title: "Menu Bar Metrics",
-                        subtitle: "Choose which metrics to display"
-                    ) {
-                        VStack(alignment: .leading, spacing: DesignTokens.Spacing.small) {
-                            // Info message when all metrics are disabled
-                            if config.metrics.filter({ $0.isEnabled }).isEmpty {
-                                HStack(alignment: .top, spacing: 8) {
-                                    Image(systemName: "info.circle.fill")
-                                        .font(.system(size: 12))
-                                        .foregroundColor(.blue)
-
-                                    VStack(alignment: .leading, spacing: 4) {
-                                        Text("appearance.all_metrics_off_title".localized)
-                                            .font(.system(size: 11, weight: .semibold))
-                                            .foregroundColor(.primary)
-
-                                        Text("appearance.all_metrics_off_description".localized)
-                                            .font(.system(size: 10))
-                                            .foregroundColor(.secondary)
-                                            .fixedSize(horizontal: false, vertical: true)
-                                    }
+                        SettingToggle(
+                            title: "appearance.show_labels_title".localized,
+                            description: "appearance.show_labels_description".localized,
+                            isOn: Binding(
+                                get: { configuration.showIconNames },
+                                set: { newValue in
+                                    configuration.showIconNames = newValue
+                                    saveConfiguration()
                                 }
-                                .padding(DesignTokens.Spacing.small)
-                                .background(
-                                    RoundedRectangle(cornerRadius: 8)
-                                        .fill(Color.blue.opacity(0.1))
-                                )
-                            }
+                            )
+                        )
+                    }
+                }
 
-                            // Session Usage
-                            if let sessionIndex = config.metrics.firstIndex(where: { $0.metricType == .session }) {
-                                MetricIconCard(
-                                    metricType: .session,
-                                    config: Binding(
-                                        get: { config.metrics[sessionIndex] },
-                                        set: { newValue in
-                                            configuration?.metrics[sessionIndex] = newValue
-                                        }
-                                    ),
-                                    onConfigChanged: { saveConfiguration() }
-                                )
-                            }
+                // Metrics Configuration
+                SettingsSectionCard(
+                    title: "Menu Bar Metrics",
+                    subtitle: "Choose which metrics to display"
+                ) {
+                    VStack(alignment: .leading, spacing: DesignTokens.Spacing.small) {
+                        // Info message when all metrics are disabled
+                        if configuration.metrics.filter({ $0.isEnabled }).isEmpty {
+                            HStack(alignment: .top, spacing: 8) {
+                                Image(systemName: "info.circle.fill")
+                                    .font(.system(size: 12))
+                                    .foregroundColor(.blue)
 
-                            // Week Usage
-                            if let weekIndex = config.metrics.firstIndex(where: { $0.metricType == .week }) {
-                                MetricIconCard(
-                                    metricType: .week,
-                                    config: Binding(
-                                        get: { config.metrics[weekIndex] },
-                                        set: { newValue in
-                                            configuration?.metrics[weekIndex] = newValue
-                                        }
-                                    ),
-                                    onConfigChanged: { saveConfiguration() }
-                                )
-                            }
+                                VStack(alignment: .leading, spacing: 4) {
+                                    Text("appearance.all_metrics_off_title".localized)
+                                        .font(.system(size: 11, weight: .semibold))
+                                        .foregroundColor(.primary)
 
-                            // API Credits
-                            if let apiIndex = config.metrics.firstIndex(where: { $0.metricType == .api }) {
-                                MetricIconCard(
-                                    metricType: .api,
-                                    config: Binding(
-                                        get: { config.metrics[apiIndex] },
-                                        set: { newValue in
-                                            configuration?.metrics[apiIndex] = newValue
-                                        }
-                                    ),
-                                    onConfigChanged: { saveConfiguration() }
-                                )
+                                    Text("appearance.all_metrics_off_description".localized)
+                                        .font(.system(size: 10))
+                                        .foregroundColor(.secondary)
+                                        .fixedSize(horizontal: false, vertical: true)
+                                }
                             }
+                            .padding(DesignTokens.Spacing.small)
+                            .background(
+                                RoundedRectangle(cornerRadius: 8)
+                                    .fill(Color.blue.opacity(0.1))
+                            )
+                        }
+
+                        // Session Usage
+                        if let sessionIndex = configuration.metrics.firstIndex(where: { $0.metricType == .session }) {
+                            MetricIconCard(
+                                metricType: .session,
+                                config: Binding(
+                                    get: { configuration.metrics[sessionIndex] },
+                                    set: { newValue in
+                                        configuration.metrics[sessionIndex] = newValue
+                                    }
+                                ),
+                                onConfigChanged: { saveConfiguration() }
+                            )
+                        }
+
+                        // Week Usage
+                        if let weekIndex = configuration.metrics.firstIndex(where: { $0.metricType == .week }) {
+                            MetricIconCard(
+                                metricType: .week,
+                                config: Binding(
+                                    get: { configuration.metrics[weekIndex] },
+                                    set: { newValue in
+                                        configuration.metrics[weekIndex] = newValue
+                                    }
+                                ),
+                                onConfigChanged: { saveConfiguration() }
+                            )
+                        }
+
+                        // API Credits
+                        if let apiIndex = configuration.metrics.firstIndex(where: { $0.metricType == .api }) {
+                            MetricIconCard(
+                                metricType: .api,
+                                config: Binding(
+                                    get: { configuration.metrics[apiIndex] },
+                                    set: { newValue in
+                                        configuration.metrics[apiIndex] = newValue
+                                    }
+                                ),
+                                onConfigChanged: { saveConfiguration() }
+                            )
                         }
                     }
-
-                    Spacer()
                 }
-                .padding()
+
+                Spacer()
             }
+            .padding()
         }
         .onAppear {
             // Load configuration from active profile
@@ -157,17 +151,12 @@ struct MenuBarSettingsView: View {
             return
         }
 
-        guard let config = configuration else {
-            LoggingService.shared.logError("Cannot save menu bar config: configuration not loaded")
-            return
-        }
-
-        profileManager.updateIconConfig(config, for: profileId)
+        profileManager.updateIconConfig(configuration, for: profileId)
 
         // Notify that config changed (for MenuBarManager to update)
         NotificationCenter.default.post(name: .menuBarIconConfigChanged, object: nil)
 
-        let enabledCount = config.metrics.filter { $0.isEnabled }.count
+        let enabledCount = configuration.metrics.filter { $0.isEnabled }.count
         LoggingService.shared.log("Saved menu bar configuration to profile (enabled: \(enabledCount))")
     }
 }

--- a/Claude Usage/Views/Settings/Profile/MenuBarSettingsView.swift
+++ b/Claude Usage/Views/Settings/Profile/MenuBarSettingsView.swift
@@ -1,0 +1,180 @@
+//
+//  MenuBarSettingsView.swift
+//  Claude Usage - Menu Bar Metrics Configuration
+//
+//  Configure which metrics appear in the menu bar
+//
+
+import SwiftUI
+
+/// Menu bar metrics configuration
+struct MenuBarSettingsView: View {
+    @ObservedObject private var profileManager = ProfileManager.shared
+    @State private var configuration: MenuBarIconConfiguration?
+
+    var body: some View {
+        ScrollView {
+            if let config = configuration {
+                VStack(alignment: .leading, spacing: DesignTokens.Spacing.section) {
+                    // Page Header
+                    SettingsPageHeader(
+                        title: "Menu Bar",
+                        subtitle: "Configure which metrics appear in your menu bar"
+                    )
+
+                    // Menu Bar Appearance
+                    SettingsSectionCard(
+                        title: "Appearance Style",
+                        subtitle: "Choose appearance settings for the menu bar"
+                    ) {
+                        VStack(alignment: .leading, spacing: DesignTokens.Spacing.cardPadding) {
+                            SettingToggle(
+                                title: "appearance.monochrome_title".localized,
+                                description: "appearance.monochrome_description".localized,
+                                isOn: Binding(
+                                    get: { config.monochromeMode },
+                                    set: { newValue in
+                                        configuration?.monochromeMode = newValue
+                                        saveConfiguration()
+                                    }
+                                )
+                            )
+
+                            SettingToggle(
+                                title: "appearance.show_labels_title".localized,
+                                description: "appearance.show_labels_description".localized,
+                                isOn: Binding(
+                                    get: { config.showIconNames },
+                                    set: { newValue in
+                                        configuration?.showIconNames = newValue
+                                        saveConfiguration()
+                                    }
+                                )
+                            )
+                        }
+                    }
+
+                    // Metrics Configuration
+                    SettingsSectionCard(
+                        title: "Menu Bar Metrics",
+                        subtitle: "Choose which metrics to display"
+                    ) {
+                        VStack(alignment: .leading, spacing: DesignTokens.Spacing.small) {
+                            // Info message when all metrics are disabled
+                            if config.metrics.filter({ $0.isEnabled }).isEmpty {
+                                HStack(alignment: .top, spacing: 8) {
+                                    Image(systemName: "info.circle.fill")
+                                        .font(.system(size: 12))
+                                        .foregroundColor(.blue)
+
+                                    VStack(alignment: .leading, spacing: 4) {
+                                        Text("appearance.all_metrics_off_title".localized)
+                                            .font(.system(size: 11, weight: .semibold))
+                                            .foregroundColor(.primary)
+
+                                        Text("appearance.all_metrics_off_description".localized)
+                                            .font(.system(size: 10))
+                                            .foregroundColor(.secondary)
+                                            .fixedSize(horizontal: false, vertical: true)
+                                    }
+                                }
+                                .padding(DesignTokens.Spacing.small)
+                                .background(
+                                    RoundedRectangle(cornerRadius: 8)
+                                        .fill(Color.blue.opacity(0.1))
+                                )
+                            }
+
+                            // Session Usage
+                            if let sessionIndex = config.metrics.firstIndex(where: { $0.metricType == .session }) {
+                                MetricIconCard(
+                                    metricType: .session,
+                                    config: Binding(
+                                        get: { config.metrics[sessionIndex] },
+                                        set: { newValue in
+                                            configuration?.metrics[sessionIndex] = newValue
+                                        }
+                                    ),
+                                    onConfigChanged: { saveConfiguration() }
+                                )
+                            }
+
+                            // Week Usage
+                            if let weekIndex = config.metrics.firstIndex(where: { $0.metricType == .week }) {
+                                MetricIconCard(
+                                    metricType: .week,
+                                    config: Binding(
+                                        get: { config.metrics[weekIndex] },
+                                        set: { newValue in
+                                            configuration?.metrics[weekIndex] = newValue
+                                        }
+                                    ),
+                                    onConfigChanged: { saveConfiguration() }
+                                )
+                            }
+
+                            // API Credits
+                            if let apiIndex = config.metrics.firstIndex(where: { $0.metricType == .api }) {
+                                MetricIconCard(
+                                    metricType: .api,
+                                    config: Binding(
+                                        get: { config.metrics[apiIndex] },
+                                        set: { newValue in
+                                            configuration?.metrics[apiIndex] = newValue
+                                        }
+                                    ),
+                                    onConfigChanged: { saveConfiguration() }
+                                )
+                            }
+                        }
+                    }
+
+                    Spacer()
+                }
+                .padding()
+            }
+        }
+        .onAppear {
+            // Load configuration from active profile
+            if let activeProfile = profileManager.activeProfile {
+                configuration = activeProfile.iconConfig
+            }
+        }
+        .onChange(of: profileManager.activeProfile?.id) { _, newProfileId in
+            // Reload configuration when profile changes
+            if let activeProfile = profileManager.activeProfile {
+                configuration = activeProfile.iconConfig
+            }
+        }
+    }
+
+    // MARK: - Helper Methods
+
+    private func saveConfiguration() {
+        // Save to active profile
+        guard let profileId = profileManager.activeProfile?.id else {
+            LoggingService.shared.logError("Cannot save menu bar config: no active profile")
+            return
+        }
+
+        guard let config = configuration else {
+            LoggingService.shared.logError("Cannot save menu bar config: configuration not loaded")
+            return
+        }
+
+        profileManager.updateIconConfig(config, for: profileId)
+
+        // Notify that config changed (for MenuBarManager to update)
+        NotificationCenter.default.post(name: .menuBarIconConfigChanged, object: nil)
+
+        let enabledCount = config.metrics.filter { $0.isEnabled }.count
+        LoggingService.shared.log("Saved menu bar configuration to profile (enabled: \(enabledCount))")
+    }
+}
+
+// MARK: - Previews
+
+#Preview {
+    MenuBarSettingsView()
+        .frame(width: 520, height: 600)
+}

--- a/Claude Usage/Views/SettingsView.swift
+++ b/Claude Usage/Views/SettingsView.swift
@@ -3,7 +3,7 @@ import UserNotifications
 
 /// Professional, native macOS Settings interface with multi-profile support
 struct SettingsView: View {
-    @State private var selectedSection: SettingsSection = .appearance
+    @State private var selectedSection: SettingsSection = .general
     @StateObject private var profileManager = ProfileManager.shared
 
     var body: some View {
@@ -37,18 +37,20 @@ struct SettingsView: View {
                     CLIAccountView()
 
                 // Profile Settings
-                case .appearance:
-                    AppearanceSettingsView()
                 case .general:
                     GeneralSettingsView()
+                case .menuBar:
+                    MenuBarSettingsView()
+                case .widgets:
+                    WidgetSettingsView()
+                case .claudeCode:
+                    ClaudeCodeView()
 
                 // Shared Settings
                 case .manageProfiles:
                     ManageProfilesView()
                 case .language:
                     LanguageSettingsView()
-                case .claudeCode:
-                    ClaudeCodeView()
                 case .updates:
                     UpdatesSettingsView()
                 case .about:
@@ -198,13 +200,14 @@ enum SettingsSection: String, CaseIterable {
     case cliAccount
 
     // Profile Settings
-    case appearance
     case general
+    case menuBar
+    case widgets
+    case claudeCode
 
     // Shared Settings
     case manageProfiles
     case language
-    case claudeCode
     case updates
     case about
 
@@ -213,8 +216,9 @@ enum SettingsSection: String, CaseIterable {
         case .claudeAI: return "section.claudeai_title".localized
         case .apiConsole: return "section.api_console_title".localized
         case .cliAccount: return "section.cli_account_title".localized
-        case .appearance: return "section.appearance_title".localized
         case .general: return "section.general_title".localized
+        case .menuBar: return "Menu Bar"
+        case .widgets: return "Widgets"
         case .manageProfiles: return "section.manage_profiles_title".localized
         case .language: return "language.title".localized
         case .claudeCode: return "settings.claude_cli".localized
@@ -228,8 +232,9 @@ enum SettingsSection: String, CaseIterable {
         case .claudeAI: return "key.fill"
         case .apiConsole: return "dollarsign.circle.fill"
         case .cliAccount: return "terminal.fill"
-        case .appearance: return "paintbrush.fill"
         case .general: return "gearshape.fill"
+        case .menuBar: return "menubar.rectangle"
+        case .widgets: return "square.grid.2x2.fill"
         case .manageProfiles: return "person.2.fill"
         case .language: return "globe"
         case .claudeCode: return "chevron.left.forwardslash.chevron.right"
@@ -243,8 +248,9 @@ enum SettingsSection: String, CaseIterable {
         case .claudeAI: return "section.claudeai_desc".localized
         case .apiConsole: return "section.api_console_desc".localized
         case .cliAccount: return "section.cli_account_desc".localized
-        case .appearance: return "section.appearance_desc".localized
         case .general: return "section.general_desc".localized
+        case .menuBar: return "Configure menu bar appearance and metrics"
+        case .widgets: return "Customize desktop widget appearance"
         case .manageProfiles: return "section.manage_profiles_desc".localized
         case .language: return "language.subtitle".localized
         case .claudeCode: return "settings.claude_cli.description".localized
@@ -264,7 +270,7 @@ enum SettingsSection: String, CaseIterable {
 
     var isProfileSetting: Bool {
         switch self {
-        case .appearance, .general:
+        case .general, .menuBar, .widgets, .claudeCode:
             return true
         default:
             return false

--- a/Claude Usage/Views/SettingsView.swift
+++ b/Claude Usage/Views/SettingsView.swift
@@ -370,6 +370,9 @@ struct ProfileCredentialCardsRow: View {
         .onChange(of: profileManager.activeProfile?.id) { _, _ in
             loadCredentials()
         }
+        .onReceive(NotificationCenter.default.publisher(for: .credentialsChanged)) { _ in
+            loadCredentials()
+        }
     }
 
     private func loadCredentials() {


### PR DESCRIPTION
## Summary

This PR adds **macOS Desktop Widgets** using WidgetKit and **Menu Bar Color Mode customization**, enabling users to monitor their Claude AI usage directly from their desktop and customize the appearance of menu bar icons.

### Features Added

**Desktop Widgets (WidgetKit)**
- **Small Widget**: Single metric display (session, weekly, or API usage)
- **Medium Widget**: Dual metric display with configurable left/right metrics
- **Large Widget**: Full dashboard with all metrics, progress bars, and reset timers
- Customizable color modes (multi-color, monochrome, single color)
- 15-minute auto-refresh timeline
- App Group data sharing between main app and widget extension

**Menu Bar Color Mode Support**
- **Multi-Color**: Green/orange/red based on usage thresholds
- **Monochrome**: Adapts to system menu bar appearance
- **Single Color**: User-selected custom color via color picker
- Backwards-compatible with existing `monochromeMode` setting

**Widget Settings UI**
- New "Widgets" tab in Settings
- Configure which metrics appear in each widget size
- Preview widgets before adding to desktop
- Sync color mode settings between menu bar and widgets

### Files Changed

| Area | Files | Description |
|------|-------|-------------|
| Widget Extension | 7 new files | `ClaudeUsageWidget.swift`, `WidgetDataProvider.swift`, widget views |
| Color Mode | `MenuBarIconConfig.swift`, `ColorModeSelector.swift` | New color mode enum and reusable selector component |
| Settings | `WidgetSettingsView.swift`, `MenuBarSettingsView.swift` | Widget and menu bar configuration UI |
| Data Sharing | `SharedDataStore.swift` | App Group storage for widget data access |
| Project Config | `project.pbxproj` | Widget extension target, entitlements, App Group |

**Stats**: 39 files changed, +4,325 lines, -243 lines

### Screenshots

<img width="1315" height="837" alt="Screenshot 2026-01-23 at 3 09 22 AM" src="https://github.com/user-attachments/assets/22c235f5-06ce-480c-b201-7c86d3b8f71a" />

<img width="747" height="378" alt="Screenshot 2026-01-23 at 3 09 40 AM" src="https://github.com/user-attachments/assets/2e71c84a-f7bd-49c8-8532-55fb7fad9c2f" />

<img width="747" height="378" alt="Screenshot 2026-01-23 at 3 09 47 AM" src="https://github.com/user-attachments/assets/6949db20-8095-497c-a11c-67a188a94a93" />

<img width="747" height="378" alt="Screenshot 2026-01-23 at 3 09 51 AM" src="https://github.com/user-attachments/assets/290b593a-32b0-43f9-8f8f-776feb8beb84" />

<img width="352" height="436" alt="Screenshot 2026-01-23 at 3 04 09 AM" src="https://github.com/user-attachments/assets/8909ad22-913a-4666-88e4-befc467eaf86" />

<img width="352" height="436" alt="Screenshot 2026-01-23 at 3 04 20 AM" src="https://github.com/user-attachments/assets/a6f6c8c4-7ca1-4282-9e9c-711ba3923b24" />


### Testing

- [x] Tested on macOS 14.0+ (Sonoma)
- [x] All three widget sizes render correctly
- [x] Widget data updates every 15 minutes
- [x] Color modes apply to both menu bar and widgets
- [x] Settings persist across app restarts
- [x] Backwards compatible with existing user settings (monochromeMode migration)
- [x] No new Xcode warnings

### Breaking Changes

None. Existing `monochromeMode` boolean is automatically migrated to the new `colorMode` enum.

---

**Note**: Per CONTRIBUTING.md, this combines related features (widgets + color mode support) that share underlying infrastructure (SharedDataStore, color mode system). The color mode work was necessary to support widget customization.
