### PR TITLE
Add time-elapsed marker on progress bars

### DIFF
--- a/Claude Usage/MenuBar/PopoverContentView.swift
+++ b/Claude Usage/MenuBar/PopoverContentView.swift
@@ -682,7 +682,7 @@ struct SmartUsageCard: View {
                         // Time elapsed marker
                         if let fraction = timeMarkerFraction {
                             Rectangle()
-                                .fill(Color.primary.opacity(0.45))
+                                .fill(Color(nsColor: .secondaryLabelColor))
                                 .frame(width: 1)
                                 .offset(x: round(geometry.size.width * fraction))
                         }


### PR DESCRIPTION
## Summary
- Adds a thin vertical marker on Session (5h) and Weekly (7d) progress bars showing how far through the time period the user is
- Lets users tell at a glance whether they're overusing or underusing relative to elapsed time: if the fill bar is left of the marker, you're pacing well; if past it, you're burning tokens faster than time is passing
- Respects "show remaining" display mode by flipping marker direction
- Marker hidden when reset time is in the past (period already reset)

## Implementation
- Single file change: `PopoverContentView.swift` (+34 lines)
- New `periodDuration` parameter on `SmartUsageCard` (5h for session, 7d for weekly, nil for others)
- 1px `Rectangle` rendered as overlay with pixel-snapped offset for crisp rendering
- Uses `secondaryLabelColor` for a subtle, macOS-native appearance in both light and dark mode

## Test plan
- [x] Verified marker appears on Session and Weekly bars
- [x] Verified marker does NOT appear on Opus, Sonnet, Extra Usage, or API Credits bars
- [x] Verified consistent 1px width across bars of different widths
- [x] Build succeeds with zero warnings
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)