### PR TITLE
feat: Add usage history tracking with interactive timeline charts

### DIFF
--- a/Claude Usage/MenuBar/MenuBarManager.swift
+++ b/Claude Usage/MenuBar/MenuBarManager.swift
@@ -19,6 +19,11 @@ class MenuBarManager: NSObject, ObservableObject {
     // Track when refresh was last triggered (for distinguishing user vs auto refresh)
     private var lastRefreshTriggerTime: Date = .distantPast
 
+    // Track last known reset times for history recording
+    private var lastKnownSessionResetTime: [UUID: Date] = [:]
+    private var lastKnownWeeklyResetTime: [UUID: Date] = [:]
+    private var lastKnownAPIResetTime: [UUID: Date] = [:]
+
     // Popover for beautiful SwiftUI interface
     private var popover: NSPopover?
 
@@ -739,10 +744,30 @@ class MenuBarManager: NSObject, ObservableObject {
             // Fetch usage for each selected profile
             for profile in selectedProfiles {
                 LoggingService.shared.log("MenuBarManager: Fetching usage for profile '\(profile.name)'")
+
+                // Capture previous usage for reset detection
+                let previousUsage = profile.claudeUsage
+
                 do {
                     let newUsage = try await fetchUsageForProfile(profile)
 
                     await MainActor.run {
+                        // Check for resets before updating usage
+                        self.checkAndRecordSessionReset(
+                            profileId: profile.id,
+                            previousUsage: previousUsage,
+                            newUsage: newUsage
+                        )
+                        self.checkAndRecordWeeklyReset(
+                            profileId: profile.id,
+                            previousUsage: previousUsage,
+                            newUsage: newUsage
+                        )
+
+                        // Record periodic snapshots for history charts
+                        UsageHistoryService.shared.recordSessionPeriodic(for: profile.id, usage: newUsage)
+                        UsageHistoryService.shared.recordWeeklyPeriodic(for: profile.id, usage: newUsage)
+
                         // Save to profile
                         self.profileManager.saveClaudeUsage(newUsage, for: profile.id)
                         LoggingService.shared.log("MenuBarManager: Saved usage for profile '\(profile.name)' - session: \(newUsage.sessionPercentage)%")
@@ -844,6 +869,11 @@ class MenuBarManager: NSObject, ObservableObject {
                 self.isRefreshing = true
             }
 
+            // Capture previous usage BEFORE fetching new data (for reset detection)
+            let previousUsage = await MainActor.run { self.usage }
+            let previousAPIUsage = await MainActor.run { self.apiUsage }
+            let currentProfileId = await MainActor.run { self.profileManager.activeProfile?.id }
+
             // Fetch usage and status in parallel
             async let usageResult = apiService.fetchUsageData()
             async let statusResult = statusService.fetchStatus()
@@ -855,6 +885,24 @@ class MenuBarManager: NSObject, ObservableObject {
                 let newUsage = try await usageResult
 
                 await MainActor.run {
+                    // Check for resets before updating usage
+                    if let profileId = currentProfileId {
+                        self.checkAndRecordSessionReset(
+                            profileId: profileId,
+                            previousUsage: previousUsage,
+                            newUsage: newUsage
+                        )
+                        self.checkAndRecordWeeklyReset(
+                            profileId: profileId,
+                            previousUsage: previousUsage,
+                            newUsage: newUsage
+                        )
+
+                        // Record periodic snapshots for history charts
+                        UsageHistoryService.shared.recordSessionPeriodic(for: profileId, usage: newUsage)
+                        UsageHistoryService.shared.recordWeeklyPeriodic(for: profileId, usage: newUsage)
+                    }
+
                     self.usage = newUsage
 
                     // Save to active profile instead of global DataStore
@@ -922,6 +970,15 @@ class MenuBarManager: NSObject, ObservableObject {
                 do {
                     let newAPIUsage = try await apiService.fetchAPIUsageData(organizationId: orgId, apiSessionKey: apiSessionKey)
                     await MainActor.run {
+                        // Check for billing cycle reset before updating usage
+                        if let profileId = currentProfileId {
+                            self.checkAndRecordBillingCycleReset(
+                                profileId: profileId,
+                                previousUsage: previousAPIUsage,
+                                newUsage: newAPIUsage
+                            )
+                        }
+
                         self.apiUsage = newAPIUsage
 
                         // Save to active profile instead of global DataStore
@@ -953,6 +1010,130 @@ class MenuBarManager: NSObject, ObservableObject {
     /// Shows a brief success notification for user-triggered refreshes
     private func showSuccessNotification() {
         NotificationManager.shared.sendSuccessNotification()
+    }
+
+    // MARK: - Reset Detection for History Recording
+
+    /// Normalizes a date to minute precision for comparison (ignores seconds)
+    private func normalizeToMinute(_ date: Date) -> Date {
+        let calendar = Calendar.current
+        let components = calendar.dateComponents([.year, .month, .day, .hour, .minute], from: date)
+        return calendar.date(from: components) ?? date
+    }
+
+    /// Checks if a session reset occurred and records a snapshot if so
+    private func checkAndRecordSessionReset(
+        profileId: UUID,
+        previousUsage: ClaudeUsage?,
+        newUsage: ClaudeUsage
+    ) {
+        let lastKnown = lastKnownSessionResetTime[profileId]
+        let newResetTime = normalizeToMinute(newUsage.sessionResetTime)
+
+        // First time seeing this profile - just record the reset time
+        if lastKnown == nil {
+            lastKnownSessionResetTime[profileId] = newResetTime
+            return
+        }
+
+        // Normalize the last known time for comparison
+        let normalizedLastKnown = normalizeToMinute(lastKnown!)
+
+        // Check if reset time changed significantly (indicates a reset occurred)
+        if newResetTime > normalizedLastKnown {
+            // Reset detected! Record snapshot of the previous usage
+            LoggingService.shared.log("History: Session reset detected for profile \(profileId.uuidString.prefix(8)). Old: \(normalizedLastKnown), New: \(newResetTime)")
+            if let prevUsage = previousUsage {
+                Task { @MainActor in
+                    UsageHistoryService.shared.recordSessionReset(
+                        for: profileId,
+                        previousUsage: prevUsage,
+                        resetTime: normalizedLastKnown
+                    )
+                }
+            }
+        }
+
+        // Update the last known reset time
+        lastKnownSessionResetTime[profileId] = newResetTime
+    }
+
+    /// Checks if a weekly reset occurred and records a snapshot if so
+    private func checkAndRecordWeeklyReset(
+        profileId: UUID,
+        previousUsage: ClaudeUsage?,
+        newUsage: ClaudeUsage
+    ) {
+        let lastKnown = lastKnownWeeklyResetTime[profileId]
+        let newResetTime = normalizeToMinute(newUsage.weeklyResetTime)
+
+        // First time seeing this profile - just record the reset time
+        if lastKnown == nil {
+            lastKnownWeeklyResetTime[profileId] = newResetTime
+            LoggingService.shared.log("History: Initial weekly reset time for profile \(profileId.uuidString.prefix(8)): \(newResetTime)")
+            return
+        }
+
+        // Normalize the last known time for comparison
+        let normalizedLastKnown = normalizeToMinute(lastKnown!)
+
+        // Check if reset time changed significantly (indicates a reset occurred)
+        // Only trigger if the new reset time is in the future compared to last known
+        if newResetTime > normalizedLastKnown {
+            // Reset detected! Record snapshot of the previous usage
+            LoggingService.shared.log("History: Weekly reset detected for profile \(profileId.uuidString.prefix(8)). Old: \(normalizedLastKnown), New: \(newResetTime)")
+            if let prevUsage = previousUsage {
+                Task { @MainActor in
+                    UsageHistoryService.shared.recordWeeklyReset(
+                        for: profileId,
+                        previousUsage: prevUsage,
+                        resetTime: normalizedLastKnown  // The reset time that was crossed
+                    )
+                }
+            }
+        }
+
+        // Update the last known reset time
+        lastKnownWeeklyResetTime[profileId] = newResetTime
+    }
+
+    /// Checks if a billing cycle reset occurred and records a snapshot if so
+    private func checkAndRecordBillingCycleReset(
+        profileId: UUID,
+        previousUsage: APIUsage?,
+        newUsage: APIUsage
+    ) {
+        let lastKnown = lastKnownAPIResetTime[profileId]
+        let newResetTime = normalizeToMinute(newUsage.resetsAt)
+
+        // First time seeing this profile - just record the reset time
+        if lastKnown == nil {
+            lastKnownAPIResetTime[profileId] = newResetTime
+            LoggingService.shared.log("History: Initial API reset time for profile \(profileId.uuidString.prefix(8)): \(newResetTime)")
+            return
+        }
+
+        // Normalize the last known time for comparison
+        let normalizedLastKnown = normalizeToMinute(lastKnown!)
+
+        // Check if reset time changed significantly (indicates a reset occurred)
+        // Only trigger if the new reset time is in the future compared to last known
+        if newResetTime > normalizedLastKnown {
+            // Reset detected! Record snapshot of the previous usage
+            LoggingService.shared.log("History: Billing cycle reset detected for profile \(profileId.uuidString.prefix(8)). Old: \(normalizedLastKnown), New: \(newResetTime)")
+            if let prevUsage = previousUsage {
+                Task { @MainActor in
+                    UsageHistoryService.shared.recordBillingCycleReset(
+                        for: profileId,
+                        previousUsage: prevUsage,
+                        resetTime: normalizedLastKnown  // The reset time that was crossed
+                    )
+                }
+            }
+        }
+
+        // Update the last known reset time
+        lastKnownAPIResetTime[profileId] = newResetTime
     }
 
     @objc private func preferencesClicked() {

--- a/Claude Usage/Resources/en.lproj/Localizable.strings
+++ b/Claude Usage/Resources/en.lproj/Localizable.strings
@@ -701,3 +701,37 @@
 "wizard.migrate_description_short" = "Import your old profiles data from previous app version";
 "wizard.skip_migration" = "Skip";
 "wizard.migration_skipped" = "Skipped";
+
+/* ==================== */
+/* MARK: - Usage History */
+/* ==================== */
+"section.history_title" = "History";
+"section.history_desc" = "View usage history";
+"history.title" = "Usage History";
+"history.subtitle" = "Track your usage over time";
+"history.tab.session" = "Sessions";
+"history.tab.weekly" = "Weekly";
+"history.tab.billing" = "Billing";
+"history.chart.session_title" = "Session Usage History";
+"history.chart.weekly_title" = "Weekly Usage Trend";
+"history.chart.billing_title" = "Monthly API Spend";
+"history.chart.now" = "Now";
+"history.empty.session_title" = "No Session History";
+"history.empty.session_description" = "Session usage will be recorded after each 5-hour reset";
+"history.empty.weekly_title" = "No Weekly History";
+"history.empty.weekly_description" = "Weekly usage will be recorded after each Monday reset";
+"history.empty.billing_title" = "No Billing History";
+"history.empty.billing_description" = "Billing data will be recorded after each monthly reset";
+"history.list.title" = "History Records";
+"history.list.count" = "%d records";
+"history.list.empty" = "No records yet. History will be recorded automatically at each reset.";
+"history.list.more" = "+%d more records";
+"history.export_button" = "Export JSON";
+"history.clear_button" = "Clear";
+"history.no_profile" = "No active profile";
+"history.reset_type.session" = "Session Reset";
+"history.reset_type.weekly" = "Weekly Reset";
+"history.reset_type.billing" = "Billing Cycle";
+"history.label.total" = "Total";
+"history.label.spent" = "Spent";
+"history.label.session" = "Session";

--- a/Claude Usage/Shared/Models/UsageHistory.swift
+++ b/Claude Usage/Shared/Models/UsageHistory.swift
@@ -1,0 +1,222 @@
+//
+//  UsageHistory.swift
+//  Claude Usage
+//
+//  Created by Claude Code on 2025-01-26.
+//
+
+import Foundation
+
+/// Reset type that triggers a usage snapshot
+enum ResetType: String, Codable, CaseIterable {
+    case sessionReset     // Session reset (every 5 hours)
+    case weeklyReset      // Weekly usage reset (every Monday)
+    case billingCycle     // API billing cycle reset (monthly)
+
+    var localizedName: String {
+        switch self {
+        case .sessionReset:
+            return "history.reset_type.session".localized
+        case .weeklyReset:
+            return "history.reset_type.weekly".localized
+        case .billingCycle:
+            return "history.reset_type.billing".localized
+        }
+    }
+}
+
+/// Usage snapshot - records usage data at the moment of reset
+struct UsageSnapshot: Codable, Identifiable, Equatable {
+    let id: UUID
+    let timestamp: Date           // When the snapshot was recorded
+    let resetType: ResetType      // Type of reset that triggered this snapshot
+
+    // Claude.ai session usage data (captured before reset)
+    let sessionTokensUsed: Int?
+    let sessionPercentage: Double?
+
+    // Claude.ai weekly usage data (captured before reset)
+    let weeklyTokensUsed: Int?
+    let weeklyPercentage: Double?
+    let opusWeeklyTokensUsed: Int?
+    let opusWeeklyPercentage: Double?
+    let sonnetWeeklyTokensUsed: Int?
+    let sonnetWeeklyPercentage: Double?
+
+    // API billing data (captured before reset)
+    let apiSpendCents: Int?
+    let apiPrepaidCreditsCents: Int?
+    let apiCurrency: String?
+
+    // The reset time that triggered this snapshot
+    let triggeringResetTime: Date
+
+    init(
+        id: UUID = UUID(),
+        timestamp: Date = Date(),
+        resetType: ResetType,
+        sessionTokensUsed: Int? = nil,
+        sessionPercentage: Double? = nil,
+        weeklyTokensUsed: Int? = nil,
+        weeklyPercentage: Double? = nil,
+        opusWeeklyTokensUsed: Int? = nil,
+        opusWeeklyPercentage: Double? = nil,
+        sonnetWeeklyTokensUsed: Int? = nil,
+        sonnetWeeklyPercentage: Double? = nil,
+        apiSpendCents: Int? = nil,
+        apiPrepaidCreditsCents: Int? = nil,
+        apiCurrency: String? = nil,
+        triggeringResetTime: Date
+    ) {
+        self.id = id
+        self.timestamp = timestamp
+        self.resetType = resetType
+        self.sessionTokensUsed = sessionTokensUsed
+        self.sessionPercentage = sessionPercentage
+        self.weeklyTokensUsed = weeklyTokensUsed
+        self.weeklyPercentage = weeklyPercentage
+        self.opusWeeklyTokensUsed = opusWeeklyTokensUsed
+        self.opusWeeklyPercentage = opusWeeklyPercentage
+        self.sonnetWeeklyTokensUsed = sonnetWeeklyTokensUsed
+        self.sonnetWeeklyPercentage = sonnetWeeklyPercentage
+        self.apiSpendCents = apiSpendCents
+        self.apiPrepaidCreditsCents = apiPrepaidCreditsCents
+        self.apiCurrency = apiCurrency
+        self.triggeringResetTime = triggeringResetTime
+    }
+
+    /// Creates a snapshot from ClaudeUsage data (for session reset)
+    static func fromSessionReset(_ usage: ClaudeUsage, resetTime: Date) -> UsageSnapshot {
+        UsageSnapshot(
+            resetType: .sessionReset,
+            sessionTokensUsed: usage.sessionTokensUsed,
+            sessionPercentage: usage.sessionPercentage,
+            triggeringResetTime: resetTime
+        )
+    }
+
+    /// Creates a snapshot from ClaudeUsage data (for weekly reset)
+    static func fromWeeklyReset(_ usage: ClaudeUsage, resetTime: Date) -> UsageSnapshot {
+        UsageSnapshot(
+            resetType: .weeklyReset,
+            weeklyTokensUsed: usage.weeklyTokensUsed,
+            weeklyPercentage: usage.weeklyPercentage,
+            opusWeeklyTokensUsed: usage.opusWeeklyTokensUsed,
+            opusWeeklyPercentage: usage.opusWeeklyPercentage,
+            sonnetWeeklyTokensUsed: usage.sonnetWeeklyTokensUsed,
+            sonnetWeeklyPercentage: usage.sonnetWeeklyPercentage,
+            triggeringResetTime: resetTime
+        )
+    }
+
+    /// Creates a snapshot from APIUsage data (for billing cycle reset)
+    static func fromBillingCycleReset(_ usage: APIUsage, resetTime: Date) -> UsageSnapshot {
+        UsageSnapshot(
+            resetType: .billingCycle,
+            apiSpendCents: usage.currentSpendCents,
+            apiPrepaidCreditsCents: usage.prepaidCreditsCents,
+            apiCurrency: usage.currency,
+            triggeringResetTime: resetTime
+        )
+    }
+
+    /// Formatted API spend amount
+    var formattedApiSpend: String? {
+        guard let cents = apiSpendCents, let currency = apiCurrency else { return nil }
+        let amount = Double(cents) / 100.0
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.currencyCode = currency
+        formatter.minimumFractionDigits = 2
+        formatter.maximumFractionDigits = 2
+        return formatter.string(from: NSNumber(value: amount))
+    }
+
+    /// Formatted date string for display
+    var formattedDate: String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        return formatter.string(from: timestamp)
+    }
+
+    /// Short date string (for weekly chart labels - shows date and hour)
+    var shortDateString: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MM/dd HH:mm"
+        return formatter.string(from: timestamp)
+    }
+
+    /// Short time string (for session chart labels - shows hour and minute)
+    var shortTimeString: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm"
+        return formatter.string(from: timestamp)
+    }
+}
+
+/// Container for a profile's usage history
+struct UsageHistoryData: Codable, Equatable {
+    var snapshots: [UsageSnapshot]
+
+    init(snapshots: [UsageSnapshot] = []) {
+        self.snapshots = snapshots
+    }
+
+    /// Snapshots filtered by reset type
+    func snapshots(for resetType: ResetType) -> [UsageSnapshot] {
+        snapshots.filter { $0.resetType == resetType }
+    }
+
+    /// Session reset snapshots sorted by date (newest first), filtered for valid data
+    var sessionSnapshots: [UsageSnapshot] {
+        snapshots(for: .sessionReset)
+            .filter { $0.triggeringResetTime <= $0.timestamp.addingTimeInterval(60) } // Allow 1 min tolerance
+            .sorted { $0.timestamp > $1.timestamp }
+    }
+
+    /// Weekly reset snapshots sorted by date (newest first), filtered for valid data
+    var weeklySnapshots: [UsageSnapshot] {
+        snapshots(for: .weeklyReset)
+            .filter { $0.triggeringResetTime <= $0.timestamp.addingTimeInterval(60) } // Allow 1 min tolerance
+            .sorted { $0.timestamp > $1.timestamp }
+    }
+
+    /// Billing cycle snapshots sorted by date (newest first), filtered for valid data
+    var billingCycleSnapshots: [UsageSnapshot] {
+        snapshots(for: .billingCycle)
+            .filter { $0.triggeringResetTime <= $0.timestamp.addingTimeInterval(60) } // Allow 1 min tolerance
+            .sorted { $0.timestamp > $1.timestamp }
+    }
+
+    /// Total number of snapshots
+    var count: Int {
+        snapshots.count
+    }
+
+    /// Whether there are any snapshots
+    var isEmpty: Bool {
+        snapshots.isEmpty
+    }
+
+    /// Add a new snapshot
+    mutating func addSnapshot(_ snapshot: UsageSnapshot) {
+        snapshots.append(snapshot)
+    }
+
+    /// Export to JSON string
+    func exportToJSON() -> String? {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+
+        guard let data = try? encoder.encode(self) else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    /// Export specific reset type to JSON
+    func exportToJSON(for resetType: ResetType) -> String? {
+        let filtered = UsageHistoryData(snapshots: snapshots(for: resetType))
+        return filtered.exportToJSON()
+    }
+}

--- a/Claude Usage/Shared/Services/ProfileManager.swift
+++ b/Claude Usage/Shared/Services/ProfileManager.swift
@@ -111,6 +111,9 @@ class ProfileManager: ObservableObject {
 
         let profileName = profiles.first(where: { $0.id == id })?.name ?? "unknown"
 
+        // Clean up usage history for this profile
+        UsageHistoryService.shared.deleteHistory(for: id)
+
         profiles.removeAll { $0.id == id }
 
         // Credentials are deleted automatically with the profile

--- a/Claude Usage/Shared/Services/UsageHistoryService.swift
+++ b/Claude Usage/Shared/Services/UsageHistoryService.swift
@@ -1,0 +1,317 @@
+//
+//  UsageHistoryService.swift
+//  Claude Usage
+//
+//  Created by Claude Code on 2025-01-26.
+//
+
+import Foundation
+import AppKit
+import UniformTypeIdentifiers
+
+/// Service for managing usage history data
+@MainActor
+class UsageHistoryService {
+    static let shared = UsageHistoryService()
+
+    private let defaults: UserDefaults
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    /// Key prefix for profile-specific history storage
+    private let historyKeyPrefix = "usageHistory_"
+
+    /// Maximum snapshots to keep per type (to prevent excessive data)
+    private let maxSessionSnapshots = 1000   // ~7 days at 10-min intervals
+    private let maxWeeklySnapshots = 500     // ~6 weeks at 2-hour intervals
+
+    /// Recording intervals for periodic snapshots
+    private let sessionRecordingInterval: TimeInterval = 10 * 60  // 10 minutes
+    private let weeklyRecordingInterval: TimeInterval = 2 * 60 * 60  // 2 hours
+
+    /// Track last recording time per profile
+    private var lastSessionRecordTime: [UUID: Date] = [:]
+    private var lastWeeklyRecordTime: [UUID: Date] = [:]
+
+    private init() {
+        self.defaults = UserDefaults.standard
+    }
+
+    // MARK: - Storage Key
+
+    /// Generates the storage key for a specific profile's history
+    private func storageKey(for profileId: UUID) -> String {
+        return "\(historyKeyPrefix)\(profileId.uuidString)"
+    }
+
+    // MARK: - Save/Load History
+
+    /// Saves usage history for a profile
+    func saveHistory(_ history: UsageHistoryData, for profileId: UUID) {
+        do {
+            let data = try encoder.encode(history)
+            defaults.set(data, forKey: storageKey(for: profileId))
+            LoggingService.shared.logStorageSave("usageHistory for profile \(profileId.uuidString.prefix(8))")
+        } catch {
+            LoggingService.shared.logStorageError("saveHistory", error: error)
+        }
+    }
+
+    /// Loads usage history for a profile
+    func loadHistory(for profileId: UUID) -> UsageHistoryData {
+        guard let data = defaults.data(forKey: storageKey(for: profileId)) else {
+            return UsageHistoryData()
+        }
+
+        do {
+            let history = try decoder.decode(UsageHistoryData.self, from: data)
+            return history
+        } catch {
+            LoggingService.shared.logStorageError("loadHistory", error: error)
+            return UsageHistoryData()
+        }
+    }
+
+    // MARK: - Record Resets
+
+    /// Records a session reset snapshot
+    func recordSessionReset(for profileId: UUID, previousUsage: ClaudeUsage?, resetTime: Date) {
+        guard let usage = previousUsage else {
+            LoggingService.shared.logInfo("recordSessionReset: No previous usage data to record")
+            return
+        }
+
+        // Only record if there was actual usage
+        guard usage.sessionTokensUsed > 0 || usage.sessionPercentage > 0 else {
+            LoggingService.shared.logInfo("recordSessionReset: Skipping snapshot - no usage to record")
+            return
+        }
+
+        let snapshot = UsageSnapshot.fromSessionReset(usage, resetTime: resetTime)
+
+        var history = loadHistory(for: profileId)
+        history.addSnapshot(snapshot)
+
+        // Prune old session snapshots if exceeding limit
+        let sessionCount = history.sessionSnapshots.count
+        if sessionCount > maxSessionSnapshots {
+            let toRemove = sessionCount - maxSessionSnapshots
+            let oldestSessions = history.sessionSnapshots.suffix(toRemove)
+            let idsToRemove = Set(oldestSessions.map { $0.id })
+            history.snapshots.removeAll { idsToRemove.contains($0.id) }
+        }
+
+        saveHistory(history, for: profileId)
+        LoggingService.shared.logInfo("Recorded session reset snapshot for profile \(profileId.uuidString.prefix(8)): \(usage.sessionPercentage)% usage")
+    }
+
+    /// Records a weekly reset snapshot
+    func recordWeeklyReset(for profileId: UUID, previousUsage: ClaudeUsage?, resetTime: Date) {
+        guard let usage = previousUsage else {
+            LoggingService.shared.logInfo("recordWeeklyReset: No previous usage data to record")
+            return
+        }
+
+        // Only record if there was actual usage
+        guard usage.weeklyTokensUsed > 0 || usage.weeklyPercentage > 0 else {
+            LoggingService.shared.logInfo("recordWeeklyReset: Skipping snapshot - no usage to record")
+            return
+        }
+
+        let snapshot = UsageSnapshot.fromWeeklyReset(usage, resetTime: resetTime)
+
+        var history = loadHistory(for: profileId)
+        history.addSnapshot(snapshot)
+        saveHistory(history, for: profileId)
+
+        LoggingService.shared.logInfo("Recorded weekly reset snapshot for profile \(profileId.uuidString.prefix(8)): \(usage.weeklyPercentage)% usage")
+    }
+
+    /// Records a billing cycle reset snapshot
+    func recordBillingCycleReset(for profileId: UUID, previousUsage: APIUsage?, resetTime: Date) {
+        guard let usage = previousUsage else {
+            LoggingService.shared.logInfo("recordBillingCycleReset: No previous usage data to record")
+            return
+        }
+
+        // Only record if there was actual spend
+        guard usage.currentSpendCents > 0 else {
+            LoggingService.shared.logInfo("recordBillingCycleReset: Skipping snapshot - no spend to record")
+            return
+        }
+
+        let snapshot = UsageSnapshot.fromBillingCycleReset(usage, resetTime: resetTime)
+
+        var history = loadHistory(for: profileId)
+        history.addSnapshot(snapshot)
+        saveHistory(history, for: profileId)
+
+        LoggingService.shared.logInfo("Recorded billing cycle snapshot for profile \(profileId.uuidString.prefix(8)): \(usage.formattedUsed) spent")
+    }
+
+    // MARK: - Periodic Recording
+
+    /// Records session usage periodically (every 10 minutes)
+    func recordSessionPeriodic(for profileId: UUID, usage: ClaudeUsage) {
+        let now = Date()
+
+        // Check if enough time has passed since last recording
+        if let lastRecord = lastSessionRecordTime[profileId] {
+            let elapsed = now.timeIntervalSince(lastRecord)
+            if elapsed < sessionRecordingInterval {
+                return  // Not enough time passed
+            }
+        }
+
+        // Create periodic snapshot
+        let snapshot = UsageSnapshot(
+            resetType: .sessionReset,
+            sessionTokensUsed: usage.sessionTokensUsed,
+            sessionPercentage: usage.sessionPercentage,
+            triggeringResetTime: now
+        )
+
+        var history = loadHistory(for: profileId)
+        history.addSnapshot(snapshot)
+
+        // Prune old session snapshots if exceeding limit
+        let sessionCount = history.sessionSnapshots.count
+        if sessionCount > maxSessionSnapshots {
+            let toRemove = sessionCount - maxSessionSnapshots
+            let oldestSessions = history.sessionSnapshots.suffix(toRemove)
+            let idsToRemove = Set(oldestSessions.map { $0.id })
+            history.snapshots.removeAll { idsToRemove.contains($0.id) }
+        }
+
+        saveHistory(history, for: profileId)
+        lastSessionRecordTime[profileId] = now
+        LoggingService.shared.logInfo("Recorded periodic session snapshot: \(usage.sessionPercentage)%")
+    }
+
+    /// Records weekly usage periodically (every 2 hours)
+    func recordWeeklyPeriodic(for profileId: UUID, usage: ClaudeUsage) {
+        let now = Date()
+
+        // Check if enough time has passed since last recording
+        if let lastRecord = lastWeeklyRecordTime[profileId] {
+            let elapsed = now.timeIntervalSince(lastRecord)
+            if elapsed < weeklyRecordingInterval {
+                return  // Not enough time passed
+            }
+        }
+
+        // Create periodic snapshot
+        let snapshot = UsageSnapshot(
+            resetType: .weeklyReset,
+            weeklyTokensUsed: usage.weeklyTokensUsed,
+            weeklyPercentage: usage.weeklyPercentage,
+            opusWeeklyTokensUsed: usage.opusWeeklyTokensUsed,
+            opusWeeklyPercentage: usage.opusWeeklyPercentage,
+            sonnetWeeklyTokensUsed: usage.sonnetWeeklyTokensUsed,
+            sonnetWeeklyPercentage: usage.sonnetWeeklyPercentage,
+            triggeringResetTime: now
+        )
+
+        var history = loadHistory(for: profileId)
+        history.addSnapshot(snapshot)
+
+        // Prune old weekly snapshots if exceeding limit
+        let weeklyCount = history.weeklySnapshots.count
+        if weeklyCount > maxWeeklySnapshots {
+            let toRemove = weeklyCount - maxWeeklySnapshots
+            let oldestWeekly = history.weeklySnapshots.suffix(toRemove)
+            let idsToRemove = Set(oldestWeekly.map { $0.id })
+            history.snapshots.removeAll { idsToRemove.contains($0.id) }
+        }
+
+        saveHistory(history, for: profileId)
+        lastWeeklyRecordTime[profileId] = now
+        LoggingService.shared.logInfo("Recorded periodic weekly snapshot: \(usage.weeklyPercentage)%")
+    }
+
+    // MARK: - Query Methods
+
+    /// Gets session snapshots for a profile (sorted newest first)
+    func getSessionSnapshots(for profileId: UUID) -> [UsageSnapshot] {
+        return loadHistory(for: profileId).sessionSnapshots
+    }
+
+    /// Gets weekly snapshots for a profile (sorted newest first)
+    func getWeeklySnapshots(for profileId: UUID) -> [UsageSnapshot] {
+        return loadHistory(for: profileId).weeklySnapshots
+    }
+
+    /// Gets billing cycle snapshots for a profile (sorted newest first)
+    func getBillingCycleSnapshots(for profileId: UUID) -> [UsageSnapshot] {
+        return loadHistory(for: profileId).billingCycleSnapshots
+    }
+
+    /// Gets all snapshots for a profile (sorted newest first)
+    func getAllSnapshots(for profileId: UUID) -> [UsageSnapshot] {
+        return loadHistory(for: profileId).snapshots.sorted { $0.timestamp > $1.timestamp }
+    }
+
+    // MARK: - Export
+
+    /// Exports history to JSON and saves to file
+    func exportToFile(for profileId: UUID, resetType: ResetType? = nil) {
+        let history = loadHistory(for: profileId)
+        let jsonString: String?
+
+        if let type = resetType {
+            jsonString = history.exportToJSON(for: type)
+        } else {
+            jsonString = history.exportToJSON()
+        }
+
+        guard let json = jsonString else {
+            LoggingService.shared.logError("Failed to export history to JSON")
+            return
+        }
+
+        // Create save panel
+        let savePanel = NSSavePanel()
+        savePanel.allowedContentTypes = [.json]
+        savePanel.canCreateDirectories = true
+
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        let dateStr = dateFormatter.string(from: Date())
+
+        let typeSuffix = resetType?.rawValue ?? "all"
+        savePanel.nameFieldStringValue = "claude-usage-history-\(typeSuffix)-\(dateStr).json"
+
+        savePanel.begin { response in
+            if response == .OK, let url = savePanel.url {
+                do {
+                    try json.write(to: url, atomically: true, encoding: .utf8)
+                    LoggingService.shared.logInfo("Exported history to \(url.path)")
+                } catch {
+                    LoggingService.shared.logError("Failed to save export file: \(error.localizedDescription)")
+                }
+            }
+        }
+    }
+
+    // MARK: - Cleanup
+
+    /// Deletes all history for a profile
+    func deleteHistory(for profileId: UUID) {
+        defaults.removeObject(forKey: storageKey(for: profileId))
+        LoggingService.shared.logInfo("Deleted usage history for profile \(profileId.uuidString.prefix(8))")
+    }
+
+    /// Clears all snapshots for a profile but keeps the history structure
+    func clearHistory(for profileId: UUID) {
+        saveHistory(UsageHistoryData(), for: profileId)
+        LoggingService.shared.logInfo("Cleared usage history for profile \(profileId.uuidString.prefix(8))")
+    }
+
+    /// Clears snapshots of a specific type for a profile
+    func clearHistory(for profileId: UUID, resetType: ResetType) {
+        var history = loadHistory(for: profileId)
+        history.snapshots.removeAll { $0.resetType == resetType }
+        saveHistory(history, for: profileId)
+        LoggingService.shared.logInfo("Cleared \(resetType.rawValue) history for profile \(profileId.uuidString.prefix(8))")
+    }
+}

--- a/Claude Usage/Views/Settings/Components/UsageCharts.swift
+++ b/Claude Usage/Views/Settings/Components/UsageCharts.swift
@@ -1,0 +1,716 @@
+//
+//  UsageCharts.swift
+//  Claude Usage
+//
+//  Created by Claude Code on 2025-01-26.
+//
+
+import SwiftUI
+import Charts
+
+/// Data point for timeline chart
+struct TimeSlot: Identifiable, Equatable {
+    let id = UUID()
+    let time: Date
+    let percentage: Double?
+
+    var timeLabel: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm"
+        return formatter.string(from: time)
+    }
+
+    var fullTimeLabel: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MM/dd HH:mm"
+        return formatter.string(from: time)
+    }
+
+    static func == (lhs: TimeSlot, rhs: TimeSlot) -> Bool {
+        lhs.id == rhs.id
+    }
+}
+
+/// Chart displaying session usage history (5-hour window, 10-min intervals = 30 slots)
+struct SessionUsageChart: View {
+    let snapshots: [UsageSnapshot]
+
+    /// Time window offset in hours (0 = current time centered)
+    @State private var timeOffset: Double = 0
+    /// Selected time for showing details
+    @State private var selectedTime: Date?
+
+    private let slotCount = 30           // 30 slots
+    private let slotInterval: TimeInterval = 10 * 60  // 10 minutes
+    private let windowDuration: TimeInterval = 5 * 60 * 60  // 5 hours
+
+    init(snapshots: [UsageSnapshot]) {
+        self.snapshots = snapshots
+    }
+
+    /// Generate time slots for the current window
+    private var timeSlots: [TimeSlot] {
+        let now = Date()
+        let offsetSeconds = timeOffset * 3600  // Convert hours to seconds
+        let centerTime = now.addingTimeInterval(offsetSeconds)
+        let startTime = centerTime.addingTimeInterval(-windowDuration / 2)
+
+        return (0..<slotCount).map { index in
+            let slotTime = startTime.addingTimeInterval(Double(index) * slotInterval)
+            let percentage = findPercentage(for: slotTime)
+            return TimeSlot(time: slotTime, percentage: percentage)
+        }
+    }
+
+    /// Find the recorded percentage for a given time slot
+    private func findPercentage(for time: Date) -> Double? {
+        let tolerance = slotInterval / 2  // ±5 minutes
+        return snapshots.first { snapshot in
+            abs(snapshot.timestamp.timeIntervalSince(time)) <= tolerance
+        }?.sessionPercentage
+    }
+
+    /// Snap cursor time to nearest slot and return info only if data exists
+    private var selectedSlotInfo: (time: String, percentage: String)? {
+        guard let cursorTime = selectedTime else { return nil }
+
+        // Find the nearest slot time
+        let slots = timeSlots
+        guard let nearestSlot = slots.min(by: {
+            abs($0.time.timeIntervalSince(cursorTime)) < abs($1.time.timeIntervalSince(cursorTime))
+        }) else { return nil }
+
+        // Only show info if this slot has data
+        guard let pct = nearestSlot.percentage else { return nil }
+
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MM/dd HH:mm"
+        let timeStr = formatter.string(from: nearestSlot.time)
+
+        return (timeStr, String(format: "%.1f%%", pct))
+    }
+
+    /// Clamp percentage to 0-100 range
+    private func clampedPercentage(_ value: Double?) -> Double {
+        guard let v = value else { return 0 }
+        return min(max(v, 0), 100)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            // Title with time range and selected info
+            HStack {
+                Text("history.chart.session_title".localized)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundColor(.secondary)
+
+                // Show selected slot info (only when hovering over a bar with data)
+                if let info = selectedSlotInfo {
+                    Spacer()
+                    HStack(spacing: 4) {
+                        Text(info.time)
+                            .font(.system(size: 11))
+                            .foregroundColor(.secondary)
+                        Text(info.percentage)
+                            .font(.system(size: 11, weight: .medium))
+                            .foregroundColor(.primary)
+                    }
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 2)
+                    .background(Color.secondary.opacity(0.1))
+                    .cornerRadius(4)
+                }
+
+                Spacer()
+                // Navigation buttons
+                HStack(spacing: 8) {
+                    Button(action: { timeOffset -= 2.5 }) {
+                        Image(systemName: "chevron.left")
+                            .font(.system(size: 10))
+                    }
+                    .buttonStyle(.plain)
+
+                    Button(action: { timeOffset = 0 }) {
+                        Text("history.chart.now".localized)
+                            .font(.system(size: 10))
+                    }
+                    .buttonStyle(.plain)
+
+                    Button(action: { timeOffset += 2.5 }) {
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: 10))
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(timeOffset >= 0)
+                }
+            }
+
+            Chart(timeSlots) { slot in
+                BarMark(
+                    x: .value("Time", slot.time, unit: .minute),
+                    y: .value("Usage", clampedPercentage(slot.percentage)),
+                    width: .fixed(8)
+                )
+                .foregroundStyle(slot.percentage != nil ? barColor(for: slot.percentage!) : Color.gray.opacity(0.2))
+                .cornerRadius(2)
+            }
+            .chartYScale(domain: 0...100)
+            .chartPlotStyle { plotArea in
+                plotArea.clipped()
+            }
+            .chartYAxis {
+                AxisMarks(position: .leading, values: [0, 50, 100]) { value in
+                    AxisGridLine(stroke: StrokeStyle(lineWidth: 0.5, dash: [4]))
+                        .foregroundStyle(Color.secondary.opacity(0.3))
+                    AxisValueLabel {
+                        if let intValue = value.as(Int.self) {
+                            Text("\(intValue)%")
+                                .font(.system(size: 10))
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                }
+            }
+            .chartXAxis {
+                AxisMarks(values: .stride(by: .hour)) { value in
+                    AxisGridLine()
+                    AxisValueLabel(format: .dateTime.hour(.defaultDigits(amPM: .omitted)).minute())
+                        .font(.system(size: 8))
+                }
+            }
+            .chartXSelection(value: $selectedTime)
+            .frame(height: 140)
+            .padding(.leading, 4)
+        }
+        .padding(16)
+        .background(Color(nsColor: .controlBackgroundColor).opacity(0.5))
+        .cornerRadius(8)
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(Color.secondary.opacity(0.15), lineWidth: 1)
+        )
+    }
+
+    private func barColor(for percentage: Double) -> Color {
+        switch percentage {
+        case 0..<50:
+            return .green
+        case 50..<80:
+            return .orange
+        default:
+            return .red
+        }
+    }
+}
+
+/// Chart displaying weekly usage history (24-hour window, 2-hour intervals = 12 slots)
+struct WeeklyUsageChart: View {
+    let snapshots: [UsageSnapshot]
+
+    /// Time window offset in hours (0 = current time centered)
+    @State private var timeOffset: Double = 0
+    /// Selected time for showing details
+    @State private var selectedTime: Date?
+
+    private let slotCount = 12           // 12 slots
+    private let slotInterval: TimeInterval = 2 * 60 * 60  // 2 hours
+    private let windowDuration: TimeInterval = 24 * 60 * 60  // 24 hours
+
+    init(snapshots: [UsageSnapshot]) {
+        self.snapshots = snapshots
+    }
+
+    /// Generate time slots for the current window
+    private var timeSlots: [TimeSlot] {
+        let now = Date()
+        let offsetSeconds = timeOffset * 3600  // Convert hours to seconds
+        let centerTime = now.addingTimeInterval(offsetSeconds)
+        let startTime = centerTime.addingTimeInterval(-windowDuration / 2)
+
+        return (0..<slotCount).map { index in
+            let slotTime = startTime.addingTimeInterval(Double(index) * slotInterval)
+            let percentage = findPercentage(for: slotTime)
+            return TimeSlot(time: slotTime, percentage: percentage)
+        }
+    }
+
+    /// Find the recorded percentage for a given time slot
+    private func findPercentage(for time: Date) -> Double? {
+        let tolerance = slotInterval / 2  // ±1 hour
+        return snapshots.first { snapshot in
+            abs(snapshot.timestamp.timeIntervalSince(time)) <= tolerance
+        }?.weeklyPercentage
+    }
+
+    /// Snap cursor time to nearest slot and return info only if data exists
+    private var selectedSlotInfo: (time: String, percentage: String)? {
+        guard let cursorTime = selectedTime else { return nil }
+
+        // Find the nearest slot time
+        let slots = timeSlots
+        guard let nearestSlot = slots.min(by: {
+            abs($0.time.timeIntervalSince(cursorTime)) < abs($1.time.timeIntervalSince(cursorTime))
+        }) else { return nil }
+
+        // Only show info if this slot has data
+        guard let pct = nearestSlot.percentage else { return nil }
+
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MM/dd HH:mm"
+        let timeStr = formatter.string(from: nearestSlot.time)
+
+        return (timeStr, String(format: "%.1f%%", pct))
+    }
+
+    /// Clamp percentage to 0-100 range
+    private func clampedPercentage(_ value: Double?) -> Double {
+        guard let v = value else { return 0 }
+        return min(max(v, 0), 100)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            // Title with navigation
+            HStack {
+                Text("history.chart.weekly_title".localized)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundColor(.secondary)
+
+                // Show selected slot info (only when hovering over a bar with data)
+                if let info = selectedSlotInfo {
+                    Spacer()
+                    HStack(spacing: 4) {
+                        Text(info.time)
+                            .font(.system(size: 11))
+                            .foregroundColor(.secondary)
+                        Text(info.percentage)
+                            .font(.system(size: 11, weight: .medium))
+                            .foregroundColor(.primary)
+                    }
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 2)
+                    .background(Color.secondary.opacity(0.1))
+                    .cornerRadius(4)
+                }
+
+                Spacer()
+                // Navigation buttons
+                HStack(spacing: 8) {
+                    Button(action: { timeOffset -= 12 }) {
+                        Image(systemName: "chevron.left")
+                            .font(.system(size: 10))
+                    }
+                    .buttonStyle(.plain)
+
+                    Button(action: { timeOffset = 0 }) {
+                        Text("history.chart.now".localized)
+                            .font(.system(size: 10))
+                    }
+                    .buttonStyle(.plain)
+
+                    Button(action: { timeOffset += 12 }) {
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: 10))
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(timeOffset >= 0)
+                }
+            }
+
+            // Chart container
+            Chart(timeSlots) { slot in
+                BarMark(
+                    x: .value("Time", slot.time, unit: .hour),
+                    y: .value("Usage", clampedPercentage(slot.percentage)),
+                    width: .fixed(20)
+                )
+                .foregroundStyle(slot.percentage != nil ? barColor(for: slot.percentage!) : Color.gray.opacity(0.2))
+                .cornerRadius(3)
+            }
+            .chartYScale(domain: 0...100)
+            .chartPlotStyle { plotArea in
+                plotArea.clipped()
+            }
+            .chartYAxis {
+                AxisMarks(position: .leading, values: [0, 50, 100]) { value in
+                    AxisGridLine(stroke: StrokeStyle(lineWidth: 0.5, dash: [4]))
+                        .foregroundStyle(Color.secondary.opacity(0.3))
+                    AxisValueLabel {
+                        if let intValue = value.as(Int.self) {
+                            Text("\(intValue)%")
+                                .font(.system(size: 10))
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                }
+            }
+            .chartXAxis {
+                AxisMarks(values: .stride(by: .hour, count: 4)) { value in
+                    AxisGridLine()
+                    AxisValueLabel(format: .dateTime.month(.defaultDigits).day().hour(.defaultDigits(amPM: .omitted)))
+                        .font(.system(size: 8))
+                }
+            }
+            .chartXSelection(value: $selectedTime)
+            .frame(height: 140)
+            .padding(.leading, 4)
+        }
+        .padding(16)
+        .background(Color(nsColor: .controlBackgroundColor).opacity(0.5))
+        .cornerRadius(8)
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(Color.secondary.opacity(0.15), lineWidth: 1)
+        )
+    }
+
+    private func barColor(for percentage: Double) -> Color {
+        switch percentage {
+        case 0..<50:
+            return .green
+        case 50..<80:
+            return .orange
+        default:
+            return .red
+        }
+    }
+}
+
+/// Chart displaying billing cycle history
+struct BillingCycleChart: View {
+    let snapshots: [UsageSnapshot]
+    let maxItems: Int
+
+    init(snapshots: [UsageSnapshot], maxItems: Int = 12) {
+        self.snapshots = snapshots
+        self.maxItems = maxItems
+    }
+
+    private var chartData: [UsageSnapshot] {
+        // Take the most recent snapshots and reverse for chronological order
+        Array(snapshots.prefix(maxItems).reversed())
+    }
+
+    private var maxSpend: Double {
+        let maxCents = chartData.compactMap { $0.apiSpendCents }.max() ?? 0
+        return Swift.max(Double(maxCents) / 100.0, 10.0)  // Minimum $10 for scale
+    }
+
+    var body: some View {
+        if chartData.isEmpty {
+            EmptyHistoryView(type: .billing)
+        } else {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("history.chart.billing_title".localized)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundColor(.secondary)
+
+                Chart(chartData) { snapshot in
+                    let spendAmount = Double(snapshot.apiSpendCents ?? 0) / 100.0
+
+                    LineMark(
+                        x: .value("Date", snapshot.shortDateString),
+                        y: .value("Spend", spendAmount)
+                    )
+                    .foregroundStyle(Color.accentColor)
+                    .interpolationMethod(.catmullRom)
+
+                    AreaMark(
+                        x: .value("Date", snapshot.shortDateString),
+                        y: .value("Spend", spendAmount)
+                    )
+                    .foregroundStyle(
+                        LinearGradient(
+                            colors: [Color.accentColor.opacity(0.3), Color.accentColor.opacity(0.05)],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
+                    )
+                    .interpolationMethod(.catmullRom)
+
+                    PointMark(
+                        x: .value("Date", snapshot.shortDateString),
+                        y: .value("Spend", spendAmount)
+                    )
+                    .foregroundStyle(Color.accentColor)
+                    .symbolSize(30)
+                }
+                .chartYScale(domain: 0...maxSpend * 1.1)
+                .chartYAxis {
+                    AxisMarks { value in
+                        AxisGridLine(stroke: StrokeStyle(lineWidth: 0.5, dash: [4]))
+                            .foregroundStyle(Color.secondary.opacity(0.3))
+                        AxisValueLabel {
+                            if let doubleValue = value.as(Double.self) {
+                                Text("$\(Int(doubleValue))")
+                                    .font(.system(size: 10))
+                                    .foregroundColor(.secondary)
+                            }
+                        }
+                    }
+                }
+                .chartXAxis {
+                    AxisMarks(values: .automatic) { _ in
+                        AxisValueLabel()
+                            .font(.system(size: 10))
+                    }
+                }
+                .chartPlotStyle { plotArea in
+                    plotArea
+                        .background(Color.clear)
+                }
+                .frame(height: 160)
+            }
+            .padding(16)
+            .background(Color(nsColor: .controlBackgroundColor).opacity(0.5))
+            .cornerRadius(8)
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(Color.secondary.opacity(0.15), lineWidth: 1)
+            )
+        }
+    }
+}
+
+/// Empty state view for history
+struct EmptyHistoryView: View {
+    enum HistoryType {
+        case session
+        case weekly
+        case billing
+
+        var icon: String {
+            switch self {
+            case .session:
+                return "clock.arrow.circlepath"
+            case .weekly:
+                return "chart.bar"
+            case .billing:
+                return "chart.line.uptrend.xyaxis"
+            }
+        }
+
+        var titleKey: String {
+            switch self {
+            case .session:
+                return "history.empty.session_title"
+            case .weekly:
+                return "history.empty.weekly_title"
+            case .billing:
+                return "history.empty.billing_title"
+            }
+        }
+
+        var descriptionKey: String {
+            switch self {
+            case .session:
+                return "history.empty.session_description"
+            case .weekly:
+                return "history.empty.weekly_description"
+            case .billing:
+                return "history.empty.billing_description"
+            }
+        }
+    }
+
+    let type: HistoryType
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Image(systemName: type.icon)
+                .font(.system(size: 32))
+                .foregroundColor(.secondary.opacity(0.5))
+
+            VStack(spacing: 4) {
+                Text(type.titleKey.localized)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundColor(.primary)
+
+                Text(type.descriptionKey.localized)
+                    .font(.system(size: 11))
+                    .foregroundColor(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: 160)
+        .padding(16)
+        .background(Color(nsColor: .controlBackgroundColor).opacity(0.5))
+        .cornerRadius(8)
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(Color.secondary.opacity(0.15), lineWidth: 1)
+        )
+    }
+}
+
+/// Row displaying a single snapshot in the history list
+struct SnapshotRow: View {
+    let snapshot: UsageSnapshot
+
+    var body: some View {
+        HStack(spacing: 12) {
+            // Date column
+            VStack(alignment: .leading, spacing: 2) {
+                Text(snapshot.formattedDate)
+                    .font(.system(size: 12))
+                    .foregroundColor(.primary)
+
+                Text(snapshot.resetType.localizedName)
+                    .font(.system(size: 11))
+                    .foregroundColor(.secondary)
+            }
+
+            Spacer()
+
+            // Usage data column
+            switch snapshot.resetType {
+            case .sessionReset:
+                sessionUsageView
+            case .weeklyReset:
+                weeklyUsageView
+            case .billingCycle:
+                billingUsageView
+            }
+        }
+        .padding(.vertical, 8)
+    }
+
+    @ViewBuilder
+    private var sessionUsageView: some View {
+        if let percentage = snapshot.sessionPercentage {
+            VStack(alignment: .trailing, spacing: 2) {
+                Text("\(Int(percentage))%")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundColor(usageColor(for: percentage))
+
+                Text("history.label.session".localized)
+                    .font(.system(size: 10))
+                    .foregroundColor(.secondary)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var weeklyUsageView: some View {
+        HStack(spacing: 12) {
+            if let percentage = snapshot.weeklyPercentage {
+                VStack(alignment: .trailing, spacing: 2) {
+                    Text("\(Int(percentage))%")
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundColor(usageColor(for: percentage))
+
+                    Text("history.label.total".localized)
+                        .font(.system(size: 10))
+                        .foregroundColor(.secondary)
+                }
+            }
+
+            if let opusPercentage = snapshot.opusWeeklyPercentage, opusPercentage > 0 {
+                VStack(alignment: .trailing, spacing: 2) {
+                    Text("\(Int(opusPercentage))%")
+                        .font(.system(size: 12))
+                        .foregroundColor(.secondary)
+
+                    Text("Opus")
+                        .font(.system(size: 10))
+                        .foregroundColor(.secondary)
+                }
+            }
+
+            if let sonnetPercentage = snapshot.sonnetWeeklyPercentage, sonnetPercentage > 0 {
+                VStack(alignment: .trailing, spacing: 2) {
+                    Text("\(Int(sonnetPercentage))%")
+                        .font(.system(size: 12))
+                        .foregroundColor(.secondary)
+
+                    Text("Sonnet")
+                        .font(.system(size: 10))
+                        .foregroundColor(.secondary)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var billingUsageView: some View {
+        if let formattedSpend = snapshot.formattedApiSpend {
+            VStack(alignment: .trailing, spacing: 2) {
+                Text(formattedSpend)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundColor(.primary)
+
+                Text("history.label.spent".localized)
+                    .font(.system(size: 10))
+                    .foregroundColor(.secondary)
+            }
+        }
+    }
+
+    private func usageColor(for percentage: Double) -> Color {
+        switch percentage {
+        case 0..<50:
+            return .green
+        case 50..<80:
+            return .orange
+        default:
+            return .red
+        }
+    }
+}
+
+#Preview("Weekly Chart") {
+    WeeklyUsageChart(snapshots: [
+        UsageSnapshot(
+            resetType: .weeklyReset,
+            weeklyTokensUsed: 500000,
+            weeklyPercentage: 50,
+            opusWeeklyTokensUsed: 300000,
+            opusWeeklyPercentage: 30,
+            sonnetWeeklyTokensUsed: 200000,
+            sonnetWeeklyPercentage: 20,
+            triggeringResetTime: Date().addingTimeInterval(-7 * 24 * 60 * 60)
+        ),
+        UsageSnapshot(
+            resetType: .weeklyReset,
+            weeklyTokensUsed: 750000,
+            weeklyPercentage: 75,
+            triggeringResetTime: Date().addingTimeInterval(-14 * 24 * 60 * 60)
+        ),
+        UsageSnapshot(
+            resetType: .weeklyReset,
+            weeklyTokensUsed: 900000,
+            weeklyPercentage: 90,
+            triggeringResetTime: Date().addingTimeInterval(-21 * 24 * 60 * 60)
+        )
+    ])
+    .padding()
+    .frame(width: 400)
+}
+
+#Preview("Empty Weekly") {
+    EmptyHistoryView(type: .weekly)
+        .padding()
+        .frame(width: 400)
+}
+
+#Preview("Billing Chart") {
+    BillingCycleChart(snapshots: [
+        UsageSnapshot(
+            resetType: .billingCycle,
+            apiSpendCents: 2500,
+            apiPrepaidCreditsCents: 5000,
+            apiCurrency: "USD",
+            triggeringResetTime: Date().addingTimeInterval(-30 * 24 * 60 * 60)
+        ),
+        UsageSnapshot(
+            resetType: .billingCycle,
+            apiSpendCents: 4200,
+            apiPrepaidCreditsCents: 5000,
+            apiCurrency: "USD",
+            triggeringResetTime: Date().addingTimeInterval(-60 * 24 * 60 * 60)
+        )
+    ])
+    .padding()
+    .frame(width: 400)
+}

--- a/Claude Usage/Views/Settings/Profile/UsageHistoryView.swift
+++ b/Claude Usage/Views/Settings/Profile/UsageHistoryView.swift
@@ -1,0 +1,279 @@
+//
+//  UsageHistoryView.swift
+//  Claude Usage
+//
+//  Created by Claude Code on 2025-01-26.
+//
+
+import SwiftUI
+
+/// Chart type selector for history view
+enum HistoryChartType: String, CaseIterable {
+    case sessionResets = "session"
+    case weeklyResets = "weekly"
+    case billingCycles = "billing"
+
+    var localizedName: String {
+        switch self {
+        case .sessionResets:
+            return "history.tab.session".localized
+        case .weeklyResets:
+            return "history.tab.weekly".localized
+        case .billingCycles:
+            return "history.tab.billing".localized
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .sessionResets:
+            return "clock.arrow.circlepath"
+        case .weeklyResets:
+            return "calendar.badge.clock"
+        case .billingCycles:
+            return "creditcard"
+        }
+    }
+
+    var resetType: ResetType {
+        switch self {
+        case .sessionResets:
+            return .sessionReset
+        case .weeklyResets:
+            return .weeklyReset
+        case .billingCycles:
+            return .billingCycle
+        }
+    }
+}
+
+/// Usage history view showing charts and historical data
+struct UsageHistoryView: View {
+    @StateObject private var profileManager = ProfileManager.shared
+    @State private var selectedChartType: HistoryChartType = .sessionResets
+    @State private var historyData: UsageHistoryData = UsageHistoryData()
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                // Page Header
+                SettingsPageHeader(
+                    title: "history.title".localized,
+                    subtitle: "history.subtitle".localized
+                )
+
+                if let profile = profileManager.activeProfile {
+                    // Chart Type Picker
+                    Picker("", selection: $selectedChartType) {
+                        ForEach(HistoryChartType.allCases, id: \.self) { type in
+                            Label(type.localizedName, systemImage: type.icon)
+                                .tag(type)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+
+                    // Chart Section
+                    chartSection
+
+                    // History List Section
+                    historyListSection
+
+                    // Action Buttons
+                    actionButtons
+                } else {
+                    noProfileView
+                }
+
+                Spacer()
+            }
+            .padding()
+        }
+        .onAppear {
+            loadHistory()
+        }
+        .onChange(of: profileManager.activeProfile?.id) { _ in
+            loadHistory()
+        }
+    }
+
+    // MARK: - Chart Section
+
+    @ViewBuilder
+    private var chartSection: some View {
+        switch selectedChartType {
+        case .sessionResets:
+            SessionUsageChart(snapshots: historyData.sessionSnapshots)
+        case .weeklyResets:
+            WeeklyUsageChart(snapshots: historyData.weeklySnapshots)
+        case .billingCycles:
+            BillingCycleChart(snapshots: historyData.billingCycleSnapshots)
+        }
+    }
+
+    // MARK: - History List Section
+
+    @ViewBuilder
+    private var historyListSection: some View {
+        let snapshots = currentSnapshots
+
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("history.list.title".localized)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundColor(.secondary)
+                Spacer()
+                Text(String(format: "history.list.count".localized, snapshots.count))
+                    .font(.system(size: 11))
+                    .foregroundColor(.secondary)
+            }
+
+            if snapshots.isEmpty {
+                emptyListView
+            } else {
+                // Scrollable list with fixed height
+                ScrollView {
+                    LazyVStack(spacing: 0) {
+                        ForEach(Array(snapshots.prefix(50).enumerated()), id: \.element.id) { index, snapshot in
+                            SnapshotRow(snapshot: snapshot)
+
+                            if index < min(snapshots.count - 1, 49) {
+                                Divider()
+                            }
+                        }
+
+                        if snapshots.count > 50 {
+                            HStack {
+                                Text(String(format: "history.list.more".localized, snapshots.count - 50))
+                                    .font(.system(size: 11))
+                                    .foregroundColor(.secondary)
+                                Spacer()
+                            }
+                            .padding(.top, 8)
+                        }
+                    }
+                    .padding(12)
+                }
+                .frame(height: 200)
+                .background(Color(nsColor: .controlBackgroundColor).opacity(0.5))
+                .cornerRadius(8)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(Color.secondary.opacity(0.15), lineWidth: 1)
+                )
+            }
+        }
+    }
+
+    private var currentSnapshots: [UsageSnapshot] {
+        switch selectedChartType {
+        case .sessionResets:
+            return historyData.sessionSnapshots
+        case .weeklyResets:
+            return historyData.weeklySnapshots
+        case .billingCycles:
+            return historyData.billingCycleSnapshots
+        }
+    }
+
+    @ViewBuilder
+    private var emptyListView: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "clock.arrow.circlepath")
+                .font(.system(size: 24))
+                .foregroundColor(.secondary.opacity(0.5))
+
+            Text("history.list.empty".localized)
+                .font(.system(size: 12))
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: 100)
+        .background(Color(nsColor: .controlBackgroundColor).opacity(0.5))
+        .cornerRadius(8)
+    }
+
+    @ViewBuilder
+    private var actionButtons: some View {
+        HStack(spacing: 12) {
+            // Export Button
+            Button(action: exportHistory) {
+                HStack(spacing: 4) {
+                    Image(systemName: "square.and.arrow.up")
+                        .font(.system(size: 11))
+                    Text("history.export_button".localized)
+                        .font(.system(size: 12))
+                }
+            }
+            .buttonStyle(.bordered)
+
+            Spacer()
+
+            // Clear Button
+            if !currentSnapshots.isEmpty {
+                Button(action: clearCurrentHistory) {
+                    HStack(spacing: 4) {
+                        Image(systemName: "trash")
+                            .font(.system(size: 11))
+                        Text("history.clear_button".localized)
+                            .font(.system(size: 12))
+                    }
+                    .foregroundColor(.red)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var noProfileView: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "person.crop.circle.badge.questionmark")
+                .font(.system(size: 48))
+                .foregroundColor(.secondary.opacity(0.5))
+
+            Text("history.no_profile".localized)
+                .font(.system(size: 13, weight: .medium))
+                .foregroundColor(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 60)
+    }
+
+    // MARK: - Actions
+
+    private func loadHistory() {
+        guard let profileId = profileManager.activeProfile?.id else {
+            historyData = UsageHistoryData()
+            return
+        }
+
+        Task { @MainActor in
+            historyData = UsageHistoryService.shared.loadHistory(for: profileId)
+        }
+    }
+
+    private func clearCurrentHistory() {
+        guard let profileId = profileManager.activeProfile?.id else { return }
+
+        Task { @MainActor in
+            UsageHistoryService.shared.clearHistory(for: profileId, resetType: selectedChartType.resetType)
+            loadHistory()
+        }
+    }
+
+    private func exportHistory() {
+        guard let profileId = profileManager.activeProfile?.id else { return }
+
+        Task { @MainActor in
+            UsageHistoryService.shared.exportToFile(for: profileId, resetType: selectedChartType.resetType)
+        }
+    }
+}
+
+// MARK: - Previews
+
+#Preview("History View") {
+    UsageHistoryView()
+        .frame(width: 520, height: 700)
+}

--- a/Claude Usage/Views/SettingsView.swift
+++ b/Claude Usage/Views/SettingsView.swift
@@ -41,6 +41,8 @@ struct SettingsView: View {
                     AppearanceSettingsView()
                 case .general:
                     GeneralSettingsView()
+                case .history:
+                    UsageHistoryView()
 
                 // Shared Settings
                 case .manageProfiles:
@@ -200,6 +202,7 @@ enum SettingsSection: String, CaseIterable {
     // Profile Settings
     case appearance
     case general
+    case history
 
     // Shared Settings
     case manageProfiles
@@ -215,6 +218,7 @@ enum SettingsSection: String, CaseIterable {
         case .cliAccount: return "section.cli_account_title".localized
         case .appearance: return "section.appearance_title".localized
         case .general: return "section.general_title".localized
+        case .history: return "section.history_title".localized
         case .manageProfiles: return "section.manage_profiles_title".localized
         case .language: return "language.title".localized
         case .claudeCode: return "settings.claude_cli".localized
@@ -230,6 +234,7 @@ enum SettingsSection: String, CaseIterable {
         case .cliAccount: return "terminal.fill"
         case .appearance: return "paintbrush.fill"
         case .general: return "gearshape.fill"
+        case .history: return "chart.bar.xaxis"
         case .manageProfiles: return "person.2.fill"
         case .language: return "globe"
         case .claudeCode: return "chevron.left.forwardslash.chevron.right"
@@ -245,6 +250,7 @@ enum SettingsSection: String, CaseIterable {
         case .cliAccount: return "section.cli_account_desc".localized
         case .appearance: return "section.appearance_desc".localized
         case .general: return "section.general_desc".localized
+        case .history: return "section.history_desc".localized
         case .manageProfiles: return "section.manage_profiles_desc".localized
         case .language: return "language.subtitle".localized
         case .claudeCode: return "settings.claude_cli.description".localized
@@ -264,7 +270,7 @@ enum SettingsSection: String, CaseIterable {
 
     var isProfileSetting: Bool {
         switch self {
-        case .appearance, .general:
+        case .appearance, .general, .history:
             return true
         default:
             return false


### PR DESCRIPTION
## Summary
- Add periodic recording of session usage (every 10 minutes) and weekly usage (every 2 hours)
- Implement interactive timeline-based charts with sliding window navigation
- Session chart: 5-hour window with 30 slots (10-min intervals)
- Weekly chart: 24-hour window with 12 slots (2-hour intervals)
- Add snap-to-bar hover interaction to show usage details
- Support JSON export of history data

## New Files
- `UsageHistory.swift` - Data models for usage snapshots
- `UsageHistoryService.swift` - Storage and recording service
- `UsageHistoryView.swift` - Settings page for viewing history
- `UsageCharts.swift` - Interactive chart components

## Test Plan
- [ ] Verify periodic recording by checking exported JSON after usage
- [ ] Test chart navigation with left/right arrows and "Now" button
- [ ] Confirm snap-to-bar hover shows correct usage percentage
- [ ] Test JSON export functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)