### PR TITLE
feat: Add 6-tier pace system for menu bar and popover

### DIFF
--- a/Claude Usage/MenuBar/MenuBarIconRenderer.swift
+++ b/Claude Usage/MenuBar/MenuBarIconRenderer.swift
@@ -20,7 +20,8 @@ final class MenuBarIconRenderer {
         usage: ClaudeUsage,
         apiUsage: APIUsage?,
         isDarkMode: Bool,
-        monochromeMode: Bool,
+        colorMode: MenuBarColorMode,
+        singleColorHex: String,
         showIconName: Bool,
         showNextSessionTime: Bool
     ) -> NSImage {
@@ -43,12 +44,31 @@ final class MenuBarIconRenderer {
             )
             : nil
 
+        // Compute pace status from RAW values (not display-adjusted)
+        let paceStatus: PaceStatus? = {
+            guard globalConfig.showPaceMarker, metricType != .api else { return nil }
+            // Get raw elapsed fraction (always non-inverted)
+            guard let rawElapsed = calculateTimeMarkerFraction(
+                metricType: metricType, usage: usage, showRemaining: false
+            ) else { return nil }
+            // Get raw used percentage
+            let rawUsed: Double = metricType == .session
+                ? usage.sessionPercentage
+                : usage.weeklyPercentage
+            return PaceStatus.calculate(
+                usedPercentage: rawUsed,
+                elapsedFraction: Double(rawElapsed)
+            )
+        }()
+        let showPaceMarker = globalConfig.showPaceMarker
+
         // API is ALWAYS text-based (no icon styles)
         if metricType == .api {
             return createAPITextStyle(
                 metricData: metricData,
                 isDarkMode: isDarkMode,
-                monochromeMode: monochromeMode,
+                colorMode: colorMode,
+                singleColorHex: singleColorHex,
                 showIconName: showIconName
             )
         }
@@ -60,47 +80,62 @@ final class MenuBarIconRenderer {
                 metricType: metricType,
                 metricData: metricData,
                 isDarkMode: isDarkMode,
-                monochromeMode: monochromeMode,
+                colorMode: colorMode,
+                singleColorHex: singleColorHex,
                 showIconName: showIconName,
                 showNextSessionTime: showNextSessionTime,
                 usage: usage,
-                timeMarkerFraction: timeMarkerFraction
+                timeMarkerFraction: timeMarkerFraction,
+                paceStatus: paceStatus,
+                showPaceMarker: showPaceMarker
             )
         case .progressBar:
             return createProgressBarStyle(
                 metricType: metricType,
                 metricData: metricData,
                 isDarkMode: isDarkMode,
-                monochromeMode: monochromeMode,
+                colorMode: colorMode,
+                singleColorHex: singleColorHex,
                 showIconName: showIconName,
                 showNextSessionTime: showNextSessionTime,
                 usage: usage,
-                timeMarkerFraction: timeMarkerFraction
+                timeMarkerFraction: timeMarkerFraction,
+                paceStatus: paceStatus,
+                showPaceMarker: showPaceMarker
             )
         case .percentageOnly:
             return createPercentageOnlyStyle(
                 metricType: metricType,
                 metricData: metricData,
                 isDarkMode: isDarkMode,
-                monochromeMode: monochromeMode,
-                showIconName: showIconName
+                colorMode: colorMode,
+                singleColorHex: singleColorHex,
+                showIconName: showIconName,
+                paceStatus: paceStatus,
+                showPaceMarker: showPaceMarker
             )
         case .icon:
             return createIconWithBarStyle(
                 metricType: metricType,
                 metricData: metricData,
                 isDarkMode: isDarkMode,
-                monochromeMode: monochromeMode,
+                colorMode: colorMode,
+                singleColorHex: singleColorHex,
                 showIconName: showIconName,
-                timeMarkerFraction: timeMarkerFraction
+                timeMarkerFraction: timeMarkerFraction,
+                paceStatus: paceStatus,
+                showPaceMarker: showPaceMarker
             )
         case .compact:
             return createCompactStyle(
                 metricType: metricType,
                 metricData: metricData,
                 isDarkMode: isDarkMode,
-                monochromeMode: monochromeMode,
-                showIconName: showIconName
+                colorMode: colorMode,
+                singleColorHex: singleColorHex,
+                showIconName: showIconName,
+                paceStatus: paceStatus,
+                showPaceMarker: showPaceMarker
             )
         }
     }
@@ -228,11 +263,14 @@ final class MenuBarIconRenderer {
         metricType: MenuBarMetricType,
         metricData: MetricData,
         isDarkMode: Bool,
-        monochromeMode: Bool,
+        colorMode: MenuBarColorMode,
+        singleColorHex: String,
         showIconName: Bool,
         showNextSessionTime: Bool,
         usage: ClaudeUsage,
-        timeMarkerFraction: CGFloat? = nil
+        timeMarkerFraction: CGFloat? = nil,
+        paceStatus: PaceStatus? = nil,
+        showPaceMarker: Bool = false
     ) -> NSImage {
         let percentage = CGFloat(metricData.percentage) / 100.0
 
@@ -251,7 +289,7 @@ final class MenuBarIconRenderer {
         let foregroundColor = menuBarForegroundColor(isDarkMode: isDarkMode)
         let outlineColor: NSColor = foregroundColor
         let textColor: NSColor = foregroundColor
-        let fillColor: NSColor = monochromeMode ? foregroundColor : getColorForStatusLevel(metricData.statusLevel)
+        let fillColor: NSColor = getColorForMode(colorMode, statusLevel: metricData.statusLevel, singleColorHex: singleColorHex, isDarkMode: isDarkMode)
 
         let xOffset: CGFloat = 0
 
@@ -293,7 +331,7 @@ final class MenuBarIconRenderer {
             let tickPath = NSBezierPath()
             tickPath.move(to: NSPoint(x: tickX, y: barY))
             tickPath.line(to: NSPoint(x: tickX, y: barY + barHeight))
-            drawTimeMarkerTick(tickPath, isDarkMode: isDarkMode)
+            drawPaceMarkerTick(tickPath, paceStatus: paceStatus, showPaceMarker: showPaceMarker, isDarkMode: isDarkMode)
         }
 
         // Label BELOW the battery (replaces percentage text)
@@ -332,11 +370,14 @@ final class MenuBarIconRenderer {
         metricType: MenuBarMetricType,
         metricData: MetricData,
         isDarkMode: Bool,
-        monochromeMode: Bool,
+        colorMode: MenuBarColorMode,
+        singleColorHex: String,
         showIconName: Bool,
         showNextSessionTime: Bool,
         usage: ClaudeUsage,
-        timeMarkerFraction: CGFloat? = nil
+        timeMarkerFraction: CGFloat? = nil,
+        paceStatus: PaceStatus? = nil,
+        showPaceMarker: Bool = false
     ) -> NSImage {
         // For progress bar: show "S" or "W" before the bar (not full prefix)
         let labelWidth: CGFloat = showIconName ? 10 : 0
@@ -353,7 +394,7 @@ final class MenuBarIconRenderer {
         // Use isDarkMode to determine correct foreground color for menu bar
         let foregroundColor = menuBarForegroundColor(isDarkMode: isDarkMode)
         let textColor: NSColor = foregroundColor
-        let fillColor: NSColor = monochromeMode ? foregroundColor : getColorForStatusLevel(metricData.statusLevel)
+        let fillColor: NSColor = getColorForMode(colorMode, statusLevel: metricData.statusLevel, singleColorHex: singleColorHex, isDarkMode: isDarkMode)
         let backgroundColor: NSColor = foregroundColor.withAlphaComponent(0.2)
 
         var xOffset: CGFloat = 1
@@ -403,7 +444,7 @@ final class MenuBarIconRenderer {
                 let tickPath = NSBezierPath()
                 tickPath.move(to: NSPoint(x: tickX, y: barY))
                 tickPath.line(to: NSPoint(x: tickX, y: barY + barHeight))
-                drawTimeMarkerTick(tickPath, isDarkMode: isDarkMode)
+                drawPaceMarkerTick(tickPath, paceStatus: paceStatus, showPaceMarker: showPaceMarker, isDarkMode: isDarkMode)
             }
 
             // Draw session reset time inside the fill area if enabled and this is a session metric
@@ -433,14 +474,14 @@ final class MenuBarIconRenderer {
         metricType: MenuBarMetricType,
         metricData: MetricData,
         isDarkMode: Bool,
-        monochromeMode: Bool,
-        showIconName: Bool
+        colorMode: MenuBarColorMode,
+        singleColorHex: String,
+        showIconName: Bool,
+        paceStatus: PaceStatus? = nil,
+        showPaceMarker: Bool = false
     ) -> NSImage {
         let font = NSFont.monospacedDigitSystemFont(ofSize: 12, weight: .semibold)  // Larger font
-
-        // Use isDarkMode to determine correct foreground color for menu bar
-        let foregroundColor = menuBarForegroundColor(isDarkMode: isDarkMode)
-        let fillColor: NSColor = monochromeMode ? foregroundColor : getColorForStatusLevel(metricData.statusLevel)
+        let fillColor: NSColor = getColorForMode(colorMode, statusLevel: metricData.statusLevel, singleColorHex: singleColorHex, isDarkMode: isDarkMode)
 
         var fullText = ""
 
@@ -456,13 +497,25 @@ final class MenuBarIconRenderer {
         ]
 
         let textSize = fullText.size(withAttributes: attributes)
-        let image = NSImage(size: NSSize(width: textSize.width + 2, height: 18))
+        let hasPaceDot = showPaceMarker && paceStatus != nil
+        let paceDotExtra: CGFloat = hasPaceDot ? 8 : 0  // dot(4) + gaps(2+2)
+        let image = NSImage(size: NSSize(width: textSize.width + 2 + paceDotExtra, height: 18))
 
         image.lockFocus()
         defer { image.unlockFocus() }
 
         let textY = (18 - textSize.height) / 2
         fullText.draw(at: NSPoint(x: 2, y: textY), withAttributes: attributes)
+
+        // Pace dot after text
+        if showPaceMarker, let pace = paceStatus {
+            let dotSize: CGFloat = 4.0
+            let dotX = 2 + textSize.width + 2
+            let dotY = (18 - dotSize) / 2
+            let dotPath = NSBezierPath(ovalIn: NSRect(x: dotX, y: dotY, width: dotSize, height: dotSize))
+            pace.color.setFill()
+            dotPath.fill()
+        }
 
         return image
     }
@@ -471,9 +524,12 @@ final class MenuBarIconRenderer {
         metricType: MenuBarMetricType,
         metricData: MetricData,
         isDarkMode: Bool,
-        monochromeMode: Bool,
+        colorMode: MenuBarColorMode,
+        singleColorHex: String,
         showIconName: Bool,
-        timeMarkerFraction: CGFloat? = nil
+        timeMarkerFraction: CGFloat? = nil,
+        paceStatus: PaceStatus? = nil,
+        showPaceMarker: Bool = false
     ) -> NSImage {
         // For circle: make it bigger to fit S/W in center
         let circleSize: CGFloat = showIconName ? 22 : 18  // Bigger when showing label
@@ -488,7 +544,7 @@ final class MenuBarIconRenderer {
         // Use isDarkMode to determine correct foreground color for menu bar
         let foregroundColor = menuBarForegroundColor(isDarkMode: isDarkMode)
         let textColor: NSColor = foregroundColor
-        let fillColor: NSColor = monochromeMode ? foregroundColor : getColorForStatusLevel(metricData.statusLevel)
+        let fillColor: NSColor = getColorForMode(colorMode, statusLevel: metricData.statusLevel, singleColorHex: singleColorHex, isDarkMode: isDarkMode)
 
         let xOffset: CGFloat = 1
 
@@ -544,7 +600,7 @@ final class MenuBarIconRenderer {
                 x: center.x + outerR * cos(tickAngle),
                 y: center.y + outerR * sin(tickAngle)
             ))
-            drawTimeMarkerTick(tickPath, isDarkMode: isDarkMode)
+            drawPaceMarkerTick(tickPath, paceStatus: paceStatus, showPaceMarker: showPaceMarker, isDarkMode: isDarkMode)
         }
 
         // Draw S/W in the CENTER of the circle
@@ -567,13 +623,18 @@ final class MenuBarIconRenderer {
         metricType: MenuBarMetricType,
         metricData: MetricData,
         isDarkMode: Bool,
-        monochromeMode: Bool,
-        showIconName: Bool
+        colorMode: MenuBarColorMode,
+        singleColorHex: String,
+        showIconName: Bool,
+        paceStatus: PaceStatus? = nil,
+        showPaceMarker: Bool = false
     ) -> NSImage {
         let prefixWidth: CGFloat = showIconName ? 16 : 0
         let dotSize: CGFloat = 8
         let spacing: CGFloat = showIconName ? 1 : 0
-        let totalWidth = prefixWidth + spacing + dotSize + 1
+        let hasPaceDot = showPaceMarker && paceStatus != nil
+        let paceDotExtra: CGFloat = hasPaceDot ? 6 : 0  // gap(2) + dot(4)
+        let totalWidth = prefixWidth + spacing + dotSize + paceDotExtra + 1
         let height: CGFloat = 18
 
         let image = NSImage(size: NSSize(width: totalWidth, height: height))
@@ -584,7 +645,7 @@ final class MenuBarIconRenderer {
         // Use isDarkMode to determine correct foreground color for menu bar
         let foregroundColor = menuBarForegroundColor(isDarkMode: isDarkMode)
         let textColor: NSColor = foregroundColor
-        let fillColor: NSColor = monochromeMode ? foregroundColor : getColorForStatusLevel(metricData.statusLevel)
+        let fillColor: NSColor = getColorForMode(colorMode, statusLevel: metricData.statusLevel, singleColorHex: singleColorHex, isDarkMode: isDarkMode)
 
         var xOffset: CGFloat = 1
 
@@ -610,6 +671,16 @@ final class MenuBarIconRenderer {
         fillColor.setFill()
         dotPath.fill()
 
+        // Pace dot next to main dot
+        if showPaceMarker, let pace = paceStatus {
+            let paceDotSize: CGFloat = 4.0
+            let paceDotX = xOffset + dotSize + 2
+            let paceDotY = (height - paceDotSize) / 2
+            let paceDotPath = NSBezierPath(ovalIn: NSRect(x: paceDotX, y: paceDotY, width: paceDotSize, height: paceDotSize))
+            pace.color.setFill()
+            paceDotPath.fill()
+        }
+
         return image
     }
 
@@ -618,7 +689,8 @@ final class MenuBarIconRenderer {
     private func createAPITextStyle(
         metricData: MetricData,
         isDarkMode: Bool,
-        monochromeMode: Bool,
+        colorMode: MenuBarColorMode,
+        singleColorHex: String,
         showIconName: Bool
     ) -> NSImage {
         let font = NSFont.systemFont(ofSize: 11, weight: .medium)
@@ -674,7 +746,10 @@ final class MenuBarIconRenderer {
         isDarkMode: Bool,
         useSystemColor: Bool = false,
         sessionTimeMarker: CGFloat? = nil,
-        weekTimeMarker: CGFloat? = nil
+        weekTimeMarker: CGFloat? = nil,
+        sessionPaceStatus: PaceStatus? = nil,
+        weekPaceStatus: PaceStatus? = nil,
+        showPaceMarker: Bool = false
     ) -> NSImage {
         let size: CGFloat = 24
         let image = NSImage(size: NSSize(width: size, height: size))
@@ -733,7 +808,7 @@ final class MenuBarIconRenderer {
             let tickPath = NSBezierPath()
             tickPath.move(to: NSPoint(x: center.x + innerR * cos(tickAngle), y: center.y + innerR * sin(tickAngle)))
             tickPath.line(to: NSPoint(x: center.x + outerR * cos(tickAngle), y: center.y + outerR * sin(tickAngle)))
-            drawTimeMarkerTick(tickPath, isDarkMode: isDarkMode)
+            drawPaceMarkerTick(tickPath, paceStatus: sessionPaceStatus, showPaceMarker: showPaceMarker, isDarkMode: isDarkMode)
         }
 
         // Inner ring (Week) - smaller radius, thinner stroke - Week is secondary
@@ -778,7 +853,7 @@ final class MenuBarIconRenderer {
             let tickPath = NSBezierPath()
             tickPath.move(to: NSPoint(x: center.x + innerR * cos(tickAngle), y: center.y + innerR * sin(tickAngle)))
             tickPath.line(to: NSPoint(x: center.x + outerR * cos(tickAngle), y: center.y + outerR * sin(tickAngle)))
-            drawTimeMarkerTick(tickPath, isDarkMode: isDarkMode)
+            drawPaceMarkerTick(tickPath, paceStatus: weekPaceStatus, showPaceMarker: showPaceMarker, isDarkMode: isDarkMode)
         }
 
         // Profile initial in center
@@ -808,7 +883,10 @@ final class MenuBarIconRenderer {
         isDarkMode: Bool,
         useSystemColor: Bool = false,
         sessionTimeMarker: CGFloat? = nil,
-        weekTimeMarker: CGFloat? = nil
+        weekTimeMarker: CGFloat? = nil,
+        sessionPaceStatus: PaceStatus? = nil,
+        weekPaceStatus: PaceStatus? = nil,
+        showPaceMarker: Bool = false
     ) -> NSImage {
         let circleSize: CGFloat = 20
         let labelHeight: CGFloat = 10
@@ -873,7 +951,7 @@ final class MenuBarIconRenderer {
             let tickPath = NSBezierPath()
             tickPath.move(to: NSPoint(x: circleCenter.x + innerR * cos(tickAngle), y: circleCenter.y + innerR * sin(tickAngle)))
             tickPath.line(to: NSPoint(x: circleCenter.x + outerR * cos(tickAngle), y: circleCenter.y + outerR * sin(tickAngle)))
-            drawTimeMarkerTick(tickPath, isDarkMode: isDarkMode)
+            drawPaceMarkerTick(tickPath, paceStatus: sessionPaceStatus, showPaceMarker: showPaceMarker, isDarkMode: isDarkMode)
         }
 
         // Inner ring (Week) - Week is secondary
@@ -918,7 +996,7 @@ final class MenuBarIconRenderer {
             let tickPath = NSBezierPath()
             tickPath.move(to: NSPoint(x: circleCenter.x + innerR * cos(tickAngle), y: circleCenter.y + innerR * sin(tickAngle)))
             tickPath.line(to: NSPoint(x: circleCenter.x + outerR * cos(tickAngle), y: circleCenter.y + outerR * sin(tickAngle)))
-            drawTimeMarkerTick(tickPath, isDarkMode: isDarkMode)
+            drawPaceMarkerTick(tickPath, paceStatus: weekPaceStatus, showPaceMarker: showPaceMarker, isDarkMode: isDarkMode)
         }
 
         // Profile label below the circle (first 3 characters)
@@ -949,7 +1027,10 @@ final class MenuBarIconRenderer {
         isDarkMode: Bool,
         useSystemColor: Bool = false,
         sessionTimeMarker: CGFloat? = nil,
-        weekTimeMarker: CGFloat? = nil
+        weekTimeMarker: CGFloat? = nil,
+        sessionPaceStatus: PaceStatus? = nil,
+        weekPaceStatus: PaceStatus? = nil,
+        showPaceMarker: Bool = false
     ) -> NSImage {
         let barWidth: CGFloat = 24
         let barHeight: CGFloat = 4
@@ -990,7 +1071,7 @@ final class MenuBarIconRenderer {
             let tickPath = NSBezierPath()
             tickPath.move(to: NSPoint(x: tickX, y: currentY))
             tickPath.line(to: NSPoint(x: tickX, y: currentY + barHeight))
-            drawTimeMarkerTick(tickPath, isDarkMode: isDarkMode)
+            drawPaceMarkerTick(tickPath, paceStatus: sessionPaceStatus, showPaceMarker: showPaceMarker, isDarkMode: isDarkMode)
         }
 
         // Week bar (if shown)
@@ -1011,7 +1092,7 @@ final class MenuBarIconRenderer {
                 let tickPath = NSBezierPath()
                 tickPath.move(to: NSPoint(x: tickX, y: currentY))
                 tickPath.line(to: NSPoint(x: tickX, y: currentY + barHeight))
-                drawTimeMarkerTick(tickPath, isDarkMode: isDarkMode)
+                drawPaceMarkerTick(tickPath, paceStatus: weekPaceStatus, showPaceMarker: showPaceMarker, isDarkMode: isDarkMode)
             }
         }
 
@@ -1040,14 +1121,18 @@ final class MenuBarIconRenderer {
         profileInitial: String?,
         monochromeMode: Bool,
         isDarkMode: Bool,
-        useSystemColor: Bool = false
+        useSystemColor: Bool = false,
+        paceStatus: PaceStatus? = nil,
+        showPaceMarker: Bool = false
     ) -> NSImage {
         let dotSize: CGFloat = 10
         let labelHeight: CGFloat = profileInitial != nil ? 10 : 0
         let spacing: CGFloat = profileInitial != nil ? 1 : 0
+        let hasPaceDot = showPaceMarker && paceStatus != nil
+        let paceDotExtra: CGFloat = hasPaceDot ? 6 : 0  // gap(2) + dot(4)
 
         let totalHeight = dotSize + spacing + labelHeight
-        let totalWidth = max(dotSize, 16)
+        let totalWidth = max(dotSize + paceDotExtra, 16)
 
         let image = NSImage(size: NSSize(width: totalWidth, height: totalHeight))
 
@@ -1058,15 +1143,26 @@ final class MenuBarIconRenderer {
         let foregroundColor = menuBarForegroundColor(isDarkMode: isDarkMode)
         let dotColor: NSColor = getColor(for: status, monochromeMode: monochromeMode, useSystemColor: useSystemColor, isDarkMode: isDarkMode)
 
-        // Draw dot
+        // Draw main status dot
+        let mainDotX = (totalWidth - dotSize - paceDotExtra) / 2
         let dotRect = NSRect(
-            x: (totalWidth - dotSize) / 2,
+            x: mainDotX,
             y: totalHeight - dotSize,
             width: dotSize,
             height: dotSize
         )
         dotColor.setFill()
         NSBezierPath(ovalIn: dotRect).fill()
+
+        // Pace dot next to main dot
+        if showPaceMarker, let pace = paceStatus {
+            let paceDotSize: CGFloat = 4.0
+            let paceDotX = mainDotX + dotSize + 2
+            let paceDotY = totalHeight - dotSize + (dotSize - paceDotSize) / 2
+            let paceDotPath = NSBezierPath(ovalIn: NSRect(x: paceDotX, y: paceDotY, width: paceDotSize, height: paceDotSize))
+            pace.color.setFill()
+            paceDotPath.fill()
+        }
 
         // Profile initial (if shown)
         if let initial = profileInitial {
@@ -1139,7 +1235,10 @@ final class MenuBarIconRenderer {
         profileName: String?,
         monochromeMode: Bool,
         isDarkMode: Bool,
-        useSystemColor: Bool = false
+        useSystemColor: Bool = false,
+        sessionPaceStatus: PaceStatus? = nil,
+        weekPaceStatus: PaceStatus? = nil,
+        showPaceMarker: Bool = false
     ) -> NSImage {
         let font = NSFont.monospacedDigitSystemFont(ofSize: 9, weight: .semibold)
         let foregroundColor = menuBarForegroundColor(isDarkMode: isDarkMode)
@@ -1172,9 +1271,11 @@ final class MenuBarIconRenderer {
         }
 
         let textSize = attributed.size()
+        let hasPaceDot = showPaceMarker && sessionPaceStatus != nil
+        let paceDotExtra: CGFloat = hasPaceDot ? 6 : 0  // gap(2) + dot(4)
         let labelHeight: CGFloat = profileName != nil ? 10 : 0
         let labelSpacing: CGFloat = profileName != nil ? 1 : 0
-        let totalWidth = max(textSize.width + 2, profileName != nil ? CGFloat(String(profileName!.prefix(3)).count) * 6 + 4 : 0)
+        let totalWidth = max(textSize.width + 2 + paceDotExtra, profileName != nil ? CGFloat(String(profileName!.prefix(3)).count) * 6 + 4 : 0)
         let totalHeight = textSize.height + labelSpacing + labelHeight
 
         let image = NSImage(size: NSSize(width: totalWidth, height: totalHeight))
@@ -1182,10 +1283,20 @@ final class MenuBarIconRenderer {
         image.lockFocus()
         defer { image.unlockFocus() }
 
-        // Draw percentage text at top, centered
-        let textX = (totalWidth - textSize.width) / 2
+        // Draw percentage text at top, centered (shift left slightly if pace dot present)
+        let textX = (totalWidth - textSize.width - paceDotExtra) / 2
         let textY = totalHeight - textSize.height
         attributed.draw(at: NSPoint(x: textX, y: textY))
+
+        // Pace dot after the percentage text
+        if showPaceMarker, let pace = sessionPaceStatus {
+            let dotSize: CGFloat = 4.0
+            let dotX = textX + textSize.width + 2
+            let dotY = textY + (textSize.height - dotSize) / 2
+            let dotPath = NSBezierPath(ovalIn: NSRect(x: dotX, y: dotY, width: dotSize, height: dotSize))
+            pace.color.setFill()
+            dotPath.fill()
+        }
 
         // Profile label below (if shown)
         if let name = profileName {
@@ -1222,6 +1333,24 @@ final class MenuBarIconRenderer {
         }
     }
 
+    /// Returns the appropriate color based on the color mode setting
+    /// - Parameters:
+    ///   - colorMode: The color mode to use
+    ///   - statusLevel: The usage status level (for multi-color mode)
+    ///   - singleColorHex: The custom hex color (for single color mode)
+    ///   - isDarkMode: Whether the menu bar is in dark mode
+    /// - Returns: The color to use for rendering
+    private func getColorForMode(_ colorMode: MenuBarColorMode, statusLevel: UsageStatusLevel, singleColorHex: String, isDarkMode: Bool) -> NSColor {
+        switch colorMode {
+        case .multiColor:
+            return getColorForStatusLevel(statusLevel)
+        case .monochrome:
+            return menuBarForegroundColor(isDarkMode: isDarkMode)
+        case .singleColor:
+            return NSColor(hex: singleColorHex) ?? NSColor.systemBlue
+        }
+    }
+
     /// Returns the appropriate color based on mode settings
     /// - Parameters:
     ///   - status: The usage status level
@@ -1237,11 +1366,24 @@ final class MenuBarIconRenderer {
         }
     }
 
-    /// Draws a time marker tick using the menu bar foreground color (same as text/outlines)
-    private func drawTimeMarkerTick(_ path: NSBezierPath, isDarkMode: Bool) {
-        menuBarForegroundColor(isDarkMode: isDarkMode).setStroke()
-        path.lineWidth = 1.5
-        path.lineCapStyle = .butt
+    /// Draws a pace-colored tick mark. When showPaceMarker is on and pace data is available,
+    /// the tick color reflects the 6-tier pace urgency (green→purple) regardless of color mode.
+    /// Otherwise falls back to the menu bar foreground color (current upstream behavior).
+    private func drawPaceMarkerTick(
+        _ path: NSBezierPath,
+        paceStatus: PaceStatus?,
+        showPaceMarker: Bool,
+        isDarkMode: Bool
+    ) {
+        let color: NSColor
+        if showPaceMarker, let pace = paceStatus {
+            color = pace.color
+        } else {
+            color = menuBarForegroundColor(isDarkMode: isDarkMode)
+        }
+        color.setStroke()
+        path.lineWidth = 2.0
+        path.lineCapStyle = .round
         path.stroke()
     }
 

--- a/Claude Usage/MenuBar/MenuBarManager.swift
+++ b/Claude Usage/MenuBar/MenuBarManager.swift
@@ -125,7 +125,8 @@ class MenuBarManager: NSObject, ObservableObject {
             let displayConfig: MenuBarIconConfiguration
             if !hasUsageCredentials {
                 displayConfig = MenuBarIconConfiguration(
-                    monochromeMode: config.monochromeMode,
+                    colorMode: config.colorMode,
+                    singleColorHex: config.singleColorHex,
                     showIconNames: config.showIconNames,
                     metrics: config.metrics.map { metric in
                         var updatedMetric = metric
@@ -420,7 +421,8 @@ class MenuBarManager: NSObject, ObservableObject {
         if !hasUsageCredentials {
             // Create config with no enabled metrics (will trigger default logo)
             displayConfig = MenuBarIconConfiguration(
-                monochromeMode: config.monochromeMode,
+                colorMode: config.colorMode,
+                singleColorHex: config.singleColorHex,
                 showIconNames: config.showIconNames,
                 metrics: config.metrics.map { metric in
                     var updatedMetric = metric
@@ -1007,7 +1009,8 @@ class MenuBarManager: NSObject, ObservableObject {
         let displayConfig: MenuBarIconConfiguration
         if !hasUsageCredentials {
             displayConfig = MenuBarIconConfiguration(
-                monochromeMode: config.monochromeMode,
+                colorMode: config.colorMode,
+                singleColorHex: config.singleColorHex,
                 showIconNames: config.showIconNames,
                 metrics: config.metrics.map { metric in
                     var updatedMetric = metric

--- a/Claude Usage/MenuBar/PopoverContentView.swift
+++ b/Claude Usage/MenuBar/PopoverContentView.swift
@@ -565,6 +565,13 @@ struct SmartUsageDashboard: View {
         return profileManager.activeProfile?.iconConfig.usePaceColoring ?? true
     }
 
+    private var showPaceMarker: Bool {
+        if profileManager.displayMode == .multi {
+            return profileManager.multiProfileConfig.showPaceMarker
+        }
+        return profileManager.activeProfile?.iconConfig.showPaceMarker ?? true
+    }
+
     private var timeDisplay: PopoverTimeDisplay {
         SharedDataStore.shared.loadPopoverTimeDisplay()
     }
@@ -580,6 +587,7 @@ struct SmartUsageDashboard: View {
                 resetTime: usage.sessionResetTime,
                 periodDuration: Constants.sessionWindow,
                 showTimeMarker: showTimeMarker,
+                showPaceMarker: showPaceMarker,
                 usePaceColoring: usePaceColoring,
                 timeDisplay: timeDisplay
             )
@@ -594,6 +602,7 @@ struct SmartUsageDashboard: View {
                 resetTime: usage.weeklyResetTime,
                 periodDuration: Constants.weeklyWindow,
                 showTimeMarker: showTimeMarker,
+                showPaceMarker: showPaceMarker,
                 usePaceColoring: usePaceColoring,
                 timeDisplay: timeDisplay
             )
@@ -673,6 +682,7 @@ struct UsageRow: View {
     let resetTime: Date?
     let periodDuration: TimeInterval?
     var showTimeMarker: Bool = true
+    var showPaceMarker: Bool = true
     var usePaceColoring: Bool = true
     var timeDisplay: PopoverTimeDisplay = .resetTime
 
@@ -694,6 +704,18 @@ struct UsageRow: View {
     private var timeMarkerFraction: CGFloat? {
         guard showTimeMarker, let f = rawElapsedFraction else { return nil }
         return CGFloat(showRemaining ? 1.0 - f : f)
+    }
+
+    private var paceStatus: PaceStatus? {
+        guard showPaceMarker, let elapsed = rawElapsedFraction else { return nil }
+        return PaceStatus.calculate(usedPercentage: usedPercentage, elapsedFraction: elapsed)
+    }
+
+    private var timeMarkerColor: Color {
+        if let pace = paceStatus {
+            return pace.swiftUIColor
+        }
+        return Color(nsColor: .labelColor)
     }
 
     private var statusLevel: UsageStatusLevel {
@@ -762,10 +784,10 @@ struct UsageRow: View {
                 }
                 .overlay(alignment: .leading) {
                     if let fraction = timeMarkerFraction {
-                        Rectangle()
-                            .fill(Color(nsColor: .labelColor))
-                            .frame(width: 1.5)
-                            .offset(x: round(geometry.size.width * fraction))
+                        RoundedRectangle(cornerRadius: 1)
+                            .fill(timeMarkerColor)
+                            .frame(width: 2.5, height: 8)
+                            .offset(x: round(geometry.size.width * fraction) - 0.75)
                     }
                 }
             }

--- a/Claude Usage/MenuBar/StatusBarUIManager.swift
+++ b/Claude Usage/MenuBar/StatusBarUIManager.swift
@@ -270,6 +270,16 @@ final class StatusBarUIManager {
                 ? weekElapsed.map { CGFloat(showRemaining ? 1.0 - $0 : $0) }
                 : nil
 
+            // Compute pace status for multi-profile rendering
+            let sessionPaceStatus: PaceStatus? = {
+                guard config.showPaceMarker, let elapsed = sessionElapsed else { return nil }
+                return PaceStatus.calculate(usedPercentage: sessionUsed, elapsedFraction: elapsed)
+            }()
+            let weekPaceStatus: PaceStatus? = {
+                guard config.showPaceMarker, let elapsed = weekElapsed else { return nil }
+                return PaceStatus.calculate(usedPercentage: weekUsed, elapsedFraction: elapsed)
+            }()
+
             // Create icon based on selected style
             let image: NSImage
             switch config.iconStyle {
@@ -285,7 +295,10 @@ final class StatusBarUIManager {
                         isDarkMode: menuBarIsDark,
                         useSystemColor: false,
                         sessionTimeMarker: sessionMarker,
-                        weekTimeMarker: config.showWeek ? weekMarker : nil
+                        weekTimeMarker: config.showWeek ? weekMarker : nil,
+                        sessionPaceStatus: sessionPaceStatus,
+                        weekPaceStatus: config.showWeek ? weekPaceStatus : nil,
+                        showPaceMarker: config.showPaceMarker
                     )
                 } else {
                     image = renderer.createConcentricIcon(
@@ -298,7 +311,10 @@ final class StatusBarUIManager {
                         isDarkMode: menuBarIsDark,
                         useSystemColor: false,
                         sessionTimeMarker: sessionMarker,
-                        weekTimeMarker: config.showWeek ? weekMarker : nil
+                        weekTimeMarker: config.showWeek ? weekMarker : nil,
+                        sessionPaceStatus: sessionPaceStatus,
+                        weekPaceStatus: config.showWeek ? weekPaceStatus : nil,
+                        showPaceMarker: config.showPaceMarker
                     )
                 }
             case .progressBar:
@@ -312,7 +328,10 @@ final class StatusBarUIManager {
                     isDarkMode: menuBarIsDark,
                     useSystemColor: false,
                     sessionTimeMarker: sessionMarker,
-                    weekTimeMarker: config.showWeek ? weekMarker : nil
+                    weekTimeMarker: config.showWeek ? weekMarker : nil,
+                    sessionPaceStatus: sessionPaceStatus,
+                    weekPaceStatus: config.showWeek ? weekPaceStatus : nil,
+                    showPaceMarker: config.showPaceMarker
                 )
             case .compact:
                 image = renderer.createCompactDot(
@@ -321,7 +340,9 @@ final class StatusBarUIManager {
                     profileInitial: config.showProfileLabel ? String(profile.name.prefix(1)) : nil,
                     monochromeMode: useMonochrome,
                     isDarkMode: menuBarIsDark,
-                    useSystemColor: false
+                    useSystemColor: false,
+                    paceStatus: sessionPaceStatus,
+                    showPaceMarker: config.showPaceMarker
                 )
             case .percentage:
                 image = renderer.createMultiProfilePercentage(
@@ -332,14 +353,15 @@ final class StatusBarUIManager {
                     profileName: config.showProfileLabel ? profile.name : nil,
                     monochromeMode: useMonochrome,
                     isDarkMode: menuBarIsDark,
-                    useSystemColor: false
+                    useSystemColor: false,
+                    sessionPaceStatus: sessionPaceStatus,
+                    weekPaceStatus: config.showWeek ? weekPaceStatus : nil,
+                    showPaceMarker: config.showPaceMarker
                 )
             }
 
+            image.isTemplate = useMonochrome && !config.showPaceMarker
             button.image = image
-            // Template mode only for monochrome (lets macOS handle color adaptation)
-            // Non-monochrome needs explicit colors for status indicators
-            button.image?.isTemplate = useMonochrome
         }
     }
 
@@ -426,15 +448,14 @@ final class StatusBarUIManager {
                 usage: usage,
                 apiUsage: apiUsage,
                 isDarkMode: menuBarIsDark,
-                monochromeMode: config.monochromeMode,
+                colorMode: config.colorMode,
+                singleColorHex: config.singleColorHex,
                 showIconName: config.showIconNames,
                 showNextSessionTime: metricConfig.showNextSessionTime
             )
 
+            image.isTemplate = config.colorMode == .monochrome && !config.showPaceMarker
             button.image = image
-            // Template mode only for monochrome (lets macOS handle color adaptation)
-            // Non-monochrome needs explicit colors for status indicators
-            button.image?.isTemplate = config.monochromeMode
         }
     }
 
@@ -466,15 +487,14 @@ final class StatusBarUIManager {
             usage: usage,
             apiUsage: apiUsage,
             isDarkMode: menuBarIsDark,
-            monochromeMode: config.monochromeMode,
+            colorMode: config.colorMode,
+            singleColorHex: config.singleColorHex,
             showIconName: config.showIconNames,
             showNextSessionTime: metricConfig.showNextSessionTime
         )
 
+        image.isTemplate = config.colorMode == .monochrome && !config.showPaceMarker
         button.image = image
-        // Template mode only for monochrome (lets macOS handle color adaptation)
-        // Non-monochrome needs explicit colors for status indicators
-        button.image?.isTemplate = config.monochromeMode
     }
 
     /// Get button for a specific metric (used for popover positioning)

--- a/Claude Usage/Resources/de.lproj/Localizable.strings
+++ b/Claude Usage/Resources/de.lproj/Localizable.strings
@@ -344,6 +344,8 @@
 "claudecode.component_context_tokens" = "Als Tokens anzeigen (statt %)";
 "claudecode.component_usage" = "Nutzungsstatistiken";
 "claudecode.component_progressbar" = "Fortschrittsbalken";
+"claudecode.component_pace_marker" = "Tempo-Markierung";
+"claudecode.pace_marker_info" = "Zeigt einen farbigen Strich an der verstrichenen Zeitposition";
 "claudecode.component_resettime" = "Zurücksetzungszeit";
 "claudecode.requirement_sessionkey" = "• Sitzungsschlüssel im Tab 'Anmeldedaten → Claude.ai' konfiguriert";
 "claudecode.requirement_restart" = "• Claude CLI nach Anwendung der Änderungen neu starten";
@@ -425,10 +427,14 @@
 "appearance.show_labels_description" = "Präfix-Labels (S:, W:, API:) für jede Metrik anzeigen";
 "appearance.show_remaining_title" = "Verbleibender Prozentsatz anzeigen";
 "appearance.show_remaining_description" = "Verbleibende Kapazität statt genutzter Prozentsatz anzeigen (wie macOS-Batterie)";
+"appearance.pace_marker_section_title" = "Tempomarkierung";
+"appearance.pace_marker_section_subtitle" = "Nutzungstempo relativ zu Zurücksetzungszeiträumen verfolgen";
 "appearance.show_time_marker_title" = "Zeitverlaufsmarkierung anzeigen";
 "appearance.show_time_marker_description" = "Eine Markierung auf Fortschrittsbalken anzeigen, die den Zeitfortschritt im Zeitraum zeigt";
-"appearance.pace_coloring_title" = "Tempobasierte Farbgebung";
-"appearance.pace_coloring_description" = "Indikatoren basierend auf dem prognostizierten Nutzungstempo einfärben. Wenn deaktiviert, spiegeln die Farben nur die aktuelle Nutzung wider.";
+"appearance.show_pace_marker_title" = "Markierung nach Tempo einfärben";
+"appearance.show_pace_marker_description" = "Die Zeitmarkierung nach dem prognostizierten Nutzungstempo einfärben (grün → lila). Gilt für Sitzungs- und Wochenmetriken.";
+"appearance.pace_coloring_title" = "Tempobasierte Balkenfarben";
+"appearance.pace_coloring_description" = "Fortschrittsbalken basierend auf dem prognostizierten Tempo statt dem aktuellen Nutzungsniveau einfärben. Prognostiziert, ob Limits bis zum Ende des Zeitraums erreicht werden.";
 "appearance.multiprofile_locked_title" = "Darstellungseinstellungen gesperrt";
 "appearance.multiprofile_locked_description" = "Diese Einstellungen sind deaktiviert, während die Mehrfach-Profil-Anzeige aktiv ist. Jedes Profil verwendet im Mehrfach-Profil-Modus seine eigene Darstellung.";
 "appearance.disable_multiprofile" = "Mehrfach-Profil-Anzeige ausschalten";

--- a/Claude Usage/Resources/en.lproj/Localizable.strings
+++ b/Claude Usage/Resources/en.lproj/Localizable.strings
@@ -366,7 +366,7 @@
 "claudecode.component_usage" = "Usage statistics";
 "claudecode.component_progressbar" = "Progress bar";
 "claudecode.component_pace_marker" = "Pace marker";
-"claudecode.pace_marker_info" = "Shows a colored tick at the elapsed time position";
+"claudecode.pace_marker_info" = "Colored by projected usage pace (green → purple)";
 "claudecode.component_resettime" = "Reset time";
 "claudecode.requirement_sessionkey" = "• Session key configured in Credentials → Claude.ai tab";
 "claudecode.requirement_restart" = "• Restart Claude CLI after applying changes";

--- a/Claude Usage/Resources/en.lproj/Localizable.strings
+++ b/Claude Usage/Resources/en.lproj/Localizable.strings
@@ -365,6 +365,8 @@
 "claudecode.component_context_tokens" = "Show as tokens (instead of %)";
 "claudecode.component_usage" = "Usage statistics";
 "claudecode.component_progressbar" = "Progress bar";
+"claudecode.component_pace_marker" = "Pace marker";
+"claudecode.pace_marker_info" = "Shows a colored tick at the elapsed time position";
 "claudecode.component_resettime" = "Reset time";
 "claudecode.requirement_sessionkey" = "• Session key configured in Credentials → Claude.ai tab";
 "claudecode.requirement_restart" = "• Restart Claude CLI after applying changes";
@@ -446,10 +448,14 @@
 "appearance.show_labels_description" = "Display prefix labels (S:, W:, API:) for each metric";
 "appearance.show_remaining_title" = "Show Remaining Percentage";
 "appearance.show_remaining_description" = "Display remaining capacity instead of used percentage (like macOS battery)";
-"appearance.show_time_marker_title" = "Show Time-Elapsed Marker";
+"appearance.pace_marker_section_title" = "Pace Marker";
+"appearance.pace_marker_section_subtitle" = "Track usage pace relative to reset periods";
+"appearance.show_time_marker_title" = "Show Time Marker";
 "appearance.show_time_marker_description" = "Display a tick mark on progress bars showing how far through the time period you are";
-"appearance.pace_coloring_title" = "Pace-Aware Coloring";
-"appearance.pace_coloring_description" = "Color indicators based on projected usage pace. When off, colors reflect current usage only.";
+"appearance.show_pace_marker_title" = "Color Marker by Pace";
+"appearance.show_pace_marker_description" = "Color the time marker based on projected usage pace (green → purple). Applies to session and weekly metrics.";
+"appearance.pace_coloring_title" = "Pace-Aware Bar Colors";
+"appearance.pace_coloring_description" = "Color progress bars based on projected pace instead of current usage level. Projects whether you'll hit limits by the end of the period.";
 "appearance.multiprofile_locked_title" = "Appearance Settings Locked";
 "appearance.multiprofile_locked_description" = "These settings are disabled while Multi-Profile Display is active. Each profile uses its own appearance in multi-profile mode.";
 "appearance.disable_multiprofile" = "Turn Off Multi-Profile Display";

--- a/Claude Usage/Resources/es.lproj/Localizable.strings
+++ b/Claude Usage/Resources/es.lproj/Localizable.strings
@@ -343,6 +343,8 @@
 "claudecode.component_context_tokens" = "Mostrar como tokens (en lugar de %)";
 "claudecode.component_usage" = "Estadísticas de uso";
 "claudecode.component_progressbar" = "Barra de progreso";
+"claudecode.component_pace_marker" = "Marcador de ritmo";
+"claudecode.pace_marker_info" = "Muestra una marca de color en la posición del tiempo transcurrido";
 "claudecode.component_resettime" = "Tiempo de reinicio";
 "claudecode.requirement_sessionkey" = "• Clave de sesión configurada en Credenciales → pestaña Claude.ai";
 "claudecode.requirement_restart" = "• Reiniciar Claude CLI después de aplicar cambios";
@@ -412,10 +414,14 @@
 "appearance.show_labels_description" = "Mostrar etiquetas de prefijo (S:, W:, API:) para cada métrica";
 "appearance.show_remaining_title" = "Mostrar Porcentaje Restante";
 "appearance.show_remaining_description" = "Mostrar capacidad restante en lugar del porcentaje usado (como la batería de macOS)";
+"appearance.pace_marker_section_title" = "Marcador de Ritmo";
+"appearance.pace_marker_section_subtitle" = "Seguimiento del ritmo de uso relativo a los períodos de reinicio";
 "appearance.show_time_marker_title" = "Mostrar marcador de tiempo transcurrido";
 "appearance.show_time_marker_description" = "Mostrar una marca en las barras de progreso indicando cuánto tiempo del período ha pasado";
-"appearance.pace_coloring_title" = "Coloración según ritmo";
-"appearance.pace_coloring_description" = "Colorear indicadores según el ritmo de uso proyectado. Cuando está desactivado, los colores reflejan solo el uso actual.";
+"appearance.show_pace_marker_title" = "Colorear marcador por ritmo";
+"appearance.show_pace_marker_description" = "Colorea el marcador de tiempo según el ritmo de uso proyectado (verde → púrpura). Aplica a métricas de sesión y semanales.";
+"appearance.pace_coloring_title" = "Colores de barra por ritmo";
+"appearance.pace_coloring_description" = "Colorear barras de progreso según el ritmo proyectado en lugar del nivel de uso actual. Proyecta si alcanzarás los límites al final del período.";
 "appearance.multiprofile_locked_title" = "Ajustes de Apariencia Bloqueados";
 "appearance.multiprofile_locked_description" = "Estos ajustes están deshabilitados mientras la Visualización Multi-Perfil está activa. Cada perfil usa su propia apariencia en modo multi-perfil.";
 "appearance.disable_multiprofile" = "Desactivar Visualización Multi-Perfil";

--- a/Claude Usage/Resources/fr.lproj/Localizable.strings
+++ b/Claude Usage/Resources/fr.lproj/Localizable.strings
@@ -340,6 +340,8 @@
 "claudecode.component_context_tokens" = "Afficher en tokens (au lieu de %)";
 "claudecode.component_usage" = "Statistiques d'utilisation";
 "claudecode.component_progressbar" = "Barre de progression";
+"claudecode.component_pace_marker" = "Marqueur de rythme";
+"claudecode.pace_marker_info" = "Affiche un repère coloré à la position du temps écoulé";
 "claudecode.component_resettime" = "Heure de réinitialisation";
 "claudecode.requirement_sessionkey" = "• Clé de session configurée dans Identifiants → onglet Claude.ai";
 "claudecode.requirement_restart" = "• Redémarrez Claude CLI après l'application des modifications";
@@ -409,10 +411,14 @@
 "appearance.show_labels_description" = "Afficher les étiquettes de préfixe (S:, W:, API:) pour chaque métrique";
 "appearance.show_remaining_title" = "Afficher le Pourcentage Restant";
 "appearance.show_remaining_description" = "Afficher la capacité restante au lieu du pourcentage utilisé (comme la batterie macOS)";
+"appearance.pace_marker_section_title" = "Marqueur de Rythme";
+"appearance.pace_marker_section_subtitle" = "Suivre le rythme d'utilisation par rapport aux périodes de réinitialisation";
 "appearance.show_time_marker_title" = "Afficher le marqueur de temps écoulé";
 "appearance.show_time_marker_description" = "Afficher un repère sur les barres de progression indiquant la progression dans la période";
-"appearance.pace_coloring_title" = "Coloration selon le rythme";
-"appearance.pace_coloring_description" = "Colorer les indicateurs selon le rythme d'utilisation projeté. Désactivé, les couleurs reflètent uniquement l'utilisation actuelle.";
+"appearance.show_pace_marker_title" = "Colorer le marqueur par rythme";
+"appearance.show_pace_marker_description" = "Colore le marqueur de temps selon le rythme d'utilisation projeté (vert → violet). S'applique aux métriques de session et hebdomadaires.";
+"appearance.pace_coloring_title" = "Couleurs de barre par rythme";
+"appearance.pace_coloring_description" = "Colorer les barres de progression selon le rythme projeté au lieu du niveau d'utilisation actuel. Projette si vous atteindrez les limites d'ici la fin de la période.";
 "appearance.multiprofile_locked_title" = "Paramètres d'Apparence Verrouillés";
 "appearance.multiprofile_locked_description" = "Ces paramètres sont désactivés pendant que l'Affichage Multi-Profil est actif. Chaque profil utilise sa propre apparence en mode multi-profil.";
 "appearance.disable_multiprofile" = "Désactiver l'Affichage Multi-Profil";

--- a/Claude Usage/Resources/it.lproj/Localizable.strings
+++ b/Claude Usage/Resources/it.lproj/Localizable.strings
@@ -342,6 +342,8 @@
 "claudecode.component_context_tokens" = "Mostra come token (invece di %)";
 "claudecode.component_usage" = "Statistiche utilizzo";
 "claudecode.component_progressbar" = "Barra di progresso";
+"claudecode.component_pace_marker" = "Indicatore di ritmo";
+"claudecode.pace_marker_info" = "Mostra un segno colorato nella posizione del tempo trascorso";
 "claudecode.component_resettime" = "Ora di ripristino";
 "claudecode.requirement_sessionkey" = "• Chiave di sessione configurata in Credenziali → scheda Claude.ai";
 "claudecode.requirement_restart" = "• Riavvia Claude CLI dopo aver applicato le modifiche";
@@ -423,10 +425,14 @@
 "appearance.show_labels_description" = "Visualizza etichette prefisso (S:, W:, API:) per ogni metrica";
 "appearance.show_remaining_title" = "Mostra Percentuale Rimanente";
 "appearance.show_remaining_description" = "Visualizza la capacità rimanente invece della percentuale utilizzata (come la batteria macOS)";
-"appearance.show_time_marker_title" = "Mostra indicatore tempo trascorso";
+"appearance.pace_marker_section_title" = "Marcatore di Ritmo";
+"appearance.pace_marker_section_subtitle" = "Monitora il ritmo di utilizzo rispetto ai periodi di reset";
+"appearance.show_time_marker_title" = "Mostra marcatore tempo";
 "appearance.show_time_marker_description" = "Mostra un segno sulle barre di avanzamento che indica quanto tempo del periodo è trascorso";
-"appearance.pace_coloring_title" = "Colorazione basata sul ritmo";
-"appearance.pace_coloring_description" = "Colora gli indicatori in base al ritmo di utilizzo previsto. Quando disattivato, i colori riflettono solo l'utilizzo attuale.";
+"appearance.show_pace_marker_title" = "Colora marcatore per ritmo";
+"appearance.show_pace_marker_description" = "Colora il marcatore del tempo in base al ritmo di utilizzo previsto (verde → viola). Si applica alle metriche di sessione e settimanali.";
+"appearance.pace_coloring_title" = "Colori barra per ritmo";
+"appearance.pace_coloring_description" = "Colora le barre di avanzamento in base al ritmo previsto invece del livello di utilizzo attuale. Prevede se raggiungerai i limiti entro la fine del periodo.";
 "appearance.multiprofile_locked_title" = "Impostazioni Aspetto Bloccate";
 "appearance.multiprofile_locked_description" = "Queste impostazioni sono disabilitate mentre la Visualizzazione Multi-Profilo è attiva. Ogni profilo usa la propria apparenza in modalità multi-profilo.";
 "appearance.disable_multiprofile" = "Disattiva Visualizzazione Multi-Profilo";

--- a/Claude Usage/Resources/ja.lproj/Localizable.strings
+++ b/Claude Usage/Resources/ja.lproj/Localizable.strings
@@ -358,6 +358,8 @@
 "claudecode.component_context_tokens" = "トークンで表示（%の代わり）";
 "claudecode.component_usage" = "使用統計";
 "claudecode.component_progressbar" = "プログレスバー";
+"claudecode.component_pace_marker" = "ペースマーカー";
+"claudecode.pace_marker_info" = "経過時間位置にカラーマークを表示";
 "claudecode.component_resettime" = "リセット時刻";
 "claudecode.requirement_sessionkey" = "• 認証情報 → Claude.aiタブでセッションキーが構成されている";
 "claudecode.requirement_restart" = "• 変更適用後にClaude CLIを再起動";
@@ -439,10 +441,14 @@
 "appearance.show_labels_description" = "各メトリクスのプレフィックスラベル（S:、W:、API:）を表示";
 "appearance.show_remaining_title" = "残り容量のパーセンテージを表示";
 "appearance.show_remaining_description" = "使用済みパーセンテージの代わりに残り容量を表示（macOSバッテリーのように）";
+"appearance.pace_marker_section_title" = "ペースマーカー";
+"appearance.pace_marker_section_subtitle" = "リセット期間に対する使用ペースを追跡";
 "appearance.show_time_marker_title" = "経過時間マーカーを表示";
 "appearance.show_time_marker_description" = "プログレスバーに期間内の経過時間を示すマーカーを表示します";
-"appearance.pace_coloring_title" = "ペース対応カラーリング";
-"appearance.pace_coloring_description" = "予測される使用ペースに基づいてインジケーターを色分けします。オフの場合、色は現在の使用量のみを反映します。";
+"appearance.show_pace_marker_title" = "ペースでマーカーを色分け";
+"appearance.show_pace_marker_description" = "予測使用ペースに基づいてタイムマーカーを色分けします（緑→紫）。セッションと週間メトリクスに適用されます。";
+"appearance.pace_coloring_title" = "ペース対応バーカラー";
+"appearance.pace_coloring_description" = "現在の使用レベルではなく予測ペースに基づいてプログレスバーを色分けします。期間終了までにリミットに達するかを予測します。";
 "appearance.multiprofile_locked_title" = "外観設定がロックされています";
 "appearance.multiprofile_locked_description" = "マルチプロファイル表示がアクティブな間、これらの設定は無効になっています。マルチプロファイルモードでは各プロファイルが独自の外観を使用します。";
 "appearance.disable_multiprofile" = "マルチプロファイル表示をオフにする";

--- a/Claude Usage/Resources/ko.lproj/Localizable.strings
+++ b/Claude Usage/Resources/ko.lproj/Localizable.strings
@@ -181,10 +181,14 @@
 "appearance.show_labels_description" = "각 메트릭에 접두사 레이블(S:, W:, API:) 표시";
 "appearance.show_remaining_title" = "남은 용량 퍼센트 표시";
 "appearance.show_remaining_description" = "사용된 퍼센트 대신 남은 용량 표시 (macOS 배터리처럼)";
+"appearance.pace_marker_section_title" = "속도 마커";
+"appearance.pace_marker_section_subtitle" = "초기화 기간 대비 사용 속도 추적";
 "appearance.show_time_marker_title" = "경과 시간 마커 표시";
 "appearance.show_time_marker_description" = "진행 막대에 기간 내 경과 시간을 나타내는 마커를 표시합니다";
-"appearance.pace_coloring_title" = "속도 기반 색상";
-"appearance.pace_coloring_description" = "예상 사용 속도에 따라 표시기 색상을 지정합니다. 비활성화 시 색상은 현재 사용량만 반영합니다.";
+"appearance.show_pace_marker_title" = "속도별 마커 색상";
+"appearance.show_pace_marker_description" = "예상 사용 속도에 따라 시간 마커 색상을 변경합니다(녹색→보라색). 세션 및 주간 메트릭에 적용됩니다.";
+"appearance.pace_coloring_title" = "속도 기반 막대 색상";
+"appearance.pace_coloring_description" = "현재 사용 수준 대신 예상 속도에 따라 진행 막대 색상을 지정합니다. 기간 종료 시 한도에 도달할지 예측합니다.";
 "appearance.multiprofile_locked_title" = "모양 설정 잠김";
 "appearance.multiprofile_locked_description" = "다중 프로필 표시가 활성화된 동안 이 설정은 비활성화됩니다. 다중 프로필 모드에서는 각 프로필이 자체 모양을 사용합니다.";
 "appearance.disable_multiprofile" = "다중 프로필 표시 끄기";
@@ -490,6 +494,8 @@
 "claudecode.component_branch" = "Git 브랜치";
 "claudecode.component_usage" = "사용 통계";
 "claudecode.component_progressbar" = "진행률 표시줄";
+"claudecode.component_pace_marker" = "페이스 마커";
+"claudecode.pace_marker_info" = "경과 시간 위치에 색상 표시를 보여줍니다";
 "claudecode.component_resettime" = "리셋 시간";
 "claudecode.requirement_sessionkey" = "• 자격 증명 → Claude.ai 탭에서 세션 키 구성됨";
 "claudecode.requirement_restart" = "• 변경사항 적용 후 Claude CLI 재시작";

--- a/Claude Usage/Resources/pt.lproj/Localizable.strings
+++ b/Claude Usage/Resources/pt.lproj/Localizable.strings
@@ -342,6 +342,8 @@
 "claudecode.component_context_tokens" = "Mostrar como tokens (em vez de %)";
 "claudecode.component_usage" = "Estatísticas de uso";
 "claudecode.component_progressbar" = "Barra de progresso";
+"claudecode.component_pace_marker" = "Marcador de ritmo";
+"claudecode.pace_marker_info" = "Mostra uma marca colorida na posição do tempo decorrido";
 "claudecode.component_resettime" = "Hora de reinício";
 "claudecode.requirement_sessionkey" = "• Chave de sessão configurada em Credenciais → aba Claude.ai";
 "claudecode.requirement_restart" = "• Reiniciar Claude CLI após aplicar as alterações";
@@ -423,10 +425,14 @@
 "appearance.show_labels_description" = "Exibir rótulos de prefixo (S:, W:, API:) para cada métrica";
 "appearance.show_remaining_title" = "Mostrar Porcentagem Restante";
 "appearance.show_remaining_description" = "Exibir capacidade restante em vez da porcentagem usada (como a bateria do macOS)";
-"appearance.show_time_marker_title" = "Mostrar marcador de tempo decorrido";
+"appearance.pace_marker_section_title" = "Marcador de Ritmo";
+"appearance.pace_marker_section_subtitle" = "Acompanhe o ritmo de uso em relação aos períodos de reinício";
+"appearance.show_time_marker_title" = "Mostrar marcador de tempo";
 "appearance.show_time_marker_description" = "Exibir uma marca nas barras de progresso mostrando quanto do período de tempo já passou";
-"appearance.pace_coloring_title" = "Coloração baseada no ritmo";
-"appearance.pace_coloring_description" = "Colorir indicadores com base no ritmo de uso projetado. Quando desativado, as cores refletem apenas o uso atual.";
+"appearance.show_pace_marker_title" = "Colorir marcador por ritmo";
+"appearance.show_pace_marker_description" = "Colore o marcador de tempo pelo ritmo de uso projetado (verde → roxo). Aplica-se a métricas de sessão e semanais.";
+"appearance.pace_coloring_title" = "Cores de barra por ritmo";
+"appearance.pace_coloring_description" = "Colorir barras de progresso com base no ritmo projetado em vez do nível de uso atual. Projeta se você atingirá os limites até o final do período.";
 "appearance.multiprofile_locked_title" = "Configurações de Aparência Bloqueadas";
 "appearance.multiprofile_locked_description" = "Estas configurações estão desativadas enquanto a Exibição Multi-Perfil está ativa. Cada perfil usa sua própria aparência no modo multi-perfil.";
 "appearance.disable_multiprofile" = "Desativar Exibição Multi-Perfil";

--- a/Claude Usage/Resources/zh-ch.lproj/Localizable.strings
+++ b/Claude Usage/Resources/zh-ch.lproj/Localizable.strings
@@ -358,6 +358,8 @@
 "claudecode.component_context_tokens" = "显示为令牌（而不是 %）";
 "claudecode.component_usage" = "使用统计";
 "claudecode.component_progressbar" = "进度条";
+"claudecode.component_pace_marker" = "节奏标记";
+"claudecode.pace_marker_info" = "在已用时间位置显示彩色标记";
 "claudecode.component_resettime" = "重置时间";
 "claudecode.requirement_sessionkey" = "• 在凭据 → Claude.ai 标签页中配置了会话密钥";
 "claudecode.requirement_restart" = "• 应用更改后重启 Claude CLI";
@@ -439,10 +441,14 @@
 "appearance.show_labels_description" = "为每个指标显示前缀标签（S:, W:, API:）";
 "appearance.show_remaining_title" = "显示剩余百分比";
 "appearance.show_remaining_description" = "显示剩余容量而不是已使用百分比（类似 macOS 电池）";
+"appearance.pace_marker_section_title" = "节奏标记";
+"appearance.pace_marker_section_subtitle" = "跟踪相对于重置周期的使用节奏";
 "appearance.show_time_marker_title" = "显示时间进度标记";
 "appearance.show_time_marker_description" = "在进度条上显示标记，指示当前时间段已经过去多少时间";
-"appearance.pace_coloring_title" = "基于节奏的着色";
-"appearance.pace_coloring_description" = "根据预测的使用节奏为指示器着色。关闭时，颜色仅反映当前使用量。";
+"appearance.show_pace_marker_title" = "按速率着色标记";
+"appearance.show_pace_marker_description" = "根据预计使用速率为时间标记着色（绿色→紫色）。适用于会话和每周指标。";
+"appearance.pace_coloring_title" = "基于节奏的进度条颜色";
+"appearance.pace_coloring_description" = "根据预测节奏而非当前使用水平为进度条着色。预测您是否会在周期结束前达到限制。";
 "appearance.multiprofile_locked_title" = "外观设置已锁定";
 "appearance.multiprofile_locked_description" = "当多配置文件显示处于活动状态时，这些设置被禁用。在多配置文件模式下，每个配置文件使用自己的外观。";
 "appearance.disable_multiprofile" = "关闭多配置文件显示";

--- a/Claude Usage/Shared/Extensions/Color+Extensions.swift
+++ b/Claude Usage/Shared/Extensions/Color+Extensions.swift
@@ -1,0 +1,112 @@
+//
+//  Color+Extensions.swift
+//  Claude Usage
+//
+//  Color utilities for hex conversion
+//
+
+import SwiftUI
+import Cocoa
+
+extension Color {
+    /// Initialize a Color from a hex string (e.g., "#FF5733" or "FF5733")
+    init?(hex: String) {
+        var hexSanitized = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+        hexSanitized = hexSanitized.replacingOccurrences(of: "#", with: "")
+
+        var rgb: UInt64 = 0
+
+        guard Scanner(string: hexSanitized).scanHexInt64(&rgb) else {
+            return nil
+        }
+
+        let length = hexSanitized.count
+
+        switch length {
+        case 6: // RGB (24-bit)
+            self.init(
+                red: Double((rgb & 0xFF0000) >> 16) / 255.0,
+                green: Double((rgb & 0x00FF00) >> 8) / 255.0,
+                blue: Double(rgb & 0x0000FF) / 255.0
+            )
+        case 8: // RGBA (32-bit)
+            self.init(
+                red: Double((rgb & 0xFF000000) >> 24) / 255.0,
+                green: Double((rgb & 0x00FF0000) >> 16) / 255.0,
+                blue: Double((rgb & 0x0000FF00) >> 8) / 255.0,
+                opacity: Double(rgb & 0x000000FF) / 255.0
+            )
+        default:
+            return nil
+        }
+    }
+
+    /// Convert Color to hex string (e.g., "#FF5733")
+    var hexString: String {
+        guard let components = NSColor(self).usingColorSpace(.sRGB)?.cgColor.components else {
+            return "#000000"
+        }
+
+        let r = components.count > 0 ? components[0] : 0
+        let g = components.count > 1 ? components[1] : 0
+        let b = components.count > 2 ? components[2] : 0
+
+        return String(format: "#%02X%02X%02X",
+                      Int(r * 255),
+                      Int(g * 255),
+                      Int(b * 255))
+    }
+
+    /// Convert Color to hex string (e.g., "#FF5733") - method variant for compatibility
+    func toHex() -> String? {
+        guard let components = NSColor(self).usingColorSpace(.sRGB)?.cgColor.components else {
+            return nil
+        }
+
+        let r = components.count > 0 ? components[0] : 0
+        let g = components.count > 1 ? components[1] : 0
+        let b = components.count > 2 ? components[2] : 0
+
+        return String(format: "#%02X%02X%02X",
+                      Int(r * 255),
+                      Int(g * 255),
+                      Int(b * 255))
+    }
+}
+
+// MARK: - NSColor Hex Extension
+
+extension NSColor {
+    /// Initialize an NSColor from a hex string (e.g., "#FF5733" or "FF5733")
+    convenience init?(hex: String) {
+        var hexSanitized = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+        hexSanitized = hexSanitized.replacingOccurrences(of: "#", with: "")
+
+        var rgb: UInt64 = 0
+
+        guard Scanner(string: hexSanitized).scanHexInt64(&rgb) else {
+            return nil
+        }
+
+        let length = hexSanitized.count
+
+        switch length {
+        case 6: // RGB (24-bit)
+            self.init(
+                red: CGFloat((rgb & 0xFF0000) >> 16) / 255.0,
+                green: CGFloat((rgb & 0x00FF00) >> 8) / 255.0,
+                blue: CGFloat(rgb & 0x0000FF) / 255.0,
+                alpha: 1.0
+            )
+        case 8: // RGBA (32-bit)
+            self.init(
+                red: CGFloat((rgb & 0xFF000000) >> 24) / 255.0,
+                green: CGFloat((rgb & 0x00FF0000) >> 16) / 255.0,
+                blue: CGFloat((rgb & 0x0000FF00) >> 8) / 255.0,
+                alpha: CGFloat(rgb & 0x000000FF) / 255.0
+            )
+        default:
+            return nil
+        }
+    }
+}

--- a/Claude Usage/Shared/Extensions/Date+Extensions.swift
+++ b/Claude Usage/Shared/Extensions/Date+Extensions.swift
@@ -92,4 +92,11 @@ extension Date {
         let hours = Int(ceil(interval / 3600))  // Round up to next hour
         return "→\(hours)H"
     }
+
+    /// Rounds date down to nearest minute (strips seconds)
+    func roundedToNearestMinute() -> Date {
+        let calendar = Calendar.current
+        let components = calendar.dateComponents([.year, .month, .day, .hour, .minute], from: self)
+        return calendar.date(from: components) ?? self
+    }
 }

--- a/Claude Usage/Shared/Models/MenuBarIconConfig.swift
+++ b/Claude Usage/Shared/Models/MenuBarIconConfig.swift
@@ -60,6 +60,46 @@ enum MenuBarMetricType: String, Codable, CaseIterable, Identifiable {
     }
 }
 
+/// Color mode for menu bar icons
+enum MenuBarColorMode: String, Codable, CaseIterable {
+    case multiColor = "multiColor"
+    case monochrome = "monochrome"
+    case singleColor = "singleColor"
+
+    var displayName: String {
+        switch self {
+        case .multiColor:
+            return "Multi-Color"
+        case .monochrome:
+            return "Greyscale"
+        case .singleColor:
+            return "Single Color"
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .multiColor:
+            return "Green, orange, red based on usage level"
+        case .monochrome:
+            return "Adapts to menu bar appearance"
+        case .singleColor:
+            return "Custom color of your choice"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .multiColor:
+            return "paintpalette.fill"
+        case .monochrome:
+            return "circle.lefthalf.filled"
+        case .singleColor:
+            return "paintbrush.fill"
+        }
+    }
+}
+
 /// Display mode for API usage
 enum APIDisplayMode: String, Codable, CaseIterable {
     case remaining
@@ -249,6 +289,7 @@ struct MultiProfileDisplayConfig: Codable, Equatable {
     var showProfileLabel: Bool // Show profile name below icon
     var useSystemColor: Bool  // If true, use system accent color instead of status colors
     var showTimeMarker: Bool  // If true, show time-elapsed tick mark on progress indicators
+    var showPaceMarker: Bool  // If true, color time marker by projected usage pace (6-tier)
     var usePaceColoring: Bool // If true, color indicators based on projected usage pace
 
     init(
@@ -257,6 +298,7 @@ struct MultiProfileDisplayConfig: Codable, Equatable {
         showProfileLabel: Bool = true,
         useSystemColor: Bool = false,
         showTimeMarker: Bool = true,
+        showPaceMarker: Bool = true,
         usePaceColoring: Bool = true
     ) {
         self.iconStyle = iconStyle
@@ -264,6 +306,7 @@ struct MultiProfileDisplayConfig: Codable, Equatable {
         self.showProfileLabel = showProfileLabel
         self.useSystemColor = useSystemColor
         self.showTimeMarker = showTimeMarker
+        self.showPaceMarker = showPaceMarker
         self.usePaceColoring = usePaceColoring
     }
 
@@ -275,6 +318,7 @@ struct MultiProfileDisplayConfig: Codable, Equatable {
         case showProfileLabel
         case useSystemColor
         case showTimeMarker
+        case showPaceMarker
         case usePaceColoring
     }
 
@@ -287,7 +331,8 @@ struct MultiProfileDisplayConfig: Codable, Equatable {
         // New properties - provide default values if missing (backwards compatibility)
         useSystemColor = try container.decodeIfPresent(Bool.self, forKey: .useSystemColor) ?? false
         showTimeMarker = try container.decodeIfPresent(Bool.self, forKey: .showTimeMarker) ?? true
-        usePaceColoring = try container.decodeIfPresent(Bool.self, forKey: .usePaceColoring) ?? true
+        showPaceMarker = try container.decodeIfPresent(Bool.self, forKey: .showPaceMarker) ?? false
+        usePaceColoring = try container.decodeIfPresent(Bool.self, forKey: .usePaceColoring) ?? false
     }
 
     static var `default`: MultiProfileDisplayConfig {
@@ -297,18 +342,22 @@ struct MultiProfileDisplayConfig: Codable, Equatable {
 
 /// Global menu bar icon configuration
 struct MenuBarIconConfiguration: Codable, Equatable {
-    var monochromeMode: Bool
+    var colorMode: MenuBarColorMode
+    var singleColorHex: String
     var showIconNames: Bool
     var showRemainingPercentage: Bool
     var showTimeMarker: Bool
+    var showPaceMarker: Bool
     var usePaceColoring: Bool
     var metrics: [MetricIconConfig]
 
     init(
-        monochromeMode: Bool = false,
+        colorMode: MenuBarColorMode = .multiColor,
+        singleColorHex: String = "#00BFFF",
         showIconNames: Bool = true,
         showRemainingPercentage: Bool = false,
         showTimeMarker: Bool = true,
+        showPaceMarker: Bool = true,
         usePaceColoring: Bool = true,
         metrics: [MetricIconConfig] = [
             .sessionDefault,
@@ -316,10 +365,12 @@ struct MenuBarIconConfiguration: Codable, Equatable {
             .apiDefault
         ]
     ) {
-        self.monochromeMode = monochromeMode
+        self.colorMode = colorMode
+        self.singleColorHex = singleColorHex
         self.showIconNames = showIconNames
         self.showRemainingPercentage = showRemainingPercentage
         self.showTimeMarker = showTimeMarker
+        self.showPaceMarker = showPaceMarker
         self.usePaceColoring = usePaceColoring
         self.metrics = metrics
     }
@@ -327,10 +378,13 @@ struct MenuBarIconConfiguration: Codable, Equatable {
     // MARK: - Codable (Custom decoder for backwards compatibility)
 
     enum CodingKeys: String, CodingKey {
-        case monochromeMode
+        case monochromeMode  // Legacy key for backwards compatibility
+        case colorMode
+        case singleColorHex
         case showIconNames
         case showRemainingPercentage
         case showTimeMarker
+        case showPaceMarker
         case usePaceColoring
         case metrics
     }
@@ -338,15 +392,33 @@ struct MenuBarIconConfiguration: Codable, Equatable {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        monochromeMode = try container.decode(Bool.self, forKey: .monochromeMode)
-        showIconNames = try container.decode(Bool.self, forKey: .showIconNames)
+        // Handle backwards compatibility: if old monochromeMode exists, convert it
+        if let monochromeMode = try container.decodeIfPresent(Bool.self, forKey: .monochromeMode) {
+            colorMode = monochromeMode ? .monochrome : .multiColor
+        } else {
+            colorMode = try container.decodeIfPresent(MenuBarColorMode.self, forKey: .colorMode) ?? .multiColor
+        }
 
-        // New property - provide default value if missing (backwards compatibility)
+        singleColorHex = try container.decodeIfPresent(String.self, forKey: .singleColorHex) ?? "#00BFFF"
+        showIconNames = try container.decode(Bool.self, forKey: .showIconNames)
         showRemainingPercentage = try container.decodeIfPresent(Bool.self, forKey: .showRemainingPercentage) ?? false
         showTimeMarker = try container.decodeIfPresent(Bool.self, forKey: .showTimeMarker) ?? true
-        usePaceColoring = try container.decodeIfPresent(Bool.self, forKey: .usePaceColoring) ?? true
-
+        showPaceMarker = try container.decodeIfPresent(Bool.self, forKey: .showPaceMarker) ?? false
+        usePaceColoring = try container.decodeIfPresent(Bool.self, forKey: .usePaceColoring) ?? false
         metrics = try container.decode([MetricIconConfig].self, forKey: .metrics)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(colorMode, forKey: .colorMode)
+        try container.encode(singleColorHex, forKey: .singleColorHex)
+        try container.encode(showIconNames, forKey: .showIconNames)
+        try container.encode(showRemainingPercentage, forKey: .showRemainingPercentage)
+        try container.encode(showTimeMarker, forKey: .showTimeMarker)
+        try container.encode(showPaceMarker, forKey: .showPaceMarker)
+        try container.encode(usePaceColoring, forKey: .usePaceColoring)
+        try container.encode(metrics, forKey: .metrics)
+        // Note: We don't encode monochromeMode anymore - it's only for reading legacy data
     }
 
     /// Get enabled metrics sorted by order

--- a/Claude Usage/Shared/Models/StatuslineColorMode.swift
+++ b/Claude Usage/Shared/Models/StatuslineColorMode.swift
@@ -1,0 +1,53 @@
+//
+//  StatuslineColorMode.swift
+//  Claude Usage
+//
+//  Statusline color mode for Claude Code integration
+//
+
+import Foundation
+
+/// Statusline color mode for Claude Code integration
+enum StatuslineColorMode: String, Codable, CaseIterable {
+    /// Multi-colored elements (default terminal colors)
+    case colored = "colored"
+
+    /// Monochrome/adaptive (uses terminal's default text color)
+    case monochrome = "monochrome"
+
+    /// Single user-selected color for all elements
+    case singleColor = "singleColor"
+
+    var displayName: String {
+        switch self {
+        case .colored:
+            return "Multi-Color"
+        case .monochrome:
+            return "Greyscale"
+        case .singleColor:
+            return "Single Color"
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .colored:
+            return "Threshold-based colors"
+        case .monochrome:
+            return "Adapts to system theme"
+        case .singleColor:
+            return "Custom color for all"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .colored:
+            return "paintpalette.fill"
+        case .monochrome:
+            return "circle.lefthalf.filled"
+        case .singleColor:
+            return "eyedropper.halffull"
+        }
+    }
+}

--- a/Claude Usage/Shared/Services/StatuslineService.swift
+++ b/Claude Usage/Shared/Services/StatuslineService.swift
@@ -123,12 +123,16 @@ if [ -f "$config_file" ]; then
   context_as_tokens=$CONTEXT_AS_TOKENS
   show_usage=$SHOW_USAGE
   show_bar=$SHOW_PROGRESS_BAR
+  show_pace_marker=$SHOW_PACE_MARKER
   show_reset=$SHOW_RESET_TIME
+  use_24h=$USE_24_HOUR_TIME
+  show_context_label=$SHOW_CONTEXT_LABEL
+  show_usage_label=$SHOW_USAGE_LABEL
+  show_reset_label=$SHOW_RESET_LABEL
+  color_mode=$COLOR_MODE
+  single_color=$SINGLE_COLOR
   show_profile=$SHOW_PROFILE
   profile_name="$PROFILE_NAME"
-  show_pace_marker=$SHOW_PACE_MARKER
-  color_mode=$COLOR_MODE
-  show_context_label=$SHOW_CONTEXT_LABEL
   pace_marker_step_colors=$PACE_MARKER_STEP_COLORS
 else
   show_model=1
@@ -138,12 +142,16 @@ else
   context_as_tokens=0
   show_usage=1
   show_bar=1
+  show_pace_marker=1
   show_reset=1
+  use_24h=0
+  show_context_label=1
+  show_usage_label=1
+  show_reset_label=1
+  color_mode="colored"
+  single_color="#00BFFF"
   show_profile=0
   profile_name=""
-  show_pace_marker=1
-  color_mode=multi
-  show_context_label=1
   pace_marker_step_colors=1
 fi
 
@@ -152,48 +160,98 @@ current_dir_path=$(echo "$input" | grep -o '"current_dir":"[^"]*"' | sed 's/"cur
 current_dir=$(basename "$current_dir_path")
 model=$(echo "$input" | grep -o '"display_name":"[^"]*"' | sed 's/"display_name":"//;s/"$//')
 
-BLUE=$'\\033[0;34m'
-GREEN=$'\\033[0;32m'
-GRAY=$'\\033[0;90m'
-YELLOW=$'\\033[0;33m'
-CYAN=$'\\033[0;36m'
-MAGENTA=$'\\033[0;35m'
+# Function to convert hex color to ANSI escape code
+hex_to_ansi() {
+  local hex=$1
+  hex=${hex#\\#}
+
+  local r=$((16#${hex:0:2}))
+  local g=$((16#${hex:2:2}))
+  local b=$((16#${hex:4:2}))
+
+  printf '\\033[38;2;%d;%d;%dm' "$r" "$g" "$b"
+}
+
+# Set colors based on mode
 RESET=$'\\033[0m'
 
-# 10-level gradient: dark green → deep red
-LEVEL_1=$'\\033[38;5;22m'   # dark green
-LEVEL_2=$'\\033[38;5;28m'   # soft green
-LEVEL_3=$'\\033[38;5;34m'   # medium green
-LEVEL_4=$'\\033[38;5;100m'  # green-yellowish dark
-LEVEL_5=$'\\033[38;5;142m'  # olive/yellow-green dark
-LEVEL_6=$'\\033[38;5;178m'  # muted yellow
-LEVEL_7=$'\\033[38;5;172m'  # muted yellow-orange
-LEVEL_8=$'\\033[38;5;166m'  # darker orange
-LEVEL_9=$'\\033[38;5;160m'  # dark red
-LEVEL_10=$'\\033[38;5;124m' # deep red
+if [ "$color_mode" = "monochrome" ]; then
+  # Monochrome mode - no colors
+  BLUE=""
+  GREEN=""
+  GRAY=""
+  YELLOW=""
+  CYAN=""
+  MAGENTA=""
+  LEVEL_1=""
+  LEVEL_2=""
+  LEVEL_3=""
+  LEVEL_4=""
+  LEVEL_5=""
+  LEVEL_6=""
+  LEVEL_7=""
+  LEVEL_8=""
+  LEVEL_9=""
+  LEVEL_10=""
+  PACE_COMFORTABLE=""
+  PACE_ON_TRACK=""
+  PACE_WARMING=""
+  PACE_PRESSING=""
+  PACE_CRITICAL=""
+  PACE_RUNAWAY=""
+elif [ "$color_mode" = "singleColor" ]; then
+  # Single color mode - use user's chosen color for everything
+  single_ansi=$(hex_to_ansi "$single_color")
+  BLUE=$single_ansi
+  GREEN=$single_ansi
+  GRAY=$single_ansi
+  YELLOW=$single_ansi
+  CYAN=$single_ansi
+  MAGENTA=$single_ansi
+  LEVEL_1=$single_ansi
+  LEVEL_2=$single_ansi
+  LEVEL_3=$single_ansi
+  LEVEL_4=$single_ansi
+  LEVEL_5=$single_ansi
+  LEVEL_6=$single_ansi
+  LEVEL_7=$single_ansi
+  LEVEL_8=$single_ansi
+  LEVEL_9=$single_ansi
+  LEVEL_10=$single_ansi
+  PACE_COMFORTABLE=$single_ansi
+  PACE_ON_TRACK=$single_ansi
+  PACE_WARMING=$single_ansi
+  PACE_PRESSING=$single_ansi
+  PACE_CRITICAL=$single_ansi
+  PACE_RUNAWAY=$single_ansi
+else
+  # Colored mode (default) - use full color palette
+  BLUE=$'\\033[0;34m'
+  GREEN=$'\\033[0;32m'
+  GRAY=$'\\033[0;90m'
+  YELLOW=$'\\033[0;33m'
+  CYAN=$'\\033[0;36m'
+  MAGENTA=$'\\033[0;35m'
 
-# 6-tier pace colors
-PACE_COMFORTABLE=$'\\033[38;5;34m'   # green
-PACE_ON_TRACK=$'\\033[38;5;37m'      # teal
-PACE_WARMING=$'\\033[38;5;178m'      # yellow
-PACE_PRESSING=$'\\033[38;5;208m'     # orange
-PACE_CRITICAL=$'\\033[38;5;160m'     # red
-PACE_RUNAWAY=$'\\033[38;5;135m'      # purple
+  # 10-level gradient: dark green → deep red
+  LEVEL_1=$'\\033[38;5;22m'   # dark green
+  LEVEL_2=$'\\033[38;5;28m'   # soft green
+  LEVEL_3=$'\\033[38;5;34m'   # medium green
+  LEVEL_4=$'\\033[38;5;100m'  # green-yellowish dark
+  LEVEL_5=$'\\033[38;5;142m'  # olive/yellow-green dark
+  LEVEL_6=$'\\033[38;5;178m'  # muted yellow
+  LEVEL_7=$'\\033[38;5;172m'  # muted yellow-orange
+  LEVEL_8=$'\\033[38;5;166m'  # darker orange
+  LEVEL_9=$'\\033[38;5;160m'  # dark red
+  LEVEL_10=$'\\033[38;5;124m' # deep red
 
-# Color mode overrides
-if [ "$color_mode" = "mono" ]; then
-  BLUE="$RESET"; GREEN="$RESET"; GRAY="$RESET"; YELLOW="$RESET"
-  CYAN="$RESET"; MAGENTA="$RESET"
-  LEVEL_1="$RESET"; LEVEL_2="$RESET"; LEVEL_3="$RESET"; LEVEL_4="$RESET"
-  LEVEL_5="$RESET"; LEVEL_6="$RESET"; LEVEL_7="$RESET"; LEVEL_8="$RESET"
-  LEVEL_9="$RESET"; LEVEL_10="$RESET"
-  PACE_COMFORTABLE="$RESET"; PACE_ON_TRACK="$RESET"; PACE_WARMING="$RESET"
-  PACE_PRESSING="$RESET"; PACE_CRITICAL="$RESET"; PACE_RUNAWAY="$RESET"
-elif [ "$color_mode" = "usage" ]; then
-  BLUE="$RESET"; GREEN="$RESET"; GRAY="$RESET"; YELLOW="$RESET"
-  CYAN="$RESET"; MAGENTA="$RESET"
-  PACE_COMFORTABLE="$RESET"; PACE_ON_TRACK="$RESET"; PACE_WARMING="$RESET"
-  PACE_PRESSING="$RESET"; PACE_CRITICAL="$RESET"; PACE_RUNAWAY="$RESET"
+  # 6-tier pace marker colors
+  PACE_COMFORTABLE=$'\\033[38;5;34m'  # green
+  PACE_ON_TRACK=$'\\033[38;5;37m'     # teal
+  PACE_WARMING=$'\\033[38;5;178m'     # yellow
+  PACE_PRESSING=$'\\033[38;5;208m'    # orange
+  PACE_CRITICAL=$'\\033[38;5;160m'    # red
+  PACE_RUNAWAY=$'\\033[38;5;135m'     # purple
 fi
 
 # When pace step colors enabled, always use real 6-tier colors regardless of color mode
@@ -258,10 +316,10 @@ if [ "$show_context" = "1" ]; then
     # Integer percentage for display
     context_int=$context_pct
 
+    # Display as tokens or percentage
     ctx_label=""
     [ "$show_context_label" = "1" ] && ctx_label="Ctx: "
 
-    # Display as tokens or percentage
     if [ "$context_as_tokens" = "1" ]; then
       if [ "$current_tokens" -ge 1000 ]; then
         tokens_k=$((current_tokens / 1000))
@@ -304,6 +362,13 @@ if [ "$show_usage" = "1" ]; then
     utilization=$(echo "$swift_result" | cut -d'|' -f1)
     resets_at=$(echo "$swift_result" | cut -d'|' -f2)
 
+    # Parse reset epoch once for shared use by pace marker and reset time display
+      reset_epoch=""
+      if [ -n "$resets_at" ] && [ "$resets_at" != "null" ]; then
+        iso_time=$(echo "$resets_at" | sed 's/\\.[0-9]*Z$//')
+        reset_epoch=$(date -ju -f "%Y-%m-%dT%H:%M:%S" "$iso_time" "+%s" 2>/dev/null)
+      fi
+
     if [ -n "$utilization" ] && [ "$utilization" != "ERROR" ]; then
       if [ "$utilization" -le 10 ]; then
         usage_color="$LEVEL_1"
@@ -340,7 +405,7 @@ if [ "$show_usage" = "1" ]; then
         empty_blocks=$((10 - filled_blocks))
 
         # Build progress bar safely without seq
-        progress_bar=""
+        progress_bar=" "
         i=0
         while [ $i -lt $filled_blocks ]; do
           progress_bar="${progress_bar}▓"
@@ -351,87 +416,101 @@ if [ "$show_usage" = "1" ]; then
           progress_bar="${progress_bar}░"
           i=$((i + 1))
         done
-
-        # Insert pace marker into progress bar
-        if [ "$show_pace_marker" = "1" ] && [ -n "$resets_at" ] && [ "$resets_at" != "null" ]; then
-          iso_reset=$(echo "$resets_at" | sed 's/\\.[0-9]*Z$//')
-          reset_epoch=$(date -ju -f "%Y-%m-%dT%H:%M:%S" "$iso_reset" "+%s" 2>/dev/null)
-          if [ -n "$reset_epoch" ]; then
-            now_epoch=$(date +%s)
-            remaining_secs=$((reset_epoch - now_epoch))
-            if [ "$remaining_secs" -gt 0 ] && [ "$remaining_secs" -lt 18000 ]; then
-              elapsed_secs=$((18000 - remaining_secs))
-              marker_pos=$(( (elapsed_secs * 10 + 9000) / 18000 ))
-              [ "$marker_pos" -lt 0 ] && marker_pos=0
-              [ "$marker_pos" -gt 9 ] && marker_pos=9
-
-              # Determine pace color from 6-tier system
-              elapsed_frac_x100=$((elapsed_secs * 100 / 18000))
-              if [ "$elapsed_frac_x100" -gt 0 ]; then
-                projected=$((utilization * 100 / elapsed_frac_x100))
-              else
-                projected=0
-              fi
-
-              if [ "$projected" -lt 50 ]; then
-                pace_color="$PACE_COMFORTABLE"
-              elif [ "$projected" -lt 75 ]; then
-                pace_color="$PACE_ON_TRACK"
-              elif [ "$projected" -lt 90 ]; then
-                pace_color="$PACE_WARMING"
-              elif [ "$projected" -lt 100 ]; then
-                pace_color="$PACE_PRESSING"
-              elif [ "$projected" -lt 120 ]; then
-                pace_color="$PACE_CRITICAL"
-              else
-                pace_color="$PACE_RUNAWAY"
-              fi
-
-              # Override: use usage bar color if step colors disabled
-              if [ "$pace_marker_step_colors" = "0" ]; then
-                pace_color="$usage_color"
-              fi
-
-              if [ -n "$pace_color" ]; then
-                left=$(echo "$progress_bar" | cut -c1-${marker_pos})
-                right_start=$((marker_pos + 2))
-                right=$(echo "$progress_bar" | cut -c${right_start}-)
-                progress_bar="${left}${pace_color}┃${RESET}${usage_color}${right}"
-              fi
-            fi
-          fi
-        fi
-
-        progress_bar=" ${progress_bar}"
       else
         progress_bar=""
       fi
 
+      # Pace marker: insert colored │ at elapsed time position
+      if [ "$show_pace_marker" = "1" ] && [ "$show_bar" = "1" ] && [ -n "$reset_epoch" ]; then
+        now_epoch=$(date +%s)
+        remaining=$((reset_epoch - now_epoch))
+        if [ $remaining -gt 0 ] && [ $remaining -lt 18000 ]; then
+          elapsed_secs=$((18000 - remaining))
+          marker_pos=$(( (elapsed_secs * 10 + 9000) / 18000 ))
+          [ $marker_pos -gt 9 ] && marker_pos=9
+          [ $marker_pos -lt 0 ] && marker_pos=0
+
+          # Compute 6-tier pace color (integer math, >= 15% elapsed = 2700s)
+          pace_color=""
+          if [ $elapsed_secs -ge 2700 ]; then
+            projected_pct=$((utilization * 18000 / elapsed_secs))
+            if [ $projected_pct -lt 50 ]; then
+              pace_color="$PACE_COMFORTABLE"
+            elif [ $projected_pct -lt 75 ]; then
+              pace_color="$PACE_ON_TRACK"
+            elif [ $projected_pct -lt 90 ]; then
+              pace_color="$PACE_WARMING"
+            elif [ $projected_pct -lt 100 ]; then
+              pace_color="$PACE_PRESSING"
+            elif [ $projected_pct -lt 120 ]; then
+              pace_color="$PACE_CRITICAL"
+            else
+              pace_color="$PACE_RUNAWAY"
+            fi
+          fi
+
+          # Override: use usage bar color if step colors disabled
+          if [ "$pace_marker_step_colors" = "0" ]; then
+            pace_color="$usage_color"
+          fi
+
+          if [ -n "$pace_color" ]; then
+            # Replace bar character at marker_pos with bold ┃
+            # progress_bar = " " + 10 block chars; marker_pos+1 is the target index
+            left="${progress_bar:0:$((marker_pos + 1))}"
+            right="${progress_bar:$((marker_pos + 2))}"
+            progress_bar="${left}${pace_color}┃${RESET}${usage_color}${right}"
+          fi
+        fi
+      fi
+
       reset_time_display=""
-      if [ "$show_reset" = "1" ] && [ -n "$resets_at" ] && [ "$resets_at" != "null" ]; then
-        iso_time=$(echo "$resets_at" | sed 's/\\.[0-9]*Z$//')
-        epoch=$(date -ju -f "%Y-%m-%dT%H:%M:%S" "$iso_time" "+%s" 2>/dev/null)
+      if [ "$show_reset" = "1" ] && [ -n "$reset_epoch" ]; then
+        epoch=$reset_epoch
 
         if [ -n "$epoch" ]; then
-          # Detect system time format (12h vs 24h) from macOS locale preferences
-          time_format=$(defaults read -g AppleICUForce24HourTime 2>/dev/null)
-          if [ "$time_format" = "1" ]; then
+          # Round to nearest minute to prevent pinballing (e.g., 6:59:45 -> 7:00)
+          seconds_part=$((epoch % 60))
+          if [ "$seconds_part" -ge 30 ]; then
+            epoch=$((epoch + (60 - seconds_part)))
+          else
+            epoch=$((epoch - seconds_part))
+          fi
+
+          # Use user's time format preference from config
+          if [ "$use_24h" = "1" ]; then
             # 24-hour format
             reset_time=$(date -r "$epoch" "+%H:%M" 2>/dev/null)
           else
             # 12-hour format (default)
             reset_time=$(date -r "$epoch" "+%I:%M %p" 2>/dev/null)
           fi
-          [ -n "$reset_time" ] && reset_time_display=$(printf " → Reset: %s" "$reset_time")
+          if [ "$show_reset_label" = "1" ]; then
+            [ -n "$reset_time" ] && reset_time_display=$(printf " → Reset: %s" "$reset_time")
+          else
+            [ -n "$reset_time" ] && reset_time_display=$(printf " → %s" "$reset_time")
+          fi
         fi
       fi
 
-      usage_text="${usage_color}Usage: ${utilization}%${progress_bar}${reset_time_display}${RESET}"
+      if [ "$show_usage_label" = "1" ]; then
+        usage_text="${usage_color}Usage: ${utilization}%${progress_bar}${reset_time_display}${RESET}"
+      else
+        usage_text="${usage_color}${utilization}%${progress_bar}${reset_time_display}${RESET}"
+      fi
     else
-      usage_text="${YELLOW}Usage: ~${RESET}"
+      if [ "$show_usage_label" = "1" ]; then
+        usage_text="${YELLOW}Usage: ~${RESET}"
+      else
+        usage_text="${YELLOW}~${RESET}"
+      fi
     fi
   else
-    usage_text="${YELLOW}Usage: ~${RESET}"
+    if [ "$show_usage_label" = "1" ]; then
+      usage_text="${YELLOW}Usage: ~${RESET}"
+    else
+      usage_text="${YELLOW}~${RESET}"
+    fi
   fi
 fi
 
@@ -525,6 +604,8 @@ printf "%s\\n" "$output"
             [.posixPermissions: 0o755],
             ofItemAtPath: bashDestination.path
         )
+
+        print("[StatuslineService] Bash script installed to: \(bashDestination.path)")
     }
 
     /// Removes the session key from the statusline Swift script
@@ -552,16 +633,30 @@ printf "%s\\n" "$output"
         contextAsTokens: Bool,
         showUsage: Bool,
         showProgressBar: Bool,
-        showResetTime: Bool,
-        showProfile: Bool,
-        profileName: String,
         showPaceMarker: Bool = true,
-        colorMode: String = "multi",
         paceMarkerStepColors: Bool = true,
-        showContextLabel: Bool = true
+        showResetTime: Bool,
+        use24HourTime: Bool = false,
+        showContextLabel: Bool = true,
+        showUsageLabel: Bool = true,
+        showResetLabel: Bool = true,
+        colorMode: StatuslineColorMode = .colored,
+        singleColorHex: String = "#00BFFF",
+        showProfile: Bool,
+        profileName: String
     ) throws {
         let configPath = Constants.ClaudePaths.claudeDirectory
             .appendingPathComponent("statusline-config.txt")
+
+        let colorModeString: String
+        switch colorMode {
+        case .colored:
+            colorModeString = "colored"
+        case .monochrome:
+            colorModeString = "monochrome"
+        case .singleColor:
+            colorModeString = "singleColor"
+        }
 
         let config = """
 SHOW_MODEL=\(showModel ? "1" : "0")
@@ -571,16 +666,24 @@ SHOW_CONTEXT=\(showContext ? "1" : "0")
 CONTEXT_AS_TOKENS=\(contextAsTokens ? "1" : "0")
 SHOW_USAGE=\(showUsage ? "1" : "0")
 SHOW_PROGRESS_BAR=\(showProgressBar ? "1" : "0")
+SHOW_PACE_MARKER=\(showPaceMarker ? "1" : "0")
+PACE_MARKER_STEP_COLORS=\(paceMarkerStepColors ? "1" : "0")
 SHOW_RESET_TIME=\(showResetTime ? "1" : "0")
+USE_24_HOUR_TIME=\(use24HourTime ? "1" : "0")
+SHOW_CONTEXT_LABEL=\(showContextLabel ? "1" : "0")
+SHOW_USAGE_LABEL=\(showUsageLabel ? "1" : "0")
+SHOW_RESET_LABEL=\(showResetLabel ? "1" : "0")
+COLOR_MODE=\(colorModeString)
+SINGLE_COLOR=\(singleColorHex)
 SHOW_PROFILE=\(showProfile ? "1" : "0")
 PROFILE_NAME="\(profileName)"
-SHOW_PACE_MARKER=\(showPaceMarker ? "1" : "0")
-COLOR_MODE=\(colorMode)
-PACE_MARKER_STEP_COLORS=\(paceMarkerStepColors ? "1" : "0")
-SHOW_CONTEXT_LABEL=\(showContextLabel ? "1" : "0")
 """
 
         try config.write(to: configPath, atomically: true, encoding: .utf8)
+
+        // Debug: Log what was written
+        print("[StatuslineService] Config written to: \(configPath.path)")
+        print("[StatuslineService] Config content:\n\(config)")
     }
 
     /// Updates only the profile name in the statusline config file.

--- a/Claude Usage/Shared/Services/StatuslineService.swift
+++ b/Claude Usage/Shared/Services/StatuslineService.swift
@@ -126,6 +126,10 @@ if [ -f "$config_file" ]; then
   show_reset=$SHOW_RESET_TIME
   show_profile=$SHOW_PROFILE
   profile_name="$PROFILE_NAME"
+  show_pace_marker=$SHOW_PACE_MARKER
+  color_mode=$COLOR_MODE
+  show_context_label=$SHOW_CONTEXT_LABEL
+  pace_marker_step_colors=$PACE_MARKER_STEP_COLORS
 else
   show_model=1
   show_dir=1
@@ -137,6 +141,10 @@ else
   show_reset=1
   show_profile=0
   profile_name=""
+  show_pace_marker=1
+  color_mode=multi
+  show_context_label=1
+  pace_marker_step_colors=1
 fi
 
 input=$(cat)
@@ -163,6 +171,40 @@ LEVEL_7=$'\\033[38;5;172m'  # muted yellow-orange
 LEVEL_8=$'\\033[38;5;166m'  # darker orange
 LEVEL_9=$'\\033[38;5;160m'  # dark red
 LEVEL_10=$'\\033[38;5;124m' # deep red
+
+# 6-tier pace colors
+PACE_COMFORTABLE=$'\\033[38;5;34m'   # green
+PACE_ON_TRACK=$'\\033[38;5;37m'      # teal
+PACE_WARMING=$'\\033[38;5;178m'      # yellow
+PACE_PRESSING=$'\\033[38;5;208m'     # orange
+PACE_CRITICAL=$'\\033[38;5;160m'     # red
+PACE_RUNAWAY=$'\\033[38;5;135m'      # purple
+
+# Color mode overrides
+if [ "$color_mode" = "mono" ]; then
+  BLUE="$RESET"; GREEN="$RESET"; GRAY="$RESET"; YELLOW="$RESET"
+  CYAN="$RESET"; MAGENTA="$RESET"
+  LEVEL_1="$RESET"; LEVEL_2="$RESET"; LEVEL_3="$RESET"; LEVEL_4="$RESET"
+  LEVEL_5="$RESET"; LEVEL_6="$RESET"; LEVEL_7="$RESET"; LEVEL_8="$RESET"
+  LEVEL_9="$RESET"; LEVEL_10="$RESET"
+  PACE_COMFORTABLE="$RESET"; PACE_ON_TRACK="$RESET"; PACE_WARMING="$RESET"
+  PACE_PRESSING="$RESET"; PACE_CRITICAL="$RESET"; PACE_RUNAWAY="$RESET"
+elif [ "$color_mode" = "usage" ]; then
+  BLUE="$RESET"; GREEN="$RESET"; GRAY="$RESET"; YELLOW="$RESET"
+  CYAN="$RESET"; MAGENTA="$RESET"
+  PACE_COMFORTABLE="$RESET"; PACE_ON_TRACK="$RESET"; PACE_WARMING="$RESET"
+  PACE_PRESSING="$RESET"; PACE_CRITICAL="$RESET"; PACE_RUNAWAY="$RESET"
+fi
+
+# When pace step colors enabled, always use real 6-tier colors regardless of color mode
+if [ "$pace_marker_step_colors" != "0" ]; then
+  PACE_COMFORTABLE=$'\\033[38;5;34m'
+  PACE_ON_TRACK=$'\\033[38;5;37m'
+  PACE_WARMING=$'\\033[38;5;178m'
+  PACE_PRESSING=$'\\033[38;5;208m'
+  PACE_CRITICAL=$'\\033[38;5;160m'
+  PACE_RUNAWAY=$'\\033[38;5;135m'
+fi
 
 # Build components (without separators)
 dir_text=""
@@ -216,16 +258,19 @@ if [ "$show_context" = "1" ]; then
     # Integer percentage for display
     context_int=$context_pct
 
+    ctx_label=""
+    [ "$show_context_label" = "1" ] && ctx_label="Ctx: "
+
     # Display as tokens or percentage
     if [ "$context_as_tokens" = "1" ]; then
       if [ "$current_tokens" -ge 1000 ]; then
         tokens_k=$((current_tokens / 1000))
-        context_text="${context_color}Ctx: ${tokens_k}K${RESET}"
+        context_text="${context_color}${ctx_label}${tokens_k}K${RESET}"
       else
-        context_text="${context_color}Ctx: ${current_tokens}${RESET}"
+        context_text="${context_color}${ctx_label}${current_tokens}${RESET}"
       fi
     else
-      context_text="${context_color}Ctx: ${context_int}%${RESET}"
+      context_text="${context_color}${ctx_label}${context_int}%${RESET}"
     fi
   fi
 fi
@@ -295,7 +340,7 @@ if [ "$show_usage" = "1" ]; then
         empty_blocks=$((10 - filled_blocks))
 
         # Build progress bar safely without seq
-        progress_bar=" "
+        progress_bar=""
         i=0
         while [ $i -lt $filled_blocks ]; do
           progress_bar="${progress_bar}▓"
@@ -306,6 +351,58 @@ if [ "$show_usage" = "1" ]; then
           progress_bar="${progress_bar}░"
           i=$((i + 1))
         done
+
+        # Insert pace marker into progress bar
+        if [ "$show_pace_marker" = "1" ] && [ -n "$resets_at" ] && [ "$resets_at" != "null" ]; then
+          iso_reset=$(echo "$resets_at" | sed 's/\\.[0-9]*Z$//')
+          reset_epoch=$(date -ju -f "%Y-%m-%dT%H:%M:%S" "$iso_reset" "+%s" 2>/dev/null)
+          if [ -n "$reset_epoch" ]; then
+            now_epoch=$(date +%s)
+            remaining_secs=$((reset_epoch - now_epoch))
+            if [ "$remaining_secs" -gt 0 ] && [ "$remaining_secs" -lt 18000 ]; then
+              elapsed_secs=$((18000 - remaining_secs))
+              marker_pos=$(( (elapsed_secs * 10 + 9000) / 18000 ))
+              [ "$marker_pos" -lt 0 ] && marker_pos=0
+              [ "$marker_pos" -gt 9 ] && marker_pos=9
+
+              # Determine pace color from 6-tier system
+              elapsed_frac_x100=$((elapsed_secs * 100 / 18000))
+              if [ "$elapsed_frac_x100" -gt 0 ]; then
+                projected=$((utilization * 100 / elapsed_frac_x100))
+              else
+                projected=0
+              fi
+
+              if [ "$projected" -lt 50 ]; then
+                pace_color="$PACE_COMFORTABLE"
+              elif [ "$projected" -lt 75 ]; then
+                pace_color="$PACE_ON_TRACK"
+              elif [ "$projected" -lt 90 ]; then
+                pace_color="$PACE_WARMING"
+              elif [ "$projected" -lt 100 ]; then
+                pace_color="$PACE_PRESSING"
+              elif [ "$projected" -lt 120 ]; then
+                pace_color="$PACE_CRITICAL"
+              else
+                pace_color="$PACE_RUNAWAY"
+              fi
+
+              # Override: use usage bar color if step colors disabled
+              if [ "$pace_marker_step_colors" = "0" ]; then
+                pace_color="$usage_color"
+              fi
+
+              if [ -n "$pace_color" ]; then
+                left=$(echo "$progress_bar" | cut -c1-${marker_pos})
+                right_start=$((marker_pos + 2))
+                right=$(echo "$progress_bar" | cut -c${right_start}-)
+                progress_bar="${left}${pace_color}┃${RESET}${usage_color}${right}"
+              fi
+            fi
+          fi
+        fi
+
+        progress_bar=" ${progress_bar}"
       else
         progress_bar=""
       fi
@@ -457,7 +554,11 @@ printf "%s\\n" "$output"
         showProgressBar: Bool,
         showResetTime: Bool,
         showProfile: Bool,
-        profileName: String
+        profileName: String,
+        showPaceMarker: Bool = true,
+        colorMode: String = "multi",
+        paceMarkerStepColors: Bool = true,
+        showContextLabel: Bool = true
     ) throws {
         let configPath = Constants.ClaudePaths.claudeDirectory
             .appendingPathComponent("statusline-config.txt")
@@ -473,6 +574,10 @@ SHOW_PROGRESS_BAR=\(showProgressBar ? "1" : "0")
 SHOW_RESET_TIME=\(showResetTime ? "1" : "0")
 SHOW_PROFILE=\(showProfile ? "1" : "0")
 PROFILE_NAME="\(profileName)"
+SHOW_PACE_MARKER=\(showPaceMarker ? "1" : "0")
+COLOR_MODE=\(colorMode)
+PACE_MARKER_STEP_COLORS=\(paceMarkerStepColors ? "1" : "0")
+SHOW_CONTEXT_LABEL=\(showContextLabel ? "1" : "0")
 """
 
         try config.write(to: configPath, atomically: true, encoding: .utf8)

--- a/Claude Usage/Shared/Services/StatuslineService.swift
+++ b/Claude Usage/Shared/Services/StatuslineService.swift
@@ -430,9 +430,9 @@ if [ "$show_usage" = "1" ]; then
           [ $marker_pos -gt 9 ] && marker_pos=9
           [ $marker_pos -lt 0 ] && marker_pos=0
 
-          # Compute 6-tier pace color (integer math, >= 15% elapsed = 2700s)
+          # Compute 6-tier pace color (integer math, >= 3% elapsed = 540s)
           pace_color=""
-          if [ $elapsed_secs -ge 2700 ]; then
+          if [ $elapsed_secs -ge 540 ]; then
             projected_pct=$((utilization * 18000 / elapsed_secs))
             if [ $projected_pct -lt 50 ]; then
               pace_color="$PACE_COMFORTABLE"

--- a/Claude Usage/Shared/Storage/DataStore.swift
+++ b/Claude Usage/Shared/Storage/DataStore.swift
@@ -431,7 +431,7 @@ class DataStore: StorageProvider {
         var config = MenuBarIconConfiguration.default
 
         // Migrate monochrome mode
-        config.monochromeMode = loadMonochromeMode()
+        config.colorMode = loadMonochromeMode() ? .monochrome : .multiColor
 
         // Migrate icon style for session (was the only option before)
         let legacyStyle = loadMenuBarIconStyle()

--- a/Claude Usage/Shared/Storage/SharedDataStore.swift
+++ b/Claude Usage/Shared/Storage/SharedDataStore.swift
@@ -27,6 +27,9 @@ class SharedDataStore {
         static let statuslineShowProgressBar = "statuslineShowProgressBar"
         static let statuslineShowResetTime = "statuslineShowResetTime"
         static let statuslineShowProfile = "statuslineShowProfile"
+        static let statuslineShowPaceMarker = "statuslineShowPaceMarker"
+        static let statuslinePaceMarkerStepColors = "statuslinePaceMarkerStepColors"
+        static let statuslineShowContextLabel = "statuslineShowContextLabel"
 
         // Setup State
         static let hasCompletedSetup = "hasCompletedSetup"
@@ -176,6 +179,39 @@ class SharedDataStore {
             return false  // Default to false (new feature)
         }
         return defaults.bool(forKey: Keys.statuslineShowProfile)
+    }
+
+    func saveStatuslineShowPaceMarker(_ show: Bool) {
+        defaults.set(show, forKey: Keys.statuslineShowPaceMarker)
+    }
+
+    func loadStatuslineShowPaceMarker() -> Bool {
+        if defaults.object(forKey: Keys.statuslineShowPaceMarker) == nil {
+            return true  // Default to true
+        }
+        return defaults.bool(forKey: Keys.statuslineShowPaceMarker)
+    }
+
+    func saveStatuslinePaceMarkerStepColors(_ useStepColors: Bool) {
+        defaults.set(useStepColors, forKey: Keys.statuslinePaceMarkerStepColors)
+    }
+
+    func loadStatuslinePaceMarkerStepColors() -> Bool {
+        if defaults.object(forKey: Keys.statuslinePaceMarkerStepColors) == nil {
+            return true
+        }
+        return defaults.bool(forKey: Keys.statuslinePaceMarkerStepColors)
+    }
+
+    func saveStatuslineShowContextLabel(_ show: Bool) {
+        defaults.set(show, forKey: Keys.statuslineShowContextLabel)
+    }
+
+    func loadStatuslineShowContextLabel() -> Bool {
+        if defaults.object(forKey: Keys.statuslineShowContextLabel) == nil {
+            return true
+        }
+        return defaults.bool(forKey: Keys.statuslineShowContextLabel)
     }
 
     // MARK: - Setup State

--- a/Claude Usage/Shared/Storage/SharedDataStore.swift
+++ b/Claude Usage/Shared/Storage/SharedDataStore.swift
@@ -30,6 +30,11 @@ class SharedDataStore {
         static let statuslineShowPaceMarker = "statuslineShowPaceMarker"
         static let statuslinePaceMarkerStepColors = "statuslinePaceMarkerStepColors"
         static let statuslineShowContextLabel = "statuslineShowContextLabel"
+        static let statuslineUse24HourTime = "statuslineUse24HourTime"
+        static let statuslineShowUsageLabel = "statuslineShowUsageLabel"
+        static let statuslineShowResetLabel = "statuslineShowResetLabel"
+        static let statuslineColorMode = "statuslineColorMode"
+        static let statuslineSingleColorHex = "statuslineSingleColorHex"
 
         // Setup State
         static let hasCompletedSetup = "hasCompletedSetup"
@@ -212,6 +217,56 @@ class SharedDataStore {
             return true
         }
         return defaults.bool(forKey: Keys.statuslineShowContextLabel)
+    }
+
+    func saveStatuslineUse24HourTime(_ use24Hour: Bool) {
+        defaults.set(use24Hour, forKey: Keys.statuslineUse24HourTime)
+    }
+
+    func loadStatuslineUse24HourTime() -> Bool {
+        return defaults.bool(forKey: Keys.statuslineUse24HourTime)
+    }
+
+    func saveStatuslineShowUsageLabel(_ show: Bool) {
+        defaults.set(show, forKey: Keys.statuslineShowUsageLabel)
+    }
+
+    func loadStatuslineShowUsageLabel() -> Bool {
+        if defaults.object(forKey: Keys.statuslineShowUsageLabel) == nil {
+            return true
+        }
+        return defaults.bool(forKey: Keys.statuslineShowUsageLabel)
+    }
+
+    func saveStatuslineShowResetLabel(_ show: Bool) {
+        defaults.set(show, forKey: Keys.statuslineShowResetLabel)
+    }
+
+    func loadStatuslineShowResetLabel() -> Bool {
+        if defaults.object(forKey: Keys.statuslineShowResetLabel) == nil {
+            return true
+        }
+        return defaults.bool(forKey: Keys.statuslineShowResetLabel)
+    }
+
+    func saveStatuslineColorMode(_ mode: StatuslineColorMode) {
+        defaults.set(mode.rawValue, forKey: Keys.statuslineColorMode)
+    }
+
+    func loadStatuslineColorMode() -> StatuslineColorMode {
+        guard let raw = defaults.string(forKey: Keys.statuslineColorMode),
+              let mode = StatuslineColorMode(rawValue: raw) else {
+            return .colored
+        }
+        return mode
+    }
+
+    func saveStatuslineSingleColorHex(_ hex: String) {
+        defaults.set(hex, forKey: Keys.statuslineSingleColorHex)
+    }
+
+    func loadStatuslineSingleColorHex() -> String {
+        return defaults.string(forKey: Keys.statuslineSingleColorHex) ?? "#00BFFF"
     }
 
     // MARK: - Setup State

--- a/Claude Usage/Shared/Utilities/PaceStatus.swift
+++ b/Claude Usage/Shared/Utilities/PaceStatus.swift
@@ -27,11 +27,12 @@ enum PaceStatus: Int, Comparable, CaseIterable {
     }
 
     /// Calculate pace status from current usage and elapsed time.
-    /// Returns nil when insufficient data (< 15% elapsed, period over, or no usage).
+    /// Returns nil when insufficient data (< 3% elapsed or period over).
     static func calculate(usedPercentage: Double, elapsedFraction: Double) -> PaceStatus? {
-        guard elapsedFraction >= 0.15, elapsedFraction < 1.0, usedPercentage > 0 else {
+        guard elapsedFraction >= 0.03, elapsedFraction < 1.0 else {
             return nil
         }
+        guard usedPercentage > 0 else { return .comfortable }
         let projected = (usedPercentage / 100.0) / elapsedFraction
         switch projected {
         case ..<0.50:     return .comfortable

--- a/Claude Usage/Shared/Utilities/PaceStatus.swift
+++ b/Claude Usage/Shared/Utilities/PaceStatus.swift
@@ -1,0 +1,71 @@
+//
+//  PaceStatus.swift
+//  Claude Usage
+//
+//  6-tier pace urgency spectrum for pace line coloring.
+//  Separate from UsageStatusLevel (3-tier) which controls bar fill color.
+//
+
+import Foundation
+import SwiftUI
+#if canImport(AppKit)
+import AppKit
+#endif
+
+/// Pace-specific status for the 6-tier color spectrum.
+/// Projects end-of-period usage from current consumption rate to determine urgency.
+enum PaceStatus: Int, Comparable, CaseIterable {
+    case comfortable = 0  // projected <50%  — way under budget
+    case onTrack     = 1  // projected 50-75% — sustainable pace
+    case warming     = 2  // projected 75-90% — starting to push it
+    case pressing    = 3  // projected 90-100% — will likely hit limit
+    case critical    = 4  // projected 100-120% — on track to exceed
+    case runaway     = 5  // projected >120% — burning way too fast
+
+    static func < (lhs: PaceStatus, rhs: PaceStatus) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+
+    /// Calculate pace status from current usage and elapsed time.
+    /// Returns nil when insufficient data (< 15% elapsed, period over, or no usage).
+    static func calculate(usedPercentage: Double, elapsedFraction: Double) -> PaceStatus? {
+        guard elapsedFraction >= 0.15, elapsedFraction < 1.0, usedPercentage > 0 else {
+            return nil
+        }
+        let projected = (usedPercentage / 100.0) / elapsedFraction
+        switch projected {
+        case ..<0.50:     return .comfortable
+        case 0.50..<0.75: return .onTrack
+        case 0.75..<0.90: return .warming
+        case 0.90..<1.00: return .pressing
+        case 1.00..<1.20: return .critical
+        default:          return .runaway
+        }
+    }
+
+    /// SwiftUI color for widgets and SwiftUI views
+    var swiftUIColor: Color {
+        switch self {
+        case .comfortable: return .green
+        case .onTrack:     return .teal
+        case .warming:     return .yellow
+        case .pressing:    return .orange
+        case .critical:    return .red
+        case .runaway:     return .purple
+        }
+    }
+
+    #if canImport(AppKit)
+    /// AppKit color for menu bar rendering
+    var color: NSColor {
+        switch self {
+        case .comfortable: return NSColor.systemGreen
+        case .onTrack:     return NSColor.systemTeal
+        case .warming:     return NSColor.systemYellow
+        case .pressing:    return NSColor.systemOrange
+        case .critical:    return NSColor.systemRed
+        case .runaway:     return NSColor.systemPurple
+        }
+    }
+    #endif
+}

--- a/Claude Usage/Views/Settings/App/ClaudeCodeView.swift
+++ b/Claude Usage/Views/Settings/App/ClaudeCodeView.swift
@@ -212,7 +212,7 @@ struct ClaudeCodeView: View {
                                         if showPaceMarker {
                                             SettingToggle(
                                                 title: "Pace tier colors",
-                                                description: "Color by projected usage rate",
+                                                description: "6-tier projected pace (green → purple)",
                                                 isOn: $paceMarkerStepColors
                                             )
                                             .padding(.leading, DesignTokens.Spacing.cardPadding * 2)

--- a/Claude Usage/Views/Settings/App/ClaudeCodeView.swift
+++ b/Claude Usage/Views/Settings/App/ClaudeCodeView.swift
@@ -9,6 +9,8 @@ import SwiftUI
 
 /// Claude Code statusline integration settings
 struct ClaudeCodeView: View {
+    @ObservedObject private var profileManager = ProfileManager.shared
+
     // Component visibility settings
     @State private var showModel: Bool = SharedDataStore.shared.loadStatuslineShowModel()
     @State private var showDirectory: Bool = SharedDataStore.shared.loadStatuslineShowDirectory()
@@ -17,142 +19,22 @@ struct ClaudeCodeView: View {
     @State private var contextAsTokens: Bool = SharedDataStore.shared.loadStatuslineContextAsTokens()
     @State private var showUsage: Bool = SharedDataStore.shared.loadStatuslineShowUsage()
     @State private var showProgressBar: Bool = SharedDataStore.shared.loadStatuslineShowProgressBar()
-    @State private var showResetTime: Bool = SharedDataStore.shared.loadStatuslineShowResetTime()
-    @State private var showProfile: Bool = SharedDataStore.shared.loadStatuslineShowProfile()
     @State private var showPaceMarker: Bool = SharedDataStore.shared.loadStatuslineShowPaceMarker()
     @State private var paceMarkerStepColors: Bool = SharedDataStore.shared.loadStatuslinePaceMarkerStepColors()
+    @State private var showResetTime: Bool = SharedDataStore.shared.loadStatuslineShowResetTime()
+    @State private var showProfile: Bool = SharedDataStore.shared.loadStatuslineShowProfile()
+    @State private var use24HourTime: Bool = SharedDataStore.shared.loadStatuslineUse24HourTime()
+    @State private var showUsageLabel: Bool = SharedDataStore.shared.loadStatuslineShowUsageLabel()
     @State private var showContextLabel: Bool = SharedDataStore.shared.loadStatuslineShowContextLabel()
+    @State private var showResetLabel: Bool = SharedDataStore.shared.loadStatuslineShowResetLabel()
+
+    // Appearance settings
+    @State private var colorMode: StatuslineColorMode = SharedDataStore.shared.loadStatuslineColorMode()
+    @State private var singleColor: Color = Color(hex: SharedDataStore.shared.loadStatuslineSingleColorHex()) ?? .cyan
 
     // Status feedback
     @State private var statusMessage: String?
     @State private var isSuccess: Bool = true
-
-    // MARK: - Terminal-Matching Colors (ANSI standard)
-    private enum TerminalColors {
-        static let blue = Color(red: 0/255, green: 0/255, blue: 238/255)
-        static let green = Color(red: 0/255, green: 187/255, blue: 0/255)
-        static let yellow = Color(red: 187/255, green: 187/255, blue: 0/255)
-        static let magenta = Color(red: 187/255, green: 0/255, blue: 187/255)
-        static let cyan = Color(red: 0/255, green: 187/255, blue: 187/255)
-        static let gray = Color(red: 128/255, green: 128/255, blue: 128/255)
-
-        static let paceComfortable = Color(red: 0/255, green: 175/255, blue: 0/255)
-        static let paceOnTrack = Color(red: 0/255, green: 175/255, blue: 175/255)
-        static let paceWarming = Color(red: 215/255, green: 175/255, blue: 0/255)
-        static let pacePressing = Color(red: 255/255, green: 135/255, blue: 0/255)
-        static let paceCritical = Color(red: 215/255, green: 0/255, blue: 0/255)
-        static let paceRunaway = Color(red: 175/255, green: 95/255, blue: 255/255)
-
-        static func usageLevel(_ percentage: Int) -> Color {
-            switch percentage {
-            case 0...10:  return Color(red: 0/255, green: 95/255, blue: 0/255)
-            case 11...20: return Color(red: 0/255, green: 135/255, blue: 0/255)
-            case 21...30: return Color(red: 0/255, green: 175/255, blue: 0/255)
-            case 31...40: return Color(red: 135/255, green: 135/255, blue: 0/255)
-            case 41...50: return Color(red: 175/255, green: 175/255, blue: 0/255)
-            case 51...60: return Color(red: 215/255, green: 175/255, blue: 0/255)
-            case 61...70: return Color(red: 215/255, green: 135/255, blue: 0/255)
-            case 71...80: return Color(red: 215/255, green: 95/255, blue: 0/255)
-            case 81...90: return Color(red: 215/255, green: 0/255, blue: 0/255)
-            default:      return Color(red: 175/255, green: 0/255, blue: 0/255)
-            }
-        }
-
-        static func paceColor(for status: PaceStatus) -> Color {
-            switch status {
-            case .comfortable: return paceComfortable
-            case .onTrack:     return paceOnTrack
-            case .warming:     return paceWarming
-            case .pressing:    return pacePressing
-            case .critical:    return paceCritical
-            case .runaway:     return paceRunaway
-            }
-        }
-    }
-
-    // MARK: - Multi-Color Preview
-
-    private var multiColorPreview: some View {
-        let percentage = 29
-        let usageColor = TerminalColors.usageLevel(percentage)
-        let ctxPrefix = showContextLabel ? "Ctx: " : ""
-
-        return HStack(spacing: 0) {
-            let parts: [(String, Color)] = {
-                var p: [(String, Color)] = []
-
-                if showDirectory {
-                    if !p.isEmpty { p.append((" | ", TerminalColors.gray)) }
-                    p.append(("claude-usage", TerminalColors.blue))
-                }
-
-                if showBranch {
-                    if !p.isEmpty { p.append((" | ", TerminalColors.gray)) }
-                    p.append(("⎇ main", TerminalColors.green))
-                }
-
-                if showModel {
-                    if !p.isEmpty { p.append((" | ", TerminalColors.gray)) }
-                    p.append(("Opus", TerminalColors.yellow))
-                }
-
-                if showProfile {
-                    if !p.isEmpty { p.append((" | ", TerminalColors.gray)) }
-                    let name = ProfileManager.shared.activeProfile?.name ?? "Profile"
-                    p.append((name, TerminalColors.magenta))
-                }
-
-                if showContext {
-                    if !p.isEmpty { p.append((" | ", TerminalColors.gray)) }
-                    if contextAsTokens {
-                        p.append(("\(ctxPrefix)96K", TerminalColors.cyan))
-                    } else {
-                        p.append(("\(ctxPrefix)48%", TerminalColors.cyan))
-                    }
-                }
-
-                if showUsage {
-                    if !p.isEmpty { p.append((" | ", TerminalColors.gray)) }
-                    p.append(("Usage: \(percentage)%", usageColor))
-                }
-
-                return p
-            }()
-
-            ForEach(Array(parts.enumerated()), id: \.offset) { _, part in
-                Text(part.0)
-                    .foregroundColor(part.1)
-            }
-
-            if showUsage && showProgressBar {
-                let filledBlocks = max(0, min(10, (percentage * 10 + 50) / 100))
-                let emptyBlocks = 10 - filledBlocks
-
-                if showPaceMarker {
-                    let markerPos = max(0, min(9, previewMarkerPosition))
-                    let paceColor = previewPaceColor(percentage: percentage)
-                    let fullBar = String(repeating: "▓", count: filledBlocks) + String(repeating: "░", count: emptyBlocks)
-                    let chars = Array(fullBar)
-                    Text(" " + String(chars.prefix(markerPos)))
-                        .foregroundColor(usageColor)
-                    Text("┃")
-                        .foregroundColor(paceColor)
-                    Text(String(chars.suffix(from: markerPos + 1)))
-                        .foregroundColor(usageColor)
-                } else {
-                    let bar = String(repeating: "▓", count: filledBlocks) + String(repeating: "░", count: emptyBlocks)
-                    Text(" \(bar)")
-                        .foregroundColor(usageColor)
-                }
-            }
-
-            if showUsage && showResetTime {
-                Text(" → Reset: 14:30")
-                    .foregroundColor(usageColor)
-            }
-        }
-        .font(DesignTokens.Typography.monospaced)
-    }
 
     var body: some View {
         ScrollView {
@@ -178,15 +60,15 @@ struct ClaudeCodeView: View {
                     }
 
                     VStack(alignment: .leading, spacing: DesignTokens.Spacing.small) {
-                        multiColorPreview
+                        previewView
                             .padding(DesignTokens.Spacing.medium)
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .background(
                                 RoundedRectangle(cornerRadius: DesignTokens.Radius.small)
-                                    .fill(Color(.windowBackgroundColor).opacity(0.4))
+                                    .fill(previewBackgroundColor)
                                     .overlay(
                                         RoundedRectangle(cornerRadius: DesignTokens.Radius.small)
-                                            .strokeBorder(Color.accentColor.opacity(0.2), lineWidth: 1)
+                                            .strokeBorder(previewBorderColor, lineWidth: 1)
                                     )
                             )
 
@@ -201,9 +83,71 @@ struct ClaudeCodeView: View {
                         .fill(DesignTokens.Colors.cardBackground)
                 )
 
-                // Components + Actions (single card)
+                // Color Mode Card
                 SettingsSectionCard(
-                    title: "ui.display_components".localized
+                    title: "Statusline Colors",
+                    subtitle: "Choose color display mode"
+                ) {
+                    HStack(spacing: DesignTokens.Spacing.small) {
+                        ForEach([StatuslineColorMode.colored, .monochrome, .singleColor], id: \.self) { mode in
+                            Button {
+                                colorMode = mode
+                                SharedDataStore.shared.saveStatuslineColorMode(mode)
+                            } label: {
+                                HStack(spacing: 6) {
+                                    Image(systemName: mode.icon)
+                                        .font(.system(size: 12))
+                                        .foregroundColor(iconColorForMode(mode))
+
+                                    VStack(alignment: .leading, spacing: 1) {
+                                        Text(mode.displayName)
+                                            .font(DesignTokens.Typography.body)
+                                            .foregroundColor(.primary)
+
+                                        Text(mode.description)
+                                            .font(.system(size: 10))
+                                            .foregroundColor(.secondary)
+                                    }
+
+                                    Spacer()
+                                }
+                                .padding(.horizontal, 10)
+                                .padding(.vertical, 8)
+                                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+                                .background(
+                                    RoundedRectangle(cornerRadius: DesignTokens.Radius.small)
+                                        .fill(colorMode == mode ? Color.accentColor.opacity(0.12) : Color.clear)
+                                )
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: DesignTokens.Radius.small)
+                                        .strokeBorder(colorMode == mode ? Color.accentColor.opacity(0.4) : Color.secondary.opacity(0.15), lineWidth: 1)
+                                )
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+
+                    if colorMode == .singleColor {
+                        HStack(spacing: DesignTokens.Spacing.small) {
+                            ColorPicker("Custom color", selection: Binding(
+                                get: { singleColor },
+                                set: { newColor in
+                                    singleColor = newColor
+                                    SharedDataStore.shared.saveStatuslineSingleColorHex(newColor.toHex() ?? "#00BFFF")
+                                }
+                            ))
+                            .font(DesignTokens.Typography.caption)
+
+                            Spacer()
+                        }
+                        .padding(.top, 4)
+                    }
+                }
+
+                // Display Components
+                SettingsSectionCard(
+                    title: "ui.display_components".localized,
+                    subtitle: "Choose which elements to display"
                 ) {
                     VStack(alignment: .leading, spacing: DesignTokens.Spacing.medium) {
                         SettingToggle(
@@ -259,8 +203,8 @@ struct ClaudeCodeView: View {
 
                                     if showProgressBar {
                                         SettingToggle(
-                                            title: "Pace marker",
-                                            description: "Show time-elapsed marker on progress bar",
+                                            title: "claudecode.component_pace_marker".localized,
+                                            description: "claudecode.pace_marker_info".localized,
                                             isOn: $showPaceMarker
                                         )
                                         .padding(.leading, DesignTokens.Spacing.cardPadding)
@@ -279,23 +223,45 @@ struct ClaudeCodeView: View {
                                         title: "claudecode.component_resettime".localized,
                                         isOn: $showResetTime
                                     )
+
+                                    if showResetTime {
+                                        SettingToggle(
+                                            title: "24-hour time format",
+                                            isOn: $use24HourTime
+                                        )
+                                        .padding(.leading, DesignTokens.Spacing.cardPadding)
+                                    }
+
+                                    Divider()
+
+                                    if showContext {
+                                        SettingToggle(
+                                            title: "Show \"Ctx:\" label",
+                                            isOn: $showContextLabel
+                                        )
+                                    }
+
+                                    SettingToggle(
+                                        title: "Show \"Usage:\" label",
+                                        isOn: $showUsageLabel
+                                    )
+
+                                    if showResetTime {
+                                        SettingToggle(
+                                            title: "Show \"Reset:\" label",
+                                            isOn: $showResetLabel
+                                        )
+                                    }
                                 }
                                 .padding(.leading, DesignTokens.Spacing.cardPadding)
                             }
                         }
+                    }
+                }
 
-                        Divider()
-
-                        // Label toggles
-                        if showContext {
-                            SettingToggle(
-                                title: "Show \"Ctx:\" label",
-                                isOn: $showContextLabel
-                            )
-                        }
-
-                        Divider()
-
+                // Action buttons + status
+                SettingsSectionCard(title: "") {
+                    VStack(alignment: .leading, spacing: DesignTokens.Spacing.medium) {
                         HStack(spacing: DesignTokens.Spacing.small) {
                             Button(action: applyConfiguration) {
                                 Text("claudecode.button_apply".localized)
@@ -353,25 +319,287 @@ struct ClaudeCodeView: View {
         }
     }
 
-    // MARK: - Preview Helpers
+    // MARK: - Computed Properties
 
+    /// Color used for preview based on selected color mode (from Menu Bar Settings)
+    private var previewColor: Color {
+        let colorMode = SharedDataStore.shared.loadStatuslineColorMode()
+        switch colorMode {
+        case .colored:
+            return .accentColor
+        case .monochrome:
+            return .primary
+        case .singleColor:
+            let hex = SharedDataStore.shared.loadStatuslineSingleColorHex()
+            return Color(hex: hex) ?? .cyan
+        }
+    }
+
+    /// Background color for preview card
+    private var previewBackgroundColor: Color {
+        let colorMode = SharedDataStore.shared.loadStatuslineColorMode()
+        switch colorMode {
+        case .colored:
+            return Color.purple.opacity(0.05)
+        case .monochrome:
+            return previewColor.opacity(0.05)
+        case .singleColor:
+            return previewColor.opacity(0.05)
+        }
+    }
+
+    /// Border color for preview card
+    private var previewBorderColor: Color {
+        let colorMode = SharedDataStore.shared.loadStatuslineColorMode()
+        switch colorMode {
+        case .colored:
+            return Color.purple.opacity(0.2)
+        case .monochrome:
+            return previewColor.opacity(0.2)
+        case .singleColor:
+            return previewColor.opacity(0.2)
+        }
+    }
+
+    /// Preview view showing statusline with appropriate colors
+    @ViewBuilder
+    private var previewView: some View {
+        let colorMode = SharedDataStore.shared.loadStatuslineColorMode()
+
+        if colorMode == .colored {
+            // Multi-color preview - each element gets its own color
+            multiColorPreview
+        } else {
+            // Single/mono color preview — split at pace marker if step colors enabled
+            let preview = generatePreview()
+            if showPaceMarker && paceMarkerStepColors && showProgressBar && showUsage,
+               let markerRange = preview.range(of: "┃") {
+                let usage = profileManager.activeProfile?.claudeUsage
+                let percentage = usage != nil ? Int(usage!.sessionPercentage) : 29
+                let paceColor = previewPaceColor(percentage: percentage)
+                HStack(spacing: 0) {
+                    Text(String(preview[preview.startIndex..<markerRange.lowerBound]))
+                        .foregroundColor(previewColor)
+                    Text("┃")
+                        .foregroundColor(paceColor)
+                    Text(String(preview[markerRange.upperBound...]))
+                        .foregroundColor(previewColor)
+                }
+                .font(.system(size: 11, design: .monospaced))
+                .lineLimit(1)
+                .truncationMode(.tail)
+            } else {
+                Text(preview)
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundColor(previewColor)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+        }
+    }
+
+    // MARK: - Terminal-Matching Colors (ANSI standard)
+
+    /// Colors matching ANSI standard terminal colors used in the bash statusline script
+    private enum TerminalColors {
+        static let blue = Color(red: 0/255, green: 0/255, blue: 238/255)
+        static let green = Color(red: 0/255, green: 187/255, blue: 0/255)
+        static let yellow = Color(red: 187/255, green: 187/255, blue: 0/255)
+        static let magenta = Color(red: 187/255, green: 0/255, blue: 187/255)
+        static let cyan = Color(red: 0/255, green: 187/255, blue: 187/255)
+        static let gray = Color(red: 128/255, green: 128/255, blue: 128/255)
+
+        // 6-tier pace marker colors (ANSI 256-color palette)
+        static let paceComfortable = Color(red: 0/255, green: 175/255, blue: 0/255)
+        static let paceOnTrack = Color(red: 0/255, green: 175/255, blue: 175/255)
+        static let paceWarming = Color(red: 215/255, green: 175/255, blue: 0/255)
+        static let pacePressing = Color(red: 255/255, green: 135/255, blue: 0/255)
+        static let paceCritical = Color(red: 215/255, green: 0/255, blue: 0/255)
+        static let paceRunaway = Color(red: 175/255, green: 95/255, blue: 255/255)
+
+        // 10-level usage gradient (ANSI 256-color palette)
+        static func usageLevel(_ percentage: Int) -> Color {
+            switch percentage {
+            case 0...10:  return Color(red: 0/255, green: 95/255, blue: 0/255)
+            case 11...20: return Color(red: 0/255, green: 135/255, blue: 0/255)
+            case 21...30: return Color(red: 0/255, green: 175/255, blue: 0/255)
+            case 31...40: return Color(red: 135/255, green: 135/255, blue: 0/255)
+            case 41...50: return Color(red: 175/255, green: 175/255, blue: 0/255)
+            case 51...60: return Color(red: 215/255, green: 175/255, blue: 0/255)
+            case 61...70: return Color(red: 215/255, green: 135/255, blue: 0/255)
+            case 71...80: return Color(red: 215/255, green: 95/255, blue: 0/255)
+            case 81...90: return Color(red: 215/255, green: 0/255, blue: 0/255)
+            default:      return Color(red: 175/255, green: 0/255, blue: 0/255)
+            }
+        }
+
+        static func paceColor(for status: PaceStatus) -> Color {
+            switch status {
+            case .comfortable: return paceComfortable
+            case .onTrack:     return paceOnTrack
+            case .warming:     return paceWarming
+            case .pressing:    return pacePressing
+            case .critical:    return paceCritical
+            case .runaway:     return paceRunaway
+            }
+        }
+    }
+
+    /// Multi-color preview showing each element in different colors
+    private var multiColorPreview: some View {
+        let usage = profileManager.activeProfile?.claudeUsage
+        let percentage = usage != nil ? Int(usage!.sessionPercentage) : 29
+        let usageColor = TerminalColors.usageLevel(percentage)
+
+        return HStack(spacing: 0) {
+            if showDirectory {
+                Text("claude-usage")
+                    .foregroundColor(TerminalColors.blue)
+                if showBranch || showModel || showProfile || showContext || showUsage {
+                    Text(" │ ").foregroundColor(TerminalColors.gray)
+                }
+            }
+
+            if showBranch {
+                Text("⎇ main")
+                    .foregroundColor(TerminalColors.green)
+                if showModel || showProfile || showContext || showUsage {
+                    Text(" │ ").foregroundColor(TerminalColors.gray)
+                }
+            }
+
+            if showModel {
+                Text("Opus")
+                    .foregroundColor(TerminalColors.yellow)
+                if showProfile || showContext || showUsage {
+                    Text(" │ ").foregroundColor(TerminalColors.gray)
+                }
+            }
+
+            if showProfile {
+                let name = ProfileManager.shared.activeProfile?.name ?? "Profile"
+                Text(name)
+                    .foregroundColor(TerminalColors.magenta)
+                if showContext || showUsage {
+                    Text(" │ ").foregroundColor(TerminalColors.gray)
+                }
+            }
+
+            if showContext {
+                let ctxPrefix = showContextLabel ? "Ctx: " : ""
+                if contextAsTokens {
+                    Text("\(ctxPrefix)96K")
+                        .foregroundColor(TerminalColors.cyan)
+                } else {
+                    Text("\(ctxPrefix)48%")
+                        .foregroundColor(TerminalColors.cyan)
+                }
+                if showUsage {
+                    Text(" │ ").foregroundColor(TerminalColors.gray)
+                }
+            }
+
+            if showUsage {
+                let usagePrefix = showUsageLabel ? "Usage: " : ""
+                Text(usagePrefix + "\(percentage)%")
+                    .foregroundColor(usageColor)
+
+                if showProgressBar {
+                    let filledBlocks = max(0, min(10, (percentage + 5) / 10))
+                    let emptyBlocks = 10 - filledBlocks
+
+                    if showPaceMarker {
+                        let markerPos = max(0, min(9, previewMarkerPosition))
+                        let paceColor = previewPaceColor(percentage: percentage)
+                        let fullBar = String(repeating: "▓", count: filledBlocks) + String(repeating: "░", count: emptyBlocks)
+                        let chars = Array(fullBar)
+
+                        Text(" " + String(chars.prefix(markerPos)))
+                            .foregroundColor(usageColor)
+                        Text("┃")
+                            .foregroundColor(paceColor)
+                        Text(String(chars.suffix(from: markerPos + 1)))
+                            .foregroundColor(usageColor)
+                    } else {
+                        let bar = String(repeating: "▓", count: filledBlocks) + String(repeating: "░", count: emptyBlocks)
+                        Text(" \(bar)")
+                            .foregroundColor(usageColor)
+                    }
+                }
+
+                if showResetTime {
+                    let resetTimeString = formatResetTime(usage?.sessionResetTime)
+                    let resetPrefix = showResetLabel ? " → Reset: " : " → "
+                    Text(resetPrefix + resetTimeString)
+                        .foregroundColor(usageColor)
+                }
+            }
+
+            if !showDirectory && !showBranch && !showModel && !showProfile && !showContext && !showUsage {
+                Text("claudecode.preview_no_components".localized)
+                    .foregroundColor(.secondary)
+            }
+        }
+        .font(.system(size: 11, design: .monospaced))
+        .lineLimit(1)
+        .truncationMode(.tail)
+    }
+
+    /// Returns the appropriate color for usage percentage based on thresholds
+    private func colorForPercentage(_ percentage: Double) -> Color {
+        switch percentage {
+        case 0..<50:
+            return SettingsColors.usageLow       // Green
+        case 50..<80:
+            return SettingsColors.usageHigh      // Orange
+        default: // 80%+
+            return SettingsColors.usageCritical  // Red
+        }
+    }
+
+    /// Formats reset time for preview display
+    /// Rounds to nearest minute to prevent display flickering
+    private func formatResetTime(_ date: Date?) -> String {
+        guard let date = date else {
+            return "--:--"
+        }
+        let formatter = DateFormatter()
+        formatter.dateFormat = use24HourTime ? "HH:mm" : "h:mm a"
+        return formatter.string(from: date.roundedToNearestMinute())
+    }
+
+    /// Returns the appropriate icon color for each color mode
+    private func iconColorForMode(_ mode: StatuslineColorMode) -> Color {
+        switch mode {
+        case .colored:
+            return .purple
+        case .monochrome:
+            return .primary
+        case .singleColor:
+            return singleColor
+        }
+    }
+
+    /// Marker position for preview (0-9), based on real elapsed time or demo
     private var previewMarkerPosition: Int {
-        if let usage = ProfileManager.shared.activeProfile?.claudeUsage {
+        if let usage = profileManager.activeProfile?.claudeUsage {
             let remaining = usage.sessionResetTime.timeIntervalSince(Date())
             if remaining > 0 && remaining < 18000 {
                 let elapsed = 18000 - remaining
                 return max(0, min(9, Int(round(elapsed * 10.0 / 18000.0))))
             }
         }
-        return 6
+        return 6 // Demo: 60% elapsed
     }
 
+    /// Pace color for the marker in preview, matching terminal ANSI colors
     private func previewPaceColor(percentage: Int) -> Color {
         guard paceMarkerStepColors else {
             return TerminalColors.usageLevel(percentage)
         }
+
         let elapsedFraction: Double
-        if let usage = ProfileManager.shared.activeProfile?.claudeUsage {
+        if let usage = profileManager.activeProfile?.claudeUsage {
             let remaining = usage.sessionResetTime.timeIntervalSince(Date())
             if remaining > 0 && remaining < 18000 {
                 elapsedFraction = (18000 - remaining) / 18000
@@ -381,6 +609,7 @@ struct ClaudeCodeView: View {
         } else {
             elapsedFraction = 0.6
         }
+
         if let paceStatus = PaceStatus.calculate(usedPercentage: Double(percentage), elapsedFraction: elapsedFraction) {
             return TerminalColors.paceColor(for: paceStatus)
         }
@@ -406,6 +635,10 @@ struct ClaudeCodeView: View {
             return
         }
 
+        // Load color settings from SharedDataStore (configured in Menu Bar Settings)
+        let colorMode = SharedDataStore.shared.loadStatuslineColorMode()
+        let singleColorHex = SharedDataStore.shared.loadStatuslineSingleColorHex()
+
         // Save user preferences
         SharedDataStore.shared.saveStatuslineShowModel(showModel)
         SharedDataStore.shared.saveStatuslineShowDirectory(showDirectory)
@@ -414,16 +647,16 @@ struct ClaudeCodeView: View {
         SharedDataStore.shared.saveStatuslineContextAsTokens(contextAsTokens)
         SharedDataStore.shared.saveStatuslineShowUsage(showUsage)
         SharedDataStore.shared.saveStatuslineShowProgressBar(showProgressBar)
-        SharedDataStore.shared.saveStatuslineShowResetTime(showResetTime)
-        SharedDataStore.shared.saveStatuslineShowProfile(showProfile)
         SharedDataStore.shared.saveStatuslineShowPaceMarker(showPaceMarker)
         SharedDataStore.shared.saveStatuslinePaceMarkerStepColors(paceMarkerStepColors)
+        SharedDataStore.shared.saveStatuslineShowResetTime(showResetTime)
+        SharedDataStore.shared.saveStatuslineShowProfile(showProfile)
+        SharedDataStore.shared.saveStatuslineUse24HourTime(use24HourTime)
         SharedDataStore.shared.saveStatuslineShowContextLabel(showContextLabel)
+        SharedDataStore.shared.saveStatuslineShowUsageLabel(showUsageLabel)
+        SharedDataStore.shared.saveStatuslineShowResetLabel(showResetLabel)
 
         do {
-            // Install scripts to ~/.claude/
-            try StatuslineService.shared.installScripts()
-
             // Write configuration file
             let profileName = ProfileManager.shared.activeProfile?.name ?? ""
             try StatuslineService.shared.updateConfiguration(
@@ -434,12 +667,17 @@ struct ClaudeCodeView: View {
                 contextAsTokens: contextAsTokens,
                 showUsage: showUsage,
                 showProgressBar: showProgressBar,
-                showResetTime: showResetTime,
-                showProfile: showProfile,
-                profileName: profileName,
                 showPaceMarker: showPaceMarker,
                 paceMarkerStepColors: paceMarkerStepColors,
-                showContextLabel: showContextLabel
+                showResetTime: showResetTime,
+                use24HourTime: use24HourTime,
+                showContextLabel: showContextLabel,
+                showUsageLabel: showUsageLabel,
+                showResetLabel: showResetLabel,
+                colorMode: colorMode,
+                singleColorHex: singleColorHex,
+                showProfile: showProfile,
+                profileName: profileName
             )
 
             // Update Claude CLI settings.json
@@ -468,7 +706,6 @@ struct ClaudeCodeView: View {
     /// Generates a preview of what the statusline will look like based on current selections.
     private func generatePreview() -> String {
         var parts: [String] = []
-        let ctxPrefix = showContextLabel ? "Ctx: " : ""
 
         if showDirectory {
             parts.append("claude-usage")
@@ -488,6 +725,7 @@ struct ClaudeCodeView: View {
         }
 
         if showContext {
+            let ctxPrefix = showContextLabel ? "Ctx: " : ""
             if contextAsTokens {
                 parts.append("\(ctxPrefix)96K")
             } else {
@@ -496,25 +734,41 @@ struct ClaudeCodeView: View {
         }
 
         if showUsage {
-            let percentage = 29
-            let filledBlocks = max(0, min(10, (percentage * 10 + 50) / 100))
-            let emptyBlocks = 10 - filledBlocks
-            var usageText = "Usage: \(percentage)%"
+            // Use real usage data if available
+            let usage = profileManager.activeProfile?.claudeUsage
+            let percentage = usage != nil ? Int(usage!.sessionPercentage) : 29
+
+            var usageText = showUsageLabel ? "Usage: \(percentage)%" : "\(percentage)%"
+
             if showProgressBar {
+                let filledBlocks = max(0, min(10, (percentage + 5) / 10))
+                let emptyBlocks = 10 - filledBlocks
                 var barChars = Array(String(repeating: "▓", count: filledBlocks) + String(repeating: "░", count: emptyBlocks))
+
                 if showPaceMarker {
                     let markerPos = max(0, min(9, previewMarkerPosition))
                     barChars[markerPos] = "┃"
                 }
+
                 usageText += " \(String(barChars))"
             }
+
             if showResetTime {
-                usageText += " → Reset: 14:30"
+                if let resetTime = usage?.sessionResetTime {
+                    let formatter = DateFormatter()
+                    formatter.dateFormat = use24HourTime ? "HH:mm" : "h:mm a"
+                    let resetPrefix = showResetLabel ? " → Reset: " : " → "
+                    usageText += "\(resetPrefix)\(formatter.string(from: resetTime.roundedToNearestMinute()))"
+                } else {
+                    let resetPrefix = showResetLabel ? " → Reset: " : " → "
+                    usageText += "\(resetPrefix)--:--"
+                }
             }
+
             parts.append(usageText)
         }
 
-        return parts.isEmpty ? "claudecode.preview_no_components".localized : parts.joined(separator: " | ")
+        return parts.isEmpty ? "claudecode.preview_no_components".localized : parts.joined(separator: " │ ")
     }
 }
 

--- a/Claude Usage/Views/Settings/App/ClaudeCodeView.swift
+++ b/Claude Usage/Views/Settings/App/ClaudeCodeView.swift
@@ -19,10 +19,140 @@ struct ClaudeCodeView: View {
     @State private var showProgressBar: Bool = SharedDataStore.shared.loadStatuslineShowProgressBar()
     @State private var showResetTime: Bool = SharedDataStore.shared.loadStatuslineShowResetTime()
     @State private var showProfile: Bool = SharedDataStore.shared.loadStatuslineShowProfile()
+    @State private var showPaceMarker: Bool = SharedDataStore.shared.loadStatuslineShowPaceMarker()
+    @State private var paceMarkerStepColors: Bool = SharedDataStore.shared.loadStatuslinePaceMarkerStepColors()
+    @State private var showContextLabel: Bool = SharedDataStore.shared.loadStatuslineShowContextLabel()
 
     // Status feedback
     @State private var statusMessage: String?
     @State private var isSuccess: Bool = true
+
+    // MARK: - Terminal-Matching Colors (ANSI standard)
+    private enum TerminalColors {
+        static let blue = Color(red: 0/255, green: 0/255, blue: 238/255)
+        static let green = Color(red: 0/255, green: 187/255, blue: 0/255)
+        static let yellow = Color(red: 187/255, green: 187/255, blue: 0/255)
+        static let magenta = Color(red: 187/255, green: 0/255, blue: 187/255)
+        static let cyan = Color(red: 0/255, green: 187/255, blue: 187/255)
+        static let gray = Color(red: 128/255, green: 128/255, blue: 128/255)
+
+        static let paceComfortable = Color(red: 0/255, green: 175/255, blue: 0/255)
+        static let paceOnTrack = Color(red: 0/255, green: 175/255, blue: 175/255)
+        static let paceWarming = Color(red: 215/255, green: 175/255, blue: 0/255)
+        static let pacePressing = Color(red: 255/255, green: 135/255, blue: 0/255)
+        static let paceCritical = Color(red: 215/255, green: 0/255, blue: 0/255)
+        static let paceRunaway = Color(red: 175/255, green: 95/255, blue: 255/255)
+
+        static func usageLevel(_ percentage: Int) -> Color {
+            switch percentage {
+            case 0...10:  return Color(red: 0/255, green: 95/255, blue: 0/255)
+            case 11...20: return Color(red: 0/255, green: 135/255, blue: 0/255)
+            case 21...30: return Color(red: 0/255, green: 175/255, blue: 0/255)
+            case 31...40: return Color(red: 135/255, green: 135/255, blue: 0/255)
+            case 41...50: return Color(red: 175/255, green: 175/255, blue: 0/255)
+            case 51...60: return Color(red: 215/255, green: 175/255, blue: 0/255)
+            case 61...70: return Color(red: 215/255, green: 135/255, blue: 0/255)
+            case 71...80: return Color(red: 215/255, green: 95/255, blue: 0/255)
+            case 81...90: return Color(red: 215/255, green: 0/255, blue: 0/255)
+            default:      return Color(red: 175/255, green: 0/255, blue: 0/255)
+            }
+        }
+
+        static func paceColor(for status: PaceStatus) -> Color {
+            switch status {
+            case .comfortable: return paceComfortable
+            case .onTrack:     return paceOnTrack
+            case .warming:     return paceWarming
+            case .pressing:    return pacePressing
+            case .critical:    return paceCritical
+            case .runaway:     return paceRunaway
+            }
+        }
+    }
+
+    // MARK: - Multi-Color Preview
+
+    private var multiColorPreview: some View {
+        let percentage = 29
+        let usageColor = TerminalColors.usageLevel(percentage)
+        let ctxPrefix = showContextLabel ? "Ctx: " : ""
+
+        return HStack(spacing: 0) {
+            let parts: [(String, Color)] = {
+                var p: [(String, Color)] = []
+
+                if showDirectory {
+                    if !p.isEmpty { p.append((" | ", TerminalColors.gray)) }
+                    p.append(("claude-usage", TerminalColors.blue))
+                }
+
+                if showBranch {
+                    if !p.isEmpty { p.append((" | ", TerminalColors.gray)) }
+                    p.append(("⎇ main", TerminalColors.green))
+                }
+
+                if showModel {
+                    if !p.isEmpty { p.append((" | ", TerminalColors.gray)) }
+                    p.append(("Opus", TerminalColors.yellow))
+                }
+
+                if showProfile {
+                    if !p.isEmpty { p.append((" | ", TerminalColors.gray)) }
+                    let name = ProfileManager.shared.activeProfile?.name ?? "Profile"
+                    p.append((name, TerminalColors.magenta))
+                }
+
+                if showContext {
+                    if !p.isEmpty { p.append((" | ", TerminalColors.gray)) }
+                    if contextAsTokens {
+                        p.append(("\(ctxPrefix)96K", TerminalColors.cyan))
+                    } else {
+                        p.append(("\(ctxPrefix)48%", TerminalColors.cyan))
+                    }
+                }
+
+                if showUsage {
+                    if !p.isEmpty { p.append((" | ", TerminalColors.gray)) }
+                    p.append(("Usage: \(percentage)%", usageColor))
+                }
+
+                return p
+            }()
+
+            ForEach(Array(parts.enumerated()), id: \.offset) { _, part in
+                Text(part.0)
+                    .foregroundColor(part.1)
+            }
+
+            if showUsage && showProgressBar {
+                let filledBlocks = max(0, min(10, (percentage * 10 + 50) / 100))
+                let emptyBlocks = 10 - filledBlocks
+
+                if showPaceMarker {
+                    let markerPos = max(0, min(9, previewMarkerPosition))
+                    let paceColor = previewPaceColor(percentage: percentage)
+                    let fullBar = String(repeating: "▓", count: filledBlocks) + String(repeating: "░", count: emptyBlocks)
+                    let chars = Array(fullBar)
+                    Text(" " + String(chars.prefix(markerPos)))
+                        .foregroundColor(usageColor)
+                    Text("┃")
+                        .foregroundColor(paceColor)
+                    Text(String(chars.suffix(from: markerPos + 1)))
+                        .foregroundColor(usageColor)
+                } else {
+                    let bar = String(repeating: "▓", count: filledBlocks) + String(repeating: "░", count: emptyBlocks)
+                    Text(" \(bar)")
+                        .foregroundColor(usageColor)
+                }
+            }
+
+            if showUsage && showResetTime {
+                Text(" → Reset: 14:30")
+                    .foregroundColor(usageColor)
+            }
+        }
+        .font(DesignTokens.Typography.monospaced)
+    }
 
     var body: some View {
         ScrollView {
@@ -48,14 +178,12 @@ struct ClaudeCodeView: View {
                     }
 
                     VStack(alignment: .leading, spacing: DesignTokens.Spacing.small) {
-                        Text(generatePreview())
-                            .font(DesignTokens.Typography.monospaced)
-                            .foregroundColor(.accentColor)
+                        multiColorPreview
                             .padding(DesignTokens.Spacing.medium)
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .background(
                                 RoundedRectangle(cornerRadius: DesignTokens.Radius.small)
-                                    .fill(Color.accentColor.opacity(0.05))
+                                    .fill(Color(.windowBackgroundColor).opacity(0.4))
                                     .overlay(
                                         RoundedRectangle(cornerRadius: DesignTokens.Radius.small)
                                             .strokeBorder(Color.accentColor.opacity(0.2), lineWidth: 1)
@@ -129,6 +257,24 @@ struct ClaudeCodeView: View {
                                         isOn: $showProgressBar
                                     )
 
+                                    if showProgressBar {
+                                        SettingToggle(
+                                            title: "Pace marker",
+                                            description: "Show time-elapsed marker on progress bar",
+                                            isOn: $showPaceMarker
+                                        )
+                                        .padding(.leading, DesignTokens.Spacing.cardPadding)
+
+                                        if showPaceMarker {
+                                            SettingToggle(
+                                                title: "Pace tier colors",
+                                                description: "Color by projected usage rate",
+                                                isOn: $paceMarkerStepColors
+                                            )
+                                            .padding(.leading, DesignTokens.Spacing.cardPadding * 2)
+                                        }
+                                    }
+
                                     SettingToggle(
                                         title: "claudecode.component_resettime".localized,
                                         isOn: $showResetTime
@@ -136,6 +282,16 @@ struct ClaudeCodeView: View {
                                 }
                                 .padding(.leading, DesignTokens.Spacing.cardPadding)
                             }
+                        }
+
+                        Divider()
+
+                        // Label toggles
+                        if showContext {
+                            SettingToggle(
+                                title: "Show \"Ctx:\" label",
+                                isOn: $showContextLabel
+                            )
                         }
 
                         Divider()
@@ -197,6 +353,40 @@ struct ClaudeCodeView: View {
         }
     }
 
+    // MARK: - Preview Helpers
+
+    private var previewMarkerPosition: Int {
+        if let usage = ProfileManager.shared.activeProfile?.claudeUsage {
+            let remaining = usage.sessionResetTime.timeIntervalSince(Date())
+            if remaining > 0 && remaining < 18000 {
+                let elapsed = 18000 - remaining
+                return max(0, min(9, Int(round(elapsed * 10.0 / 18000.0))))
+            }
+        }
+        return 6
+    }
+
+    private func previewPaceColor(percentage: Int) -> Color {
+        guard paceMarkerStepColors else {
+            return TerminalColors.usageLevel(percentage)
+        }
+        let elapsedFraction: Double
+        if let usage = ProfileManager.shared.activeProfile?.claudeUsage {
+            let remaining = usage.sessionResetTime.timeIntervalSince(Date())
+            if remaining > 0 && remaining < 18000 {
+                elapsedFraction = (18000 - remaining) / 18000
+            } else {
+                elapsedFraction = 0.6
+            }
+        } else {
+            elapsedFraction = 0.6
+        }
+        if let paceStatus = PaceStatus.calculate(usedPercentage: Double(percentage), elapsedFraction: elapsedFraction) {
+            return TerminalColors.paceColor(for: paceStatus)
+        }
+        return TerminalColors.usageLevel(percentage)
+    }
+
     // MARK: - Actions
 
     /// Applies the current configuration to Claude Code statusline.
@@ -226,6 +416,9 @@ struct ClaudeCodeView: View {
         SharedDataStore.shared.saveStatuslineShowProgressBar(showProgressBar)
         SharedDataStore.shared.saveStatuslineShowResetTime(showResetTime)
         SharedDataStore.shared.saveStatuslineShowProfile(showProfile)
+        SharedDataStore.shared.saveStatuslineShowPaceMarker(showPaceMarker)
+        SharedDataStore.shared.saveStatuslinePaceMarkerStepColors(paceMarkerStepColors)
+        SharedDataStore.shared.saveStatuslineShowContextLabel(showContextLabel)
 
         do {
             // Install scripts to ~/.claude/
@@ -243,7 +436,10 @@ struct ClaudeCodeView: View {
                 showProgressBar: showProgressBar,
                 showResetTime: showResetTime,
                 showProfile: showProfile,
-                profileName: profileName
+                profileName: profileName,
+                showPaceMarker: showPaceMarker,
+                paceMarkerStepColors: paceMarkerStepColors,
+                showContextLabel: showContextLabel
             )
 
             // Update Claude CLI settings.json
@@ -272,6 +468,7 @@ struct ClaudeCodeView: View {
     /// Generates a preview of what the statusline will look like based on current selections.
     private func generatePreview() -> String {
         var parts: [String] = []
+        let ctxPrefix = showContextLabel ? "Ctx: " : ""
 
         if showDirectory {
             parts.append("claude-usage")
@@ -292,16 +489,24 @@ struct ClaudeCodeView: View {
 
         if showContext {
             if contextAsTokens {
-                parts.append("Ctx: 96K")
+                parts.append("\(ctxPrefix)96K")
             } else {
-                parts.append("Ctx: 48%")
+                parts.append("\(ctxPrefix)48%")
             }
         }
 
         if showUsage {
-            var usageText = "Usage: 29%"
+            let percentage = 29
+            let filledBlocks = max(0, min(10, (percentage * 10 + 50) / 100))
+            let emptyBlocks = 10 - filledBlocks
+            var usageText = "Usage: \(percentage)%"
             if showProgressBar {
-                usageText += " ▓▓▓░░░░░░░"
+                var barChars = Array(String(repeating: "▓", count: filledBlocks) + String(repeating: "░", count: emptyBlocks))
+                if showPaceMarker {
+                    let markerPos = max(0, min(9, previewMarkerPosition))
+                    barChars[markerPos] = "┃"
+                }
+                usageText += " \(String(barChars))"
             }
             if showResetTime {
                 usageText += " → Reset: 14:30"
@@ -309,7 +514,7 @@ struct ClaudeCodeView: View {
             parts.append(usageText)
         }
 
-        return parts.isEmpty ? "claudecode.preview_no_components".localized : parts.joined(separator: " │ ")
+        return parts.isEmpty ? "claudecode.preview_no_components".localized : parts.joined(separator: " | ")
     }
 }
 

--- a/Claude Usage/Views/Settings/App/ManageProfilesView.swift
+++ b/Claude Usage/Views/Settings/App/ManageProfilesView.swift
@@ -194,7 +194,22 @@ struct ManageProfilesView: View {
                                 )
                             )
 
-                            // Pace-Aware Coloring Toggle
+                            // Pace Marker Toggle
+                            SettingToggle(
+                                title: "appearance.show_pace_marker_title".localized,
+                                description: "appearance.show_pace_marker_description".localized,
+                                isOn: Binding(
+                                    get: { profileManager.multiProfileConfig.showPaceMarker },
+                                    set: { showPace in
+                                        var config = profileManager.multiProfileConfig
+                                        config.showPaceMarker = showPace
+                                        profileManager.updateMultiProfileConfig(config)
+                                        NotificationCenter.default.post(name: .displayModeChanged, object: nil)
+                                    }
+                                )
+                            )
+
+                            // Pace-Aware Bar Colors Toggle
                             SettingToggle(
                                 title: "appearance.pace_coloring_title".localized,
                                 description: "appearance.pace_coloring_description".localized,

--- a/Claude Usage/Views/Settings/Profile/AppearanceSettingsView.swift
+++ b/Claude Usage/Views/Settings/Profile/AppearanceSettingsView.swift
@@ -46,9 +46,9 @@ struct AppearanceSettingsView: View {
                             title: "appearance.monochrome_title".localized,
                             description: "appearance.monochrome_description".localized,
                             isOn: Binding(
-                                get: { configuration.monochromeMode },
+                                get: { configuration.colorMode == .monochrome },
                                 set: { newValue in
-                                    configuration.monochromeMode = newValue
+                                    configuration.colorMode = newValue ? .monochrome : .multiColor
                                     saveConfiguration()
                                 }
                             )
@@ -85,6 +85,18 @@ struct AppearanceSettingsView: View {
                                 get: { configuration.showTimeMarker },
                                 set: { newValue in
                                     configuration.showTimeMarker = newValue
+                                    saveConfiguration()
+                                }
+                            )
+                        )
+
+                        SettingToggle(
+                            title: "appearance.show_pace_marker_title".localized,
+                            description: "appearance.show_pace_marker_description".localized,
+                            isOn: Binding(
+                                get: { configuration.showPaceMarker },
+                                set: { newValue in
+                                    configuration.showPaceMarker = newValue
                                     saveConfiguration()
                                 }
                             )


### PR DESCRIPTION
## Summary
- Adds a 6-tier pace status system (comfortable → on-track → warming → pressing → critical → runaway) that projects end-of-period usage from current consumption rate
- Pace-colored dots (4pt) in all menu bar icon styles: percentage, compact, compactDot, and multi-profile
- Pace-colored tick marks (2pt, round caps) for progress bar style icons
- Popover time marker restyled: wider (2.5pt), rounded, extends above/below the bar, colored by pace status
- Pace markers in greyscale mode render in color while the rest stays monochrome (`isTemplate = false` when pace is active)
- Settings toggles for show/hide pace marker and pace coloring in both single and multi-profile modes
- Pace defaults to off for new users — opt-in via Appearance settings
- Localized pace marker strings across all 9 languages (en, es, pt, de, ja, zh-ch, ko, fr, it)

## Files changed (19)
- `PaceStatus.swift` — new 6-tier pace enum with SwiftUI + AppKit colors
- `Color+Extensions.swift` — new hex color extensions (used by single-color mode)
- `MenuBarIconRenderer.swift` — pace dot/tick rendering in all icon styles
- `MenuBarIconConfig.swift` — showPaceMarker, usePaceColoring config properties
- `StatusBarUIManager.swift` — pace status computation, isTemplate logic
- `PopoverContentView.swift` — popover pace marker (colored, wider, rounded)
- `MenuBarManager.swift` — colorMode forwarding
- `AppearanceSettingsView.swift` / `ManageProfilesView.swift` — pace toggles
- `DataStore.swift` — legacy migration update
- 9x `Localizable.strings` — pace marker labels

## Test plan
- [ ] Enable pace marker in Appearance settings → verify colored dot appears next to menu bar icon
- [ ] Toggle greyscale mode with pace on → dot should remain colored while icon is grey
- [ ] Check all icon styles (percentage, compact, dot, progress bar, multi-profile)
- [ ] Open popover → time marker should be wider, rounded, and colored by pace
- [ ] Disable pace marker → dots and colored time marker should disappear
- [ ] Verify multi-profile mode pace toggles work independently
- [ ] Fresh install: pace should default to off

🤖 Generated with [Claude Code](https://claude.com/claude-code)