### PR TITLE
Add Windows port mention for Windows users

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
   ### [Download Latest Release (v3.0.3)](https://github.com/hamed-elfayome/Claude-Usage-Tracker/releases/latest/download/Claude-Usage.zip)
 
   <sub>macOS 14.0+ (Sonoma) | ~6 MB | Native Swift/SwiftUI | Officially Signed</sub>
+> 🪟 **Windows user?** A community-maintained port is available: [ClaudeTracker for Windows](https://github.com/TobiiNT/ClaudeTracker) — built with WPF/.NET 8, includes pace tracking, ETA estimation, and WebView2 sign-in.
 
   <a href="https://www.buymeacoffee.com/hamedelfayome" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" height="40"></a>
 </div>
@@ -778,6 +779,9 @@ If automatic updates aren't working:
 <img src="https://contrib.rocks/image?repo=hamed-elfayome/Claude-Usage-Tracker" alt="Contributors" height="30px" />
 
 This project is built for the community — everyone is welcome
+
+### Windows Port
+- [ClaudeTracker for Windows](https://github.com/TobiiNT/ClaudeTracker) by [@TobiiNT](https://github.com/TobiiNT) — WPF/.NET 8 port for Windows users
 
 ### Special Thanks
 


### PR DESCRIPTION
## docs: add Windows port mention for Windows users

As mentioned in [#148](https://github.com/hamed-elfayome/Claude-Usage-Tracker/discussions/148), I've been maintaining a Windows port of this project — [ClaudeTracker](https://github.com/TobiiNT/ClaudeTracker), built with WPF/.NET 8.

This PR adds a small callout near the top of the README so Windows users who land on this repo know a maintained port exists, rather than bouncing when they see the macOS badge.

### What's changed
- Added a blockquote callout just before the Overview section pointing to the Windows port
- Added a mention under a new "Windows Port" entry in the Contributors section

### Why here
The top placement catches skimmers early. The Contributors section gives it proper attribution without cluttering the main content.

### About the Windows port (v1.2.0)
- 6-tier pace system with ETA estimation
- Claude system status indicator (live from status.claude.com)
- WebView2 browser sign-in (no manual session key copying)
- Setup wizard with 3 connection options
- Network auto-recovery
- 98 unit tests

Happy to adjust wording or placement to fit your README style — just let me know!