### PR TITLE
fix(menubar): align circular progress arcs with clockwise convention

### DIFF
--- a/Claude Usage/MenuBar/MenuBarIconRenderer.swift
+++ b/Claude Usage/MenuBar/MenuBarIconRenderer.swift
@@ -447,7 +447,7 @@ final class MenuBarIconRenderer {
         let center = NSPoint(x: centerX, y: size / 2)
         let radius = (circleSize - 4.0) / 2
         let startAngle: CGFloat = 90
-        let endAngle = startAngle + (360 * CGFloat(percentage))
+        let endAngle = startAngle - (360 * CGFloat(percentage))
 
         // Background ring
         let bgArcPath = NSBezierPath()
@@ -471,7 +471,7 @@ final class MenuBarIconRenderer {
                 radius: radius,
                 startAngle: startAngle,
                 endAngle: endAngle,
-                clockwise: false
+                clockwise: true
             )
             fillColor.setStroke()
             arcPath.lineWidth = 3.0
@@ -640,14 +640,14 @@ final class MenuBarIconRenderer {
 
         // Session progress ring (outer - primary metric)
         if sessionPercentage > 0 {
-            let sessionEndAngle = 90 + (360 * CGFloat(sessionPercentage / 100.0))
+            let sessionEndAngle = 90 - (360 * CGFloat(sessionPercentage / 100.0))
             let outerProgressPath = NSBezierPath()
             outerProgressPath.appendArc(
                 withCenter: center,
                 radius: outerRadius,
                 startAngle: 90,
                 endAngle: sessionEndAngle,
-                clockwise: false
+                clockwise: true
             )
             sessionColor.setStroke()
             outerProgressPath.lineWidth = outerStrokeWidth
@@ -674,14 +674,14 @@ final class MenuBarIconRenderer {
 
         // Week progress ring (inner - secondary metric)
         if weekPercentage > 0 {
-            let weekEndAngle = 90 + (360 * CGFloat(weekPercentage / 100.0))
+            let weekEndAngle = 90 - (360 * CGFloat(weekPercentage / 100.0))
             let innerProgressPath = NSBezierPath()
             innerProgressPath.appendArc(
                 withCenter: center,
                 radius: innerRadius,
                 startAngle: 90,
                 endAngle: weekEndAngle,
-                clockwise: false
+                clockwise: true
             )
             weekColor.setStroke()
             innerProgressPath.lineWidth = innerStrokeWidth
@@ -756,14 +756,14 @@ final class MenuBarIconRenderer {
 
         // Session progress ring (outer - primary metric)
         if sessionPercentage > 0 {
-            let sessionEndAngle = 90 + (360 * CGFloat(sessionPercentage / 100.0))
+            let sessionEndAngle = 90 - (360 * CGFloat(sessionPercentage / 100.0))
             let outerProgressPath = NSBezierPath()
             outerProgressPath.appendArc(
                 withCenter: circleCenter,
                 radius: outerRadius,
                 startAngle: 90,
                 endAngle: sessionEndAngle,
-                clockwise: false
+                clockwise: true
             )
             sessionColor.setStroke()
             outerProgressPath.lineWidth = outerStrokeWidth
@@ -790,14 +790,14 @@ final class MenuBarIconRenderer {
 
         // Week progress ring (inner - secondary metric)
         if weekPercentage > 0 {
-            let weekEndAngle = 90 + (360 * CGFloat(weekPercentage / 100.0))
+            let weekEndAngle = 90 - (360 * CGFloat(weekPercentage / 100.0))
             let innerProgressPath = NSBezierPath()
             innerProgressPath.appendArc(
                 withCenter: circleCenter,
                 radius: innerRadius,
                 startAngle: 90,
                 endAngle: weekEndAngle,
-                clockwise: false
+                clockwise: true
             )
             weekColor.setStroke()
             innerProgressPath.lineWidth = innerStrokeWidth


### PR DESCRIPTION
## Summary

Circular progress rings currently fill counterclockwise from 12 o'clock. This aligns them with clockwise motion, matching macOS platform conventions (Activity Monitor, clock faces, timers).

**Affected styles:** circular icon, concentric multi-profile, labeled concentric multi-profile.
No change to battery, progress bar, percentage-only, compact, or text styles.

Fixes #103

## Changes

- Reverse arc sweep direction (`startAngle + sweep` → `startAngle - sweep`)
- Flip `clockwise` parameter on progress rings from `false` to `true`
- Background rings (full 360°) are unaffected

## Screenshots

| Before (v2.3.0) | After |
|---|---|
|<div align="center"><img width="78" height="31" alt="counterclockwise-progress-arcs-before" src="https://github.com/user-attachments/assets/0b416e0c-898a-44d3-93a1-bebdae2c90fc" /></div>|<div align="center"><img width="78" height="32" alt="clockwise-progress-arcs-after" src="https://github.com/user-attachments/assets/8e2933da-415a-4544-b370-b49733e7eaa0" /></div>|

## Notes

Happy to add a user-facing toggle in Settings if both directions should be supported.