### PR TITLE
feat(statusline): add weekly and extra usage segments

### DIFF
--- a/Claude Usage/Shared/Services/StatuslineService.swift
+++ b/Claude Usage/Shared/Services/StatuslineService.swift
@@ -134,6 +134,8 @@ if [ -f "$config_file" ]; then
   show_profile=$SHOW_PROFILE
   profile_name="$PROFILE_NAME"
   pace_marker_step_colors=$PACE_MARKER_STEP_COLORS
+  show_weekly=$SHOW_WEEKLY
+  show_extra_usage=$SHOW_EXTRA_USAGE
 else
   show_model=1
   show_dir=1
@@ -153,6 +155,8 @@ else
   show_profile=0
   profile_name=""
   pace_marker_step_colors=1
+  show_weekly=0
+  show_extra_usage=0
 fi
 
 input=$(cat)
@@ -514,6 +518,186 @@ if [ "$show_usage" = "1" ]; then
   fi
 fi
 
+weekly_text=""
+if [ "$show_weekly" = "1" ] && [ "$show_usage" = "1" ]; then
+  cache_file="$HOME/.claude/.statusline-usage-cache"
+  weekly_util=""
+  weekly_reset=""
+  if [ -f "$cache_file" ]; then
+    cache_ts=$(grep "^TIMESTAMP=" "$cache_file" 2>/dev/null | cut -d= -f2)
+    now_ts=$(date +%s)
+    if [ -n "$cache_ts" ]; then
+      cache_age=$((now_ts - cache_ts))
+      if [ "$cache_age" -lt 300 ]; then
+        weekly_util=$(grep "^WEEKLY_UTILIZATION=" "$cache_file" | cut -d= -f2)
+        weekly_reset=$(grep "^WEEKLY_RESETS_AT=" "$cache_file" | cut -d= -f2)
+      fi
+    fi
+  fi
+
+  if [ -n "$weekly_util" ]; then
+    if [ "$weekly_util" -le 10 ]; then
+      weekly_color="$LEVEL_1"
+    elif [ "$weekly_util" -le 20 ]; then
+      weekly_color="$LEVEL_2"
+    elif [ "$weekly_util" -le 30 ]; then
+      weekly_color="$LEVEL_3"
+    elif [ "$weekly_util" -le 40 ]; then
+      weekly_color="$LEVEL_4"
+    elif [ "$weekly_util" -le 50 ]; then
+      weekly_color="$LEVEL_5"
+    elif [ "$weekly_util" -le 60 ]; then
+      weekly_color="$LEVEL_6"
+    elif [ "$weekly_util" -le 70 ]; then
+      weekly_color="$LEVEL_7"
+    elif [ "$weekly_util" -le 80 ]; then
+      weekly_color="$LEVEL_8"
+    elif [ "$weekly_util" -le 90 ]; then
+      weekly_color="$LEVEL_9"
+    else
+      weekly_color="$LEVEL_10"
+    fi
+
+    if [ "$show_bar" = "1" ]; then
+      if [ "$weekly_util" -eq 0 ]; then
+        w_filled=0
+      elif [ "$weekly_util" -eq 100 ]; then
+        w_filled=10
+      else
+        w_filled=$(( (weekly_util * 10 + 50) / 100 ))
+      fi
+      [ "$w_filled" -lt 0 ] && w_filled=0
+      [ "$w_filled" -gt 10 ] && w_filled=10
+      w_empty=$((10 - w_filled))
+
+      weekly_bar=" "
+      i=0
+      while [ $i -lt $w_filled ]; do
+        weekly_bar="${weekly_bar}▓"
+        i=$((i + 1))
+      done
+      i=0
+      while [ $i -lt $w_empty ]; do
+        weekly_bar="${weekly_bar}░"
+        i=$((i + 1))
+      done
+    else
+      weekly_bar=""
+    fi
+
+    if [ "$show_pace_marker" = "1" ] && [ "$show_bar" = "1" ] && [ -n "$weekly_reset" ] && [ "$weekly_reset" != "null" ]; then
+      w_iso=$(echo "$weekly_reset" | sed 's/\\.[0-9]*Z$//')
+      w_reset_epoch=$(date -ju -f "%Y-%m-%dT%H:%M:%S" "$w_iso" "+%s" 2>/dev/null)
+      if [ -n "$w_reset_epoch" ]; then
+        now_epoch=$(date +%s)
+        w_remaining=$((w_reset_epoch - now_epoch))
+        if [ $w_remaining -gt 0 ] && [ $w_remaining -lt 604800 ]; then
+          w_elapsed=$((604800 - w_remaining))
+          w_marker_pos=$(( (w_elapsed * 10 + 302400) / 604800 ))
+          [ $w_marker_pos -gt 9 ] && w_marker_pos=9
+          [ $w_marker_pos -lt 0 ] && w_marker_pos=0
+
+          w_pace_color="$weekly_color"
+          if [ $w_elapsed -ge 3024 ] && [ "$pace_marker_step_colors" != "0" ]; then
+            w_projected=$((weekly_util * 604800 / w_elapsed))
+            if [ $w_projected -lt 50 ]; then
+              w_pace_color="$PACE_COMFORTABLE"
+            elif [ $w_projected -lt 75 ]; then
+              w_pace_color="$PACE_ON_TRACK"
+            elif [ $w_projected -lt 90 ]; then
+              w_pace_color="$PACE_WARMING"
+            elif [ $w_projected -lt 100 ]; then
+              w_pace_color="$PACE_PRESSING"
+            elif [ $w_projected -lt 120 ]; then
+              w_pace_color="$PACE_CRITICAL"
+            else
+              w_pace_color="$PACE_RUNAWAY"
+            fi
+          fi
+
+          if [ -n "$w_pace_color" ]; then
+            w_left="${weekly_bar:0:$((w_marker_pos + 1))}"
+            w_right="${weekly_bar:$((w_marker_pos + 2))}"
+            weekly_bar="${w_left}${w_pace_color}┃${RESET}${weekly_color}${w_right}"
+          fi
+        fi
+      fi
+    fi
+
+    weekly_reset_display=""
+    if [ "$show_reset" = "1" ] && [ -n "$weekly_reset" ] && [ "$weekly_reset" != "null" ]; then
+      w_iso=$(echo "$weekly_reset" | sed 's/\\.[0-9]*Z$//')
+      w_reset_epoch=$(date -ju -f "%Y-%m-%dT%H:%M:%S" "$w_iso" "+%s" 2>/dev/null)
+      if [ -n "$w_reset_epoch" ]; then
+        seconds_part=$((w_reset_epoch % 60))
+        if [ "$seconds_part" -ge 30 ]; then
+          w_reset_epoch=$((w_reset_epoch + (60 - seconds_part)))
+        else
+          w_reset_epoch=$((w_reset_epoch - seconds_part))
+        fi
+        if [ "$use_24h" = "1" ]; then
+          w_reset_time=$(date -r "$w_reset_epoch" "+%a %H:%M" 2>/dev/null)
+        else
+          w_reset_time=$(date -r "$w_reset_epoch" "+%a %I:%M %p" 2>/dev/null)
+        fi
+        [ -n "$w_reset_time" ] && weekly_reset_display=$(printf " → %s" "$w_reset_time")
+      fi
+    fi
+
+    if [ "$show_usage_label" = "1" ]; then
+      weekly_text="${weekly_color}Weekly: ${weekly_util}%${weekly_bar}${weekly_reset_display}${RESET}"
+    else
+      weekly_text="${weekly_color}${weekly_util}%${weekly_bar}${weekly_reset_display}${RESET}"
+    fi
+  fi
+fi
+
+extra_usage_text=""
+if [ "$show_extra_usage" = "1" ] && [ "$show_usage" = "1" ]; then
+  cache_file="$HOME/.claude/.statusline-usage-cache"
+  cost_used=""
+  cost_limit=""
+  cost_currency=""
+  if [ -f "$cache_file" ]; then
+    cache_ts=$(grep "^TIMESTAMP=" "$cache_file" 2>/dev/null | cut -d= -f2)
+    now_ts=$(date +%s)
+    if [ -n "$cache_ts" ]; then
+      cache_age=$((now_ts - cache_ts))
+      if [ "$cache_age" -lt 300 ]; then
+        cost_used=$(grep "^COST_USED=" "$cache_file" | cut -d= -f2)
+        cost_limit=$(grep "^COST_LIMIT=" "$cache_file" | cut -d= -f2)
+        cost_currency=$(grep "^COST_CURRENCY=" "$cache_file" | cut -d= -f2)
+      fi
+    fi
+  fi
+
+  if [ -n "$cost_used" ] && [ -n "$cost_limit" ] && [ -n "$cost_currency" ]; then
+    cost_pct=$(awk "BEGIN { p = int($cost_used / $cost_limit * 100); if (p > 100) p = 100; if (p < 0) p = 0; print p }")
+    if [ "$cost_pct" -le 10 ]; then
+      cost_color="$LEVEL_1"
+    elif [ "$cost_pct" -le 20 ]; then
+      cost_color="$LEVEL_2"
+    elif [ "$cost_pct" -le 30 ]; then
+      cost_color="$LEVEL_3"
+    elif [ "$cost_pct" -le 40 ]; then
+      cost_color="$LEVEL_4"
+    elif [ "$cost_pct" -le 50 ]; then
+      cost_color="$LEVEL_5"
+    elif [ "$cost_pct" -le 60 ]; then
+      cost_color="$LEVEL_6"
+    elif [ "$cost_pct" -le 70 ]; then
+      cost_color="$LEVEL_7"
+    elif [ "$cost_pct" -le 80 ]; then
+      cost_color="$LEVEL_8"
+    elif [ "$cost_pct" -le 90 ]; then
+      cost_color="$LEVEL_9"
+    else
+      cost_color="$LEVEL_10"
+    fi
+    extra_usage_text="${cost_color}${cost_used} ${cost_currency}${RESET}"
+  fi
+fi
+
 output=""
 separator="${GRAY} │ ${RESET}"
 
@@ -549,6 +733,18 @@ fi
 if [ -n "$usage_text" ]; then
   [ -n "$output" ] && output="${output}${separator}"
   output="${output}${usage_text}"
+fi
+
+# Then weekly usage
+if [ -n "$weekly_text" ]; then
+  [ -n "$output" ] && output="${output}${separator}"
+  output="${output}${weekly_text}"
+fi
+
+# Then extra usage
+if [ -n "$extra_usage_text" ]; then
+  [ -n "$output" ] && output="${output}${separator}"
+  output="${output}${extra_usage_text}"
 fi
 
 printf "%s\\n" "$output"
@@ -643,7 +839,9 @@ printf "%s\\n" "$output"
         colorMode: StatuslineColorMode = .colored,
         singleColorHex: String = "#00BFFF",
         showProfile: Bool,
-        profileName: String
+        profileName: String,
+        showWeekly: Bool = false,
+        showExtraUsage: Bool = false
     ) throws {
         let configPath = Constants.ClaudePaths.claudeDirectory
             .appendingPathComponent("statusline-config.txt")
@@ -677,6 +875,8 @@ COLOR_MODE=\(colorModeString)
 SINGLE_COLOR=\(singleColorHex)
 SHOW_PROFILE=\(showProfile ? "1" : "0")
 PROFILE_NAME="\(profileName)"
+SHOW_WEEKLY=\(showWeekly ? "1" : "0")
+SHOW_EXTRA_USAGE=\(showExtraUsage ? "1" : "0")
 """
 
         try config.write(to: configPath, atomically: true, encoding: .utf8)
@@ -780,6 +980,18 @@ PROFILE_NAME="\(profileName)"
 
         if let name = profileName {
             cacheContent += "\nPROFILE_NAME=\(name)"
+        }
+
+        let weeklyPct = Int(usage.weeklyPercentage)
+        cacheContent += "\nWEEKLY_UTILIZATION=\(weeklyPct)"
+        cacheContent += "\nWEEKLY_RESETS_AT=\(formatter.string(from: usage.weeklyResetTime))"
+
+        if let costUsed = usage.costUsed, let costLimit = usage.costLimit, let costCurrency = usage.costCurrency, costLimit > 0 {
+            let usedStr = String(format: "%.2f", costUsed / 100.0)
+            let limitStr = String(format: "%.2f", costLimit / 100.0)
+            cacheContent += "\nCOST_USED=\(usedStr)"
+            cacheContent += "\nCOST_LIMIT=\(limitStr)"
+            cacheContent += "\nCOST_CURRENCY=\(costCurrency)"
         }
 
         try? cacheContent.write(to: cachePath, atomically: true, encoding: .utf8)

--- a/Claude Usage/Shared/Services/StatuslineService.swift
+++ b/Claude Usage/Shared/Services/StatuslineService.swift
@@ -598,7 +598,7 @@ if [ "$show_weekly" = "1" ] && [ "$show_usage" = "1" ]; then
           [ $w_marker_pos -lt 0 ] && w_marker_pos=0
 
           w_pace_color="$weekly_color"
-          if [ $w_elapsed -ge 3024 ] && [ "$pace_marker_step_colors" != "0" ]; then
+          if [ "$pace_marker_step_colors" != "0" ] && [ $w_elapsed -ge 3024 ]; then
             w_projected=$((weekly_util * 604800 / w_elapsed))
             if [ $w_projected -lt 50 ]; then
               w_pace_color="$PACE_COMFORTABLE"
@@ -615,11 +615,10 @@ if [ "$show_weekly" = "1" ] && [ "$show_usage" = "1" ]; then
             fi
           fi
 
-          if [ -n "$w_pace_color" ]; then
-            w_left="${weekly_bar:0:$((w_marker_pos + 1))}"
-            w_right="${weekly_bar:$((w_marker_pos + 2))}"
-            weekly_bar="${w_left}${w_pace_color}┃${RESET}${weekly_color}${w_right}"
-          fi
+          # Always insert marker; w_pace_color may be empty (monochrome = no color wrap)
+          w_left="${weekly_bar:0:$((w_marker_pos + 1))}"
+          w_right="${weekly_bar:$((w_marker_pos + 2))}"
+          weekly_bar="${w_left}${w_pace_color}┃${RESET}${weekly_color}${w_right}"
         fi
       fi
     fi

--- a/Claude Usage/Shared/Storage/SharedDataStore.swift
+++ b/Claude Usage/Shared/Storage/SharedDataStore.swift
@@ -33,6 +33,8 @@ class SharedDataStore {
         static let statuslineUse24HourTime = "statuslineUse24HourTime"
         static let statuslineShowUsageLabel = "statuslineShowUsageLabel"
         static let statuslineShowResetLabel = "statuslineShowResetLabel"
+        static let statuslineShowWeekly = "statuslineShowWeekly"
+        static let statuslineShowExtraUsage = "statuslineShowExtraUsage"
         static let statuslineColorMode = "statuslineColorMode"
         static let statuslineSingleColorHex = "statuslineSingleColorHex"
 
@@ -247,6 +249,28 @@ class SharedDataStore {
             return true
         }
         return defaults.bool(forKey: Keys.statuslineShowResetLabel)
+    }
+
+    func saveStatuslineShowWeekly(_ show: Bool) {
+        defaults.set(show, forKey: Keys.statuslineShowWeekly)
+    }
+
+    func loadStatuslineShowWeekly() -> Bool {
+        if defaults.object(forKey: Keys.statuslineShowWeekly) == nil {
+            return false
+        }
+        return defaults.bool(forKey: Keys.statuslineShowWeekly)
+    }
+
+    func saveStatuslineShowExtraUsage(_ show: Bool) {
+        defaults.set(show, forKey: Keys.statuslineShowExtraUsage)
+    }
+
+    func loadStatuslineShowExtraUsage() -> Bool {
+        if defaults.object(forKey: Keys.statuslineShowExtraUsage) == nil {
+            return false
+        }
+        return defaults.bool(forKey: Keys.statuslineShowExtraUsage)
     }
 
     func saveStatuslineColorMode(_ mode: StatuslineColorMode) {

--- a/Claude Usage/Views/Settings/App/ClaudeCodeView.swift
+++ b/Claude Usage/Views/Settings/App/ClaudeCodeView.swift
@@ -27,6 +27,8 @@ struct ClaudeCodeView: View {
     @State private var showUsageLabel: Bool = SharedDataStore.shared.loadStatuslineShowUsageLabel()
     @State private var showContextLabel: Bool = SharedDataStore.shared.loadStatuslineShowContextLabel()
     @State private var showResetLabel: Bool = SharedDataStore.shared.loadStatuslineShowResetLabel()
+    @State private var showWeekly: Bool = SharedDataStore.shared.loadStatuslineShowWeekly()
+    @State private var showExtraUsage: Bool = SharedDataStore.shared.loadStatuslineShowExtraUsage()
 
     // Appearance settings
     @State private var colorMode: StatuslineColorMode = SharedDataStore.shared.loadStatuslineColorMode()
@@ -252,6 +254,20 @@ struct ClaudeCodeView: View {
                                             isOn: $showResetLabel
                                         )
                                     }
+
+                                    Divider()
+
+                                    SettingToggle(
+                                        title: "Show Weekly Usage",
+                                        description: "Weekly token usage with bar and reset time",
+                                        isOn: $showWeekly
+                                    )
+
+                                    SettingToggle(
+                                        title: "Show Extra Usage",
+                                        description: "Cost indicator (e.g., 9.49 USD)",
+                                        isOn: $showExtraUsage
+                                    )
                                 }
                                 .padding(.leading, DesignTokens.Spacing.cardPadding)
                             }
@@ -535,7 +551,58 @@ struct ClaudeCodeView: View {
                 }
             }
 
-            if !showDirectory && !showBranch && !showModel && !showProfile && !showContext && !showUsage {
+            if showWeekly && showUsage {
+                let usage = profileManager.activeProfile?.claudeUsage
+                let weeklyPct = usage != nil ? Int(usage!.weeklyPercentage) : 45
+                let weeklyColor = TerminalColors.usageLevel(weeklyPct)
+                if showDirectory || showBranch || showModel || showProfile || showContext || showUsage {
+                    Text(" │ ").foregroundColor(TerminalColors.gray)
+                }
+                let weeklyPrefix = showUsageLabel ? "Weekly: " : ""
+                Text("\(weeklyPrefix)\(weeklyPct)%")
+                    .foregroundColor(weeklyColor)
+                if showProgressBar {
+                    let wFilled = max(0, min(10, (weeklyPct + 5) / 10))
+                    let wEmpty = 10 - wFilled
+                    let wBar = String(repeating: "▓", count: wFilled) + String(repeating: "░", count: wEmpty)
+                    if showPaceMarker {
+                        let wMarkerPos = max(0, min(9, previewWeeklyMarkerPosition))
+                        let wChars = Array(wBar)
+                        Text(" " + String(wChars.prefix(wMarkerPos)))
+                            .foregroundColor(weeklyColor)
+                        Text("┃")
+                            .foregroundColor(previewWeeklyPaceColor(percentage: weeklyPct))
+                        Text(String(wChars.suffix(from: wMarkerPos + 1)))
+                            .foregroundColor(weeklyColor)
+                    } else {
+                        Text(" \(wBar)").foregroundColor(weeklyColor)
+                    }
+                }
+                if showResetTime {
+                    let weeklyResetString = formatWeeklyResetTime(usage?.weeklyResetTime)
+                    Text(" → \(weeklyResetString)").foregroundColor(weeklyColor)
+                }
+            }
+
+            if showExtraUsage && showUsage {
+                if showDirectory || showBranch || showModel || showProfile || showContext || showUsage || (showWeekly && showUsage) {
+                    Text(" │ ").foregroundColor(TerminalColors.gray)
+                }
+                if let claudeUsage = profileManager.activeProfile?.claudeUsage,
+                   let costUsed = claudeUsage.costUsed,
+                   let costLimit = claudeUsage.costLimit,
+                   let costCurrency = claudeUsage.costCurrency,
+                   costLimit > 0 {
+                    let costPct = min(100, Int(costUsed / costLimit * 100))
+                    let costColor = TerminalColors.usageLevel(costPct)
+                    Text(String(format: "%.2f %@", costUsed / 100.0, costCurrency))
+                        .foregroundColor(costColor)
+                } else {
+                    Text("– USD").foregroundColor(TerminalColors.gray)
+                }
+            }
+
+            if !showDirectory && !showBranch && !showModel && !showProfile && !showContext && !showUsage && !showWeekly && !showExtraUsage {
                 Text("claudecode.preview_no_components".localized)
                     .foregroundColor(.secondary)
             }
@@ -568,6 +635,14 @@ struct ClaudeCodeView: View {
         return formatter.string(from: date.roundedToNearestMinute())
     }
 
+    /// Formats weekly reset time for preview display (weekday + time)
+    private func formatWeeklyResetTime(_ date: Date?) -> String {
+        guard let date = date else { return "Mon --:--" }
+        let formatter = DateFormatter()
+        formatter.dateFormat = use24HourTime ? "EEE HH:mm" : "EEE h:mm a"
+        return formatter.string(from: date.roundedToNearestMinute())
+    }
+
     /// Returns the appropriate icon color for each color mode
     private func iconColorForMode(_ mode: StatuslineColorMode) -> Color {
         switch mode {
@@ -590,6 +665,18 @@ struct ClaudeCodeView: View {
             }
         }
         return 6 // Demo: 60% elapsed
+    }
+
+    /// Marker position for weekly preview (0-9), based on real elapsed time or demo
+    private var previewWeeklyMarkerPosition: Int {
+        if let usage = profileManager.activeProfile?.claudeUsage {
+            let remaining = usage.weeklyResetTime.timeIntervalSince(Date())
+            if remaining > 0 && remaining < 604800 {
+                let elapsed = 604800 - remaining
+                return max(0, min(9, Int(round(elapsed * 10.0 / 604800.0))))
+            }
+        }
+        return 3 // Demo: ~30% elapsed in weekly window
     }
 
     /// Pace color for the marker in preview, matching terminal ANSI colors
@@ -616,13 +703,37 @@ struct ClaudeCodeView: View {
         return TerminalColors.usageLevel(percentage)
     }
 
+    /// Pace color for the weekly marker in preview, matching terminal ANSI colors
+    private func previewWeeklyPaceColor(percentage: Int) -> Color {
+        guard paceMarkerStepColors else {
+            return TerminalColors.usageLevel(percentage)
+        }
+
+        let elapsedFraction: Double
+        if let usage = profileManager.activeProfile?.claudeUsage {
+            let remaining = usage.weeklyResetTime.timeIntervalSince(Date())
+            if remaining > 0 && remaining < 604800 {
+                elapsedFraction = (604800 - remaining) / 604800
+            } else {
+                elapsedFraction = 0.3
+            }
+        } else {
+            elapsedFraction = 0.3
+        }
+
+        if let paceStatus = PaceStatus.calculate(usedPercentage: Double(percentage), elapsedFraction: elapsedFraction) {
+            return TerminalColors.paceColor(for: paceStatus)
+        }
+        return TerminalColors.usageLevel(percentage)
+    }
+
     // MARK: - Actions
 
     /// Applies the current configuration to Claude Code statusline.
     /// Installs scripts, updates config file, and enables statusline in settings.json.
     private func applyConfiguration() {
         // Validate: at least one component must be selected
-        guard showModel || showDirectory || showBranch || showContext || showUsage || showProfile else {
+        guard showModel || showDirectory || showBranch || showContext || showUsage || showProfile || showWeekly || showExtraUsage else {
             statusMessage = "claudecode.error_no_components".localized
             isSuccess = false
             return
@@ -655,6 +766,8 @@ struct ClaudeCodeView: View {
         SharedDataStore.shared.saveStatuslineShowContextLabel(showContextLabel)
         SharedDataStore.shared.saveStatuslineShowUsageLabel(showUsageLabel)
         SharedDataStore.shared.saveStatuslineShowResetLabel(showResetLabel)
+        SharedDataStore.shared.saveStatuslineShowWeekly(showWeekly)
+        SharedDataStore.shared.saveStatuslineShowExtraUsage(showExtraUsage)
 
         do {
             // Write configuration file
@@ -677,7 +790,9 @@ struct ClaudeCodeView: View {
                 colorMode: colorMode,
                 singleColorHex: singleColorHex,
                 showProfile: showProfile,
-                profileName: profileName
+                profileName: profileName,
+                showWeekly: showWeekly,
+                showExtraUsage: showExtraUsage
             )
 
             // Update Claude CLI settings.json
@@ -766,6 +881,42 @@ struct ClaudeCodeView: View {
             }
 
             parts.append(usageText)
+        }
+
+        if showWeekly && showUsage {
+            let usage = profileManager.activeProfile?.claudeUsage
+            let weeklyPct = usage != nil ? Int(usage!.weeklyPercentage) : 45
+            var weeklyText = showUsageLabel ? "Weekly: \(weeklyPct)%" : "\(weeklyPct)%"
+
+            if showProgressBar {
+                let wFilled = max(0, min(10, (weeklyPct + 5) / 10))
+                let wEmpty = 10 - wFilled
+                var wChars = Array(String(repeating: "▓", count: wFilled) + String(repeating: "░", count: wEmpty))
+                if showPaceMarker {
+                    let wMarkerPos = max(0, min(9, previewWeeklyMarkerPosition))
+                    wChars[wMarkerPos] = "┃"
+                }
+                weeklyText += " \(String(wChars))"
+            }
+
+            if showResetTime {
+                let wResetStr = formatWeeklyResetTime(usage?.weeklyResetTime)
+                weeklyText += " → \(wResetStr)"
+            }
+
+            parts.append(weeklyText)
+        }
+
+        if showExtraUsage && showUsage {
+            if let claudeUsage = profileManager.activeProfile?.claudeUsage,
+               let costUsed = claudeUsage.costUsed,
+               let costLimit = claudeUsage.costLimit,
+               let costCurrency = claudeUsage.costCurrency,
+               costLimit > 0 {
+                parts.append(String(format: "%.2f %@", costUsed / 100.0, costCurrency))
+            } else {
+                parts.append("– USD")
+            }
         }
 
         return parts.isEmpty ? "claudecode.preview_no_components".localized : parts.joined(separator: " │ ")


### PR DESCRIPTION
## Description

Adds two new optional statusline segments to the Claude Code integration, both disabled by default.

## Changes

- **Show Weekly Usage** toggle in Settings → Claude Code: displays weekly token utilisation percentage with the existing progress bar, optional pace marker (incl. step colours), and reset countdown. Reads `WEEKLY_UTILIZATION` and `WEEKLY_RESETS_AT` from the statusline cache.
- **Show Extra Usage** toggle: displays the current overage spend in `cost currency` format (e.g. `9.49 USD`), colour-coded by percentage of the spend limit. Reads `COST_USED`, `COST_LIMIT`, and `COST_CURRENCY` from the cache.
- Both segments are gated on the existing **Show Usage** toggle (they hide automatically when main usage stats are disabled).
- Live preview in the Settings view reflects both new segments including bar, pace marker, and reset time.
- `StatuslineService.writeConfiguration` and the embedded bash script updated with `SHOW_WEEKLY` / `SHOW_EXTRA_USAGE` config flags.
- New `UserDefaults` keys: `statuslineShowWeekly`, `statuslineShowExtraUsage` (default `false`).

## Screenshots / Screen Recordings
<img width="766" height="796" alt="CleanShot 2026-03-13 at 22 32 58" src="https://github.com/user-attachments/assets/e37e5ae7-5b64-4a1d-b2e5-6aa0c7a21344" />
<img width="766" height="796" alt="CleanShot 2026-03-13 at 22 33 01" src="https://github.com/user-attachments/assets/b5a93174-535e-4dbc-9efa-3207d7beedee" />
<img width="1029" height="84" alt="CleanShot 2026-03-13 at 22 36 26" src="https://github.com/user-attachments/assets/a3b5eb01-c69a-4bf1-83ef-3cb87dff078a" />

## Important Guidelines

- No App Group or grouped Keychain usage introduced — standard `UserDefaults` only.
- Follows existing MVVM architecture: state in `SharedDataStore`, view bindings in `ClaudeCodeView`, bash rendering in `StatuslineService`.
- New `SettingToggle` title/description strings are hardcoded inline, consistent with the immediately surrounding toggles in the same section (e.g. `"Show \"Usage:\" label"`). Happy to add localization keys if the project wants to converge on that.

## Checklist

- [x] I have tested these changes on a running build
- [x] I have attached screenshots/recordings for any visual changes
- [x] I have not introduced App Group or grouped Keychain usage
- [ ] I have added localization keys for any new user-facing strings *(strings match existing non-localized pattern in this section — see note above)*