### PR TITLE
fix(menubar): resolve status bar icon not reappearing on re-enable

### DIFF
--- a/Claude Usage/MenuBar/MenuBarManager.swift
+++ b/Claude Usage/MenuBar/MenuBarManager.swift
@@ -357,7 +357,12 @@ class MenuBarManager: NSObject, ObservableObject {
             config: displayConfig
         )
 
-        updateAllStatusBarIcons()
+        // Defer icon update to the next run loop iteration so that NSStatusBar
+        // can finalize layout for any newly created status items and their
+        // buttons adopt the correct effectiveAppearance before we render icons.
+        DispatchQueue.main.async { [weak self] in
+            self?.updateAllStatusBarIcons()
+        }
     }
 
     private func restartAutoRefreshWithInterval(_ interval: TimeInterval) {


### PR DESCRIPTION
Defer icon rendering to the next run loop iteration after creating new NSStatusItems, giving NSStatusBar time to finalize layout and button appearance before images are assigned.

Without this, toggling a metric off and back on creates a new status item whose button isn't ready for image assignment in the same run loop tick -- so it stays invisible.

Closes #97