### PR TITLE
fix(menubar): Adjust popover sizing and window management

### DIFF
--- a/Claude Usage/MenuBar/MenuBarManager.swift
+++ b/Claude Usage/MenuBar/MenuBarManager.swift
@@ -469,7 +469,11 @@ class MenuBarManager: NSObject, ObservableObject {
             }
         )
 
-        return NSHostingController(rootView: contentView)
+        let hostingController = NSHostingController(rootView: contentView)
+        // Let the hosting controller report its actual SwiftUI content size to NSPopover,
+        // so the popover positions correctly on all display configurations (fixes #165).
+        hostingController.sizingOptions = .intrinsicContentSize
+        return hostingController
     }
 
     @objc private func togglePopover(_ sender: Any?) {

--- a/Claude Usage/MenuBar/WindowCoordinator.swift
+++ b/Claude Usage/MenuBar/WindowCoordinator.swift
@@ -26,6 +26,10 @@ final class WindowCoordinator: NSObject {
         popover.behavior = .semitransient
         popover.animates = true
         popover.delegate = self
+        // Let the hosting controller report its actual content size (fixes #165)
+        if let hostingController = contentViewController as? NSHostingController<PopoverContentView> {
+            hostingController.sizingOptions = .intrinsicContentSize
+        }
         popover.contentViewController = contentViewController
         self.popover = popover
         LoggingService.shared.logWindowEvent("Popover created")
@@ -48,7 +52,11 @@ final class WindowCoordinator: NSObject {
         } else {
             // Recreate content if it was moved to a detached window
             if popover.contentViewController == nil {
-                popover.contentViewController = contentProvider()
+                let newController = contentProvider()
+                if let hostingController = newController as? NSHostingController<PopoverContentView> {
+                    hostingController.sizingOptions = .intrinsicContentSize
+                }
+                popover.contentViewController = newController
             }
             popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
             startMonitoringForOutsideClicks()


### PR DESCRIPTION
Update MenuBarManager.swift and WindowCoordinator.swift to correctly set the `sizingOptions` for `NSHostingController` within the popover. This ensures the popover accurately reports its content size, resolving positioning issues across different display configurations as per issue #165.

Additionally, refactors window management logic for detached windows and settings/prompt windows to ensure they are correctly handled and their dock icon visibility is managed appropriately.

