### PR TITLE
fix(statusline): fix pace marker hidden in monochrome mode

### DIFF
--- a/Claude Usage/Shared/Services/StatuslineService.swift
+++ b/Claude Usage/Shared/Services/StatuslineService.swift
@@ -254,8 +254,8 @@ else
   PACE_RUNAWAY=$'\\033[38;5;135m'     # purple
 fi
 
-# When pace step colors enabled, always use real 6-tier colors regardless of color mode
-if [ "$pace_marker_step_colors" != "0" ]; then
+# When pace step colors enabled, use real 6-tier colors (but not in monochrome mode)
+if [ "$pace_marker_step_colors" != "0" ] && [ "$color_mode" != "monochrome" ]; then
   PACE_COMFORTABLE=$'\\033[38;5;34m'
   PACE_ON_TRACK=$'\\033[38;5;37m'
   PACE_WARMING=$'\\033[38;5;178m'
@@ -430,9 +430,9 @@ if [ "$show_usage" = "1" ]; then
           [ $marker_pos -gt 9 ] && marker_pos=9
           [ $marker_pos -lt 0 ] && marker_pos=0
 
-          # Compute 6-tier pace color (integer math, >= 3% elapsed = 540s)
-          pace_color=""
-          if [ $elapsed_secs -ge 540 ]; then
+          # Compute pace color; fall back to usage_color (empty in monochrome = no color)
+          pace_color="$usage_color"
+          if [ "$pace_marker_step_colors" != "0" ] && [ $elapsed_secs -ge 540 ]; then
             projected_pct=$((utilization * 18000 / elapsed_secs))
             if [ $projected_pct -lt 50 ]; then
               pace_color="$PACE_COMFORTABLE"
@@ -449,18 +449,10 @@ if [ "$show_usage" = "1" ]; then
             fi
           fi
 
-          # Override: use usage bar color if step colors disabled
-          if [ "$pace_marker_step_colors" = "0" ]; then
-            pace_color="$usage_color"
-          fi
-
-          if [ -n "$pace_color" ]; then
-            # Replace bar character at marker_pos with bold ┃
-            # progress_bar = " " + 10 block chars; marker_pos+1 is the target index
-            left="${progress_bar:0:$((marker_pos + 1))}"
-            right="${progress_bar:$((marker_pos + 2))}"
-            progress_bar="${left}${pace_color}┃${RESET}${usage_color}${right}"
-          fi
+          # Always insert marker (color may be empty in monochrome = terminal default)
+          left="${progress_bar:0:$((marker_pos + 1))}"
+          right="${progress_bar:$((marker_pos + 2))}"
+          progress_bar="${left}${pace_color}┃${RESET}${usage_color}${right}"
         fi
       fi
 


### PR DESCRIPTION
## Summary

- In monochrome mode, the step-colors override block was unconditionally restoring ANSI codes for `PACE_*` variables, bypassing the intent of the mode
- `pace_color` was initialized to `""` and gated behind `if [ -n "$pace_color" ]`, which silently prevented marker insertion whenever colors were empty (always the case in monochrome with step colors disabled)
- Removes the `if [ -n "$pace_color" ]` guard — the `┃` marker should always be inserted when within a valid time window; an empty color simply renders in the terminal's default foreground, which is exactly right for monochrome

## Root cause

Two interacting bugs:

1. The step-colors override (lines ~261) ran unconditionally after the monochrome block had cleared all color vars, injecting real ANSI codes back in. Fixed by adding `&& [ "$color_mode" != "monochrome" ]`.

2. `pace_color` was only ever assigned inside an `elapsed_secs >= 540` guard. With the `if [ -n "$pace_color" ]` insertion guard, the marker was invisible for the first 9 minutes of every window — and permanently invisible in monochrome+step-colors-disabled because `usage_color` (the fallback) is also `""` in that mode. Fixed by initializing `pace_color="$usage_color"`, combining the step-colors and elapsed-time conditions, and removing the guard.

## Screenshots / Screen Recordings
<img width="800" height="150" alt="CleanShot 2026-03-13 at 23 18 14" src="https://github.com/user-attachments/assets/8d0ec8e7-903a-45e5-9bbe-c7065f3a9a9d" />
^ Before
<img width="800" height="150" alt="CleanShot 2026-03-13 at 23 17 24" src="https://github.com/user-attachments/assets/2f8ecbdf-9b9e-41e8-bd43-5102961513d6" />
^ After


## Test plan

- [x] Monochrome mode, step colors disabled: pace marker (`┃`) visible in progress bar
- [x] Monochrome mode, step colors enabled: pace marker visible, no ANSI color codes applied
- [x] Colored mode: pace marker behavior unchanged
- [x] Single color mode: pace marker behavior unchanged
- [x] Within first 9 minutes of window (elapsed < 540s): marker still appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)