### PR TITLE
Expand clickable area for CredentialMiniCard and SettingMiniButton

### DIFF
--- a/Claude Usage/Views/SettingsView.swift
+++ b/Claude Usage/Views/SettingsView.swift
@@ -404,6 +404,7 @@ struct CredentialMiniCard: View {
             RoundedRectangle(cornerRadius: 4)
                 .fill(isSelected ? SettingsColors.primary : Color.clear)
         )
+        .contentShape(Rectangle())
         .padding(.horizontal, 4)
         .padding(.vertical, 1)
     }
@@ -435,6 +436,7 @@ struct SettingMiniButton: View {
             RoundedRectangle(cornerRadius: 4)
                 .fill(isSelected ? SettingsColors.primary : Color.clear)
         )
+        .contentShape(Rectangle())
         .padding(.horizontal, 4)
         .padding(.vertical, 1)
     }


### PR DESCRIPTION
Add .contentShape(Rectangle()) to ensure the entire row area is tappable.

<img width="832" height="724" alt="clickable_area" src="https://github.com/user-attachments/assets/30454515-638c-4998-8780-14b826c7458a" />
