### PR TITLE
feat(localization): add Brazilian Portuguese (pt-BR) support

### DIFF
--- a/Claude Usage.xcodeproj/project.pbxproj
+++ b/Claude Usage.xcodeproj/project.pbxproj
@@ -154,6 +154,7 @@
 				de,
 				it,
 				pt,
+				"pt-BR",
 				ja,
 				ko,
 				"zh-ch",

--- a/Claude Usage/Resources/pt-BR.lproj/Localizable.strings
+++ b/Claude Usage/Resources/pt-BR.lproj/Localizable.strings
@@ -1,0 +1,945 @@
+/*
+   Localizable.strings
+   Claude Usage Tracker
+
+   Brazilian Portuguese (Português do Brasil)
+   Created by Hudson Arruda on 2026-03-18.
+*/
+
+/* ==================== */
+/* MARK: - App Info */
+/* ==================== */
+"app.name" = "Claude Usage Tracker";
+"app.window.main" = "Uso do Claude";
+"app.window.settings" = "Configurações";
+"app.window.github_prompt" = "Apoie o Claude Usage Tracker";
+
+/* ==================== */
+/* MARK: - Common Actions */
+/* ==================== */
+"common.ok" = "OK";
+"common.cancel" = "Cancelar";
+"common.save" = "Salvar";
+"common.delete" = "Excluir";
+"common.done" = "Concluído";
+"common.close" = "Fechar";
+"common.refresh" = "Atualizar";
+"common.settings" = "Configurações";
+"common.quit" = "Sair";
+"common.validate" = "Validar";
+"common.yes" = "Sim";
+"common.no" = "Não";
+
+/* ==================== */
+/* MARK: - Settings Navigation */
+/* ==================== */
+"settings.title" = "Configurações";
+"settings.personal_usage" = "Uso Pessoal";
+"settings.personal_usage.description" = "Rastreie seu uso do plano gratuito do Claude.ai";
+"settings.api_billing" = "Faturamento da API";
+"settings.api_billing.description" = "Monitore faturamento e créditos do Console da API";
+"settings.general" = "Geral";
+"settings.general.description" = "Comportamento e preferências do aplicativo";
+"settings.appearance" = "Aparência";
+"settings.appearance.description" = "Personalização do ícone da barra de menu";
+"settings.session_management" = "Gerenciamento de Sessão";
+"settings.session_management.description" = "Gerenciamento automático de sessão";
+"settings.notifications" = "Notificações";
+"settings.notifications.description" = "Alertas de uso e notificações";
+"settings.claude_cli" = "Claude CLI";
+"settings.claude_cli.description" = "Integração com linha de status do terminal";
+"settings.about" = "Sobre";
+"settings.about.description" = "Informações e créditos do aplicativo";
+
+/* ==================== */
+/* MARK: - Menu Bar */
+/* ==================== */
+"menubar.claude_usage" = "Uso do Claude";
+"menubar.session_usage" = "Uso da Sessão";
+"menubar.weekly_usage" = "Semanal";
+"menubar.opus_usage" = "Opus";
+"menubar.sonnet_usage" = "Sonnet";
+"menubar.extra_usage" = "Uso Extra";
+"menubar.api_credits" = "Créditos da API";
+"menubar.5_hour_window" = "Janela móvel de 5 horas";
+"menubar.all_models" = "Todos os modelos";
+"menubar.weekly" = "Semanal";
+"menubar.anthropic_console" = "Console da API Anthropic";
+"menubar.used" = "Usado";
+"menubar.remaining" = "Restante";
+"menubar.resets_time" = "Reinicia %@";
+"menubar.resets_in" = "Reinicia em %@";
+"menubar.resets_both" = "Reinicia em %@ (%@)";
+"menubar.click_status" = "Clique para abrir status.claude.com";
+
+/* ==================== */
+/* MARK: - Usage Status */
+/* ==================== */
+"usage.high_session" = "Uso Alto da Sessão";
+"usage.high_session.desc" = "Considere fazer uma pausa para reiniciar sua janela de sessão";
+"usage.weekly_approaching" = "Aproximando do Limite Semanal";
+"usage.weekly_approaching.desc" = "Você está próximo do seu limite semanal de tokens";
+"usage.efficient" = "Uso Eficiente";
+"usage.efficient.desc" = "Ótimo trabalho gerenciando seu consumo de tokens!";
+
+/* ==================== */
+/* MARK: - General Settings */
+/* ==================== */
+"general.launch_at_login" = "Iniciar ao fazer login";
+"general.launch_at_login.description" = "Iniciar automaticamente o Claude Usage Tracker ao fazer login no seu Mac";
+"general.refresh_interval" = "Intervalo de Atualização";
+"general.refresh_interval.description" = "Intervalos menores fornecem dados mais em tempo real, mas podem impactar a vida útil da bateria";
+"general.check_overage_limit" = "Verificar Limite de Uso Extra";
+"general.check_overage_limit.description" = "Buscar e exibir custo mensal e informações de limite de uso extra";
+"general.language.title" = "Idioma";
+"general.language.select" = "Selecionar Idioma";
+"general.language.restart_note" = "As alterações de idioma entrarão em vigor após reiniciar o aplicativo";
+"general.language.restart_app" = "Reiniciar para Aplicar";
+
+/* ==================== */
+/* MARK: - Appearance Settings */
+/* ==================== */
+"appearance.menu_bar_icons" = "Ícones da Barra de Menu";
+"appearance.menu_bar_icons.subtitle" = "Personalize quais métricas aparecem na sua barra de menu";
+"appearance.show_icon_names" = "Mostrar nomes dos ícones";
+"appearance.show_icon_names.description" = "Exibir rótulos de métricas (S:, W:, API:) ao lado dos ícones";
+"appearance.monochrome_mode" = "Monocromático (Adaptativo)";
+"appearance.monochrome_mode.description" = "Os ícones se adaptam automaticamente ao modo claro/escuro";
+"appearance.metric_configuration" = "Configuração de Métricas";
+"appearance.drag_to_reorder" = "Arraste para reordenar os ícones. Métricas desabilitadas ficam ocultas da barra de menu.";
+
+/* ==================== */
+/* MARK: - Session Management */
+/* ==================== */
+"session.auto_start" = "Iniciar sessão automaticamente ao reiniciar";
+"session.auto_start.description" = "Enviar automaticamente 'Oi' para o Claude quando sua sessão reiniciar para 0%. Isso mantém sua sessão sempre pronta sem intervenção manual.";
+"session.enable_auto_start" = "Habilitar início automático de sessão";
+"session.beta_badge" = "BETA";
+
+/* ==================== */
+/* MARK: - Notifications Settings */
+/* ==================== */
+"notifications.enable" = "Habilitar notificações";
+"notifications.enable.description" = "Receber alertas ao se aproximar dos limites de uso";
+"notifications.alert_thresholds" = "Limites de Alerta";
+"notifications.threshold.warning" = "Aviso";
+"notifications.threshold.high" = "Uso Alto";
+"notifications.threshold.critical" = "Crítico";
+"notifications.threshold.session_reset" = "Reinício de Sessão";
+
+/* ==================== */
+/* MARK: - Setup Wizard */
+/* ==================== */
+"setup.welcome.title" = "Bem-vindo ao Claude Usage Tracker";
+"setup.welcome.subtitle" = "Configure seu acesso à API para começar a rastrear o uso";
+"setup.step.get_session_key" = "Obtenha Sua Chave de Sessão";
+"setup.step.get_session_key.description" = "Você precisará extrair sua chave de sessão do claude.ai";
+"setup.step.enter_session_key" = "Digite Sua Chave de Sessão";
+"setup.open_claude_ai" = "Abrir claude.ai";
+"setup.show_instructions" = "Mostrar Instruções";
+"setup.hide_instructions" = "Ocultar";
+"setup.instruction.step1" = "Abra as Ferramentas do Desenvolvedor (F12 ou Cmd+Option+I)";
+"setup.instruction.step2" = "Vá para Application/Storage → Cookies → https://claude.ai";
+"setup.instruction.step3" = "Encontre o cookie 'sessionKey'";
+"setup.instruction.step4" = "Clique duas vezes no seu Valor e copie (Cmd+C)";
+"setup.paste_session_key" = "Cole o valor de sessionKey que você copiou";
+"setup.auto_start_session" = "Iniciar sessão automaticamente ao reiniciar";
+"setup.auto_start_session.description" = "Enviar automaticamente 'Oi' para o Claude quando sua sessão reiniciar para 0%. Isso mantém sua sessão sempre pronta sem intervenção manual.";
+"setup.enable_auto_start" = "Habilitar início automático de sessão";
+"setup.menubar_appearance" = "Aparência da Barra de Menu";
+"setup.choose_icon_style" = "Escolha seu estilo de ícone preferido";
+"setup.monochrome_adaptive" = "Monocromático (Adaptativo)";
+"setup.validation.success" = "Conectado com sucesso à organização";
+
+/* ==================== */
+/* MARK: - About */
+/* ==================== */
+"about.version" = "Versão %@";
+"about.created_by" = "Criado Por";
+"about.contributors" = "Colaboradores (%d)";
+"about.contributors_loading" = "Colaboradores";
+"about.links" = "Links";
+"about.star_github" = "Dar Estrela no GitHub";
+"about.report_issue" = "Reportar Problema";
+"about.send_feedback" = "Enviar Feedback";
+"about.mit_license" = "Licença MIT • Código Aberto";
+"about.copyright" = "© 2025 Hamed Elfayome";
+
+/* ==================== */
+/* MARK: - Icon Styles */
+/* ==================== */
+"icon_style.battery" = "Bateria";
+"icon_style.percentage" = "Porcentagem";
+"icon_style.text_only" = "Apenas Texto";
+"icon_style.minimal" = "Minimalista";
+
+/* ==================== */
+/* MARK: - Metric Types */
+/* ==================== */
+"metric.session_usage" = "Uso da Sessão";
+"metric.session_usage.description" = "Janela móvel de uso de 5 horas";
+"metric.week_usage" = "Uso Semanal";
+"metric.week_usage.description" = "Uso semanal de tokens (todos os modelos)";
+"metric.api_credits" = "Créditos da API";
+"metric.api_credits.description" = "Créditos de faturamento do Console da API";
+
+/* ==================== */
+/* MARK: - Display Modes */
+/* ==================== */
+"display.remaining_credits" = "Créditos Restantes";
+"display.remaining_credits.description" = "Mostrar apenas créditos restantes";
+"display.used_amount" = "Valor Usado";
+"display.used_amount.description" = "Mostrar apenas valor gasto";
+"display.both_used_total" = "Ambos (Usado / Total)";
+"display.both_used_total.description" = "Mostrar usado e total";
+"display.percentage" = "Porcentagem";
+"display.percentage.description" = "Mostrar como porcentagem (ex: 60%)";
+"display.token_count" = "Contagem de Tokens";
+"display.token_count.description" = "Mostrar números de tokens (ex: 600K/1M)";
+
+/* ==================== */
+/* MARK: - Notification Messages */
+/* ==================== */
+"notification.session_warning.title" = "Aviso de Uso da Sessão";
+"notification.session_warning.message" = "Você usou %@ do seu limite de sessão de 5 horas. %@";
+"notification.session_critical.title" = "Uso da Sessão Crítico";
+"notification.session_critical.message" = "Você usou %@ do seu limite de sessão de 5 horas! %@";
+"notification.session_reset.title" = "Sessão Reiniciada";
+"notification.session_reset.message" = "Sua sessão foi reiniciada! Você agora tem uma nova sessão de 5 horas disponível.";
+"notification.session_auto_started.title" = "Sessão Iniciada Automaticamente";
+"notification.session_auto_started.message" = "Uma nova sessão foi inicializada automaticamente com o Claude. Sua nova sessão de 5 horas está pronta!";
+"notification.session_auto_start_failed.title" = "Falha no Início Automático";
+"notification.session_auto_start_failed.message" = "Falha ao iniciar sessão automaticamente. Verifique suas credenciais.";
+"notification.weekly_warning.title" = "Aviso de Uso Semanal";
+"notification.weekly_warning.message" = "Você usou %@ do seu limite semanal. %@";
+"notification.weekly_critical.title" = "Uso Semanal Crítico";
+"notification.weekly_critical.message" = "Você usou %@ do seu limite semanal! %@";
+"notification.opus_warning.title" = "Aviso de Uso do Opus";
+"notification.opus_warning.message" = "Você usou %@ do seu limite semanal do Opus. %@";
+"notification.opus_critical.title" = "Uso do Opus Crítico";
+"notification.opus_critical.message" = "Você usou %@ do seu limite semanal do Opus! %@";
+"notification.enabled.title" = "Notificações Habilitadas";
+"notification.enabled.message" = "Você agora receberá alertas em 75%, 90% e 95% dos limites de uso, além de notificações de reinício de sessão.";
+"notification.profile_auto_switched.title" = "Perfil alternado automaticamente";
+"notification.profile_auto_switched.message" = "%@ → %@ devido ao limite de sessão atingido";
+
+/* ==================== */
+/* MARK: - Auto-Switch Profile */
+/* ==================== */
+"auto_switch.title" = "Troca automática de perfil";
+"auto_switch.subtitle" = "Trocar automaticamente quando o limite de sessão for atingido";
+"auto_switch.enable_title" = "Ativar troca automática";
+"auto_switch.enable_description" = "Quando o perfil ativo atinge 100% de uso da sessão, trocar automaticamente para o próximo perfil disponível";
+
+/* ==================== */
+/* MARK: - Error Messages */
+/* ==================== */
+"error.session_key_not_found" = "Nenhuma chave de sessão encontrada";
+"error.session_key_not_found.suggestion" = "Por favor, configure sua chave de sessão do Claude nas Configurações";
+"error.session_key_invalid" = "Chave de sessão inválida";
+"error.session_key_invalid.suggestion" = "Por favor, verifique o formato da sua chave de sessão. Ela deve começar com 'sk-ant-'";
+"error.network_unavailable" = "Sem conexão com a internet";
+"error.network_unavailable.suggestion" = "Por favor, verifique sua conexão com a internet e tente novamente";
+"error.network_timeout" = "Tempo de solicitação esgotado";
+"error.network_timeout.suggestion" = "Por favor, tente novamente. Se o problema persistir, verifique o status do Claude em status.claude.com";
+"error.api_unauthorized" = "Acesso não autorizado";
+"error.api_unauthorized.suggestion" = "Sua chave de sessão pode ter expirado. Por favor, atualize-a nas Configurações";
+"error.api_server_error" = "Erro do servidor";
+"error.api_server_error.suggestion" = "O servidor encontrou um erro. Por favor, tente novamente mais tarde";
+"error.api_rate_limited" = "Limite de taxa excedido";
+"error.api_rate_limited.suggestion" = "Por favor, aguarde alguns momentos antes de tentar novamente";
+
+/* ==================== */
+/* MARK: - Validation Messages */
+/* ==================== */
+"validation.session_key_too_short" = "Chave de sessão muito curta";
+"validation.session_key_too_long" = "Chave de sessão muito longa";
+"validation.invalid_prefix" = "Prefixo de chave de sessão inválido";
+"validation.invalid_characters" = "Caracteres inválidos na chave de sessão";
+"validation.invalid_format" = "Formato de chave de sessão inválido";
+"validation.contains_whitespace" = "A chave de sessão contém espaços em branco";
+
+/* ==================== */
+/* MARK: - GitHub Star Prompt */
+/* ==================== */
+"github.enjoy_app" = "Gostando do Claude Usage Tracker?";
+"github.star_description" = "Se este aplicativo foi útil, considere dar uma estrela no GitHub! Isso ajuda outras pessoas a descobrir o projeto e motiva o desenvolvimento contínuo.";
+"github.star_button" = "Dar Estrela no GitHub";
+"github.maybe_later" = "Talvez Mais Tarde";
+"github.never_show" = "Não Mostrar Novamente";
+
+/* ==================== */
+/* MARK: - API Settings */
+/* ==================== */
+"api.enable_tracking" = "Habilitar rastreamento da API";
+"api.enable_tracking.description" = "Rastreie seus créditos e gastos do Console da API Anthropic";
+"api.session_key_placeholder" = "sk-ant-api03-...";
+"api.configure" = "Configurar Rastreamento da API";
+"api.configure.description" = "Monitore o uso e créditos da sua API do Console Anthropic";
+"api.instructions" = "Para rastrear o uso da API, você precisa fornecer sua chave de sessão da API:";
+"api.instruction_step1" = "Faça login em console.anthropic.com";
+"api.instruction_step2" = "Abra as Ferramentas do Desenvolvedor (F12 ou Cmd+Option+I)";
+"api.instruction_step3" = "Vá para Application → Cookies → https://console.anthropic.com";
+"api.instruction_step4" = "Encontre 'sessionKey' e copie seu valor";
+
+/* ==================== */
+/* MARK: - Personal Usage */
+/* ==================== */
+"personal.configure" = "Configurar Uso Pessoal";
+"personal.configure.description" = "Rastreie seu uso do plano gratuito no claude.ai";
+"personal.status" = "Status";
+"personal.session_key" = "Chave de Sessão";
+"personal.session_key.configured" = "Configurada";
+"personal.session_key.not_configured" = "Não Configurada";
+"personal.reconfigure" = "Reconfigurar";
+"personal.remove" = "Remover Chave de Sessão";
+
+/* ==================== */
+/* MARK: - Claude Code (CLI) */
+/* ==================== */
+"claudecode.title" = "Integração com Claude CLI";
+"claudecode.description" = "Exibir informações de uso na linha de status do seu terminal";
+"claudecode.coming_soon" = "Em Breve";
+"claudecode.features_description" = "A integração com o Claude Code CLI para exibição na linha de status do terminal chegará em uma atualização futura.";
+
+/* ==================== */
+/* MARK: - Additional UI Labels */
+/* ==================== */
+"ui.app_behavior" = "Comportamento do Aplicativo";
+"ui.usage_tracking" = "Rastreamento de Uso";
+"ui.global_settings" = "Configurações Globais";
+"ui.menu_bar_metrics" = "Métricas da Barra de Menu";
+"ui.quick_actions" = "Ações Rápidas";
+"ui.how_it_works" = "Como funciona";
+"ui.display_components" = "Componentes de Exibição";
+"ui.requirements" = "Requisitos";
+"ui.live_preview" = "Visualização ao Vivo";
+"ui.updates_realtime" = "Atualizações em tempo real";
+"ui.organization" = "Organização";
+"ui.icon_style" = "Estilo do Ícone";
+"ui.display_mode" = "Modo de Exibição";
+"ui.at_least_one_metric" = "Pelo menos uma métrica deve estar habilitada";
+
+/* ==================== */
+/* MARK: - Session Management (Additional) */
+/* ==================== */
+"session.subtitle" = "Inicialização e manutenção automática de sessão";
+"session.auto_description_line1" = "• Detecta quando sua sessão reinicia para 0%";
+"session.auto_description_line2" = "• Envia 'Oi' para o Claude (modelo mais barato)";
+"session.auto_description_line3" = "• Usa um chat temporário que não aparecerá no seu histórico";
+"session.auto_description_line4" = "• Nova sessão de 5 horas fica pronta instantaneamente";
+
+/* ==================== */
+/* MARK: - Claude CLI (Additional) */
+/* ==================== */
+"claudecode.subtitle" = "Personalize a exibição da linha de status do seu terminal";
+"claudecode.preview_label" = "Visualização ao Vivo";
+"claudecode.preview_description" = "É assim que sua linha de status aparecerá no Claude CLI";
+"claudecode.component_model" = "Nome do modelo";
+"claudecode.component_directory" = "Nome do diretório";
+"claudecode.component_branch" = "Branch do Git";
+"claudecode.component_context" = "Janela de contexto";
+"claudecode.component_context_tokens" = "Mostrar como tokens (em vez de %)";
+"claudecode.component_usage" = "Estatísticas de uso";
+"claudecode.component_progressbar" = "Barra de progresso";
+"claudecode.component_pace_marker" = "Marcador de ritmo";
+"claudecode.pace_marker_info" = "Mostra uma marca colorida na posição do tempo decorrido";
+"claudecode.component_resettime" = "Hora de reinício";
+"claudecode.requirement_sessionkey" = "• Chave de sessão configurada em Credenciais → aba Claude.ai";
+"claudecode.requirement_restart" = "• Reiniciar Claude CLI após aplicar as alterações";
+"claudecode.error_no_components" = "Por favor, selecione pelo menos um componente para exibir";
+"claudecode.error_no_sessionkey" = "Chave de sessão não configurada. Por favor, configure-a primeiro na aba Uso Pessoal.";
+"claudecode.success_applied" = "Configuração aplicada! Reinicie o Claude CLI para ver as alterações.";
+"claudecode.success_disabled" = "Linha de status desabilitada. Reinicie o Claude CLI.";
+"claudecode.preview_no_components" = "Nenhum componente selecionado";
+
+/* ==================== */
+/* MARK: - API Billing (Additional) */
+/* ==================== */
+"api.title" = "Faturamento da API";
+"api.subtitle" = "Monitore o uso e gastos da API";
+"api.enable_billing_tracking" = "Habilitar rastreamento de faturamento da API";
+"api.enable_billing_description" = "Monitore seu uso da API, gastos atuais e créditos pré-pagos restantes";
+"api.label_api_session_key" = "Chave de Sessão da API";
+"api.placeholder_api_session_key" = "sk-ant-api03-...";
+"api.help_api_session_key" = "Sua chave de sessão de console.anthropic.com";
+"api.button_fetch_organizations" = "Buscar Organizações";
+"api.button_fetching" = "Buscando...";
+"api.button_save_configuration" = "Salvar Configuração";
+"api.success_organizations_found" = "Encontrada(s) %d organização(ões)";
+"api.error_fetch_failed" = "Falha ao buscar organizações: %@";
+"api.success_configuration_saved" = "Configuração da API salva com sucesso";
+
+/* ==================== */
+/* MARK: - Personal Usage (Additional) */
+/* ==================== */
+"personal.title" = "Uso Pessoal";
+"personal.subtitle" = "Rastreie seu uso e sessões do Claude.ai";
+"personal.label_session_key" = "Chave de Sessão";
+"personal.placeholder_session_key" = "sk-ant-sid-...";
+"personal.help_session_key" = "Cole seu cookie sessionKey do DevTools do claude.ai";
+"personal.button_test_connection" = "Testar Conexão";
+"personal.button_save_and_continue" = "Salvar e Continuar";
+"personal.button_remove_key" = "Remover Chave";
+"personal.success_connected" = "Conectado com sucesso à organização";
+"personal.confirm_remove_title" = "Remover Chave de Sessão?";
+"personal.confirm_remove_message" = "Isso interromperá o rastreamento do seu uso pessoal.";
+
+/* ==================== */
+/* MARK: - Error Presenter */
+/* ==================== */
+"error.code_label" = "Código do Erro:";
+"error.what_to_do" = "O que fazer:";
+"error.occurred_at" = "Ocorreu em: %@";
+
+/* ==================== */
+/* MARK: - General Settings (Additional) */
+/* ==================== */
+"general.slider_realtime" = "Atualizações em tempo real";
+"general.slider_frequent" = "Atualizações frequentes";
+"general.slider_balanced" = "Modo balanceado";
+"general.slider_efficient" = "Economia de energia";
+"general.slider_battery_saver" = "Economia de bateria";
+"general.slider_fast" = "Rápido";
+"general.slider_balanced_label" = "Balanceado";
+"general.slider_battery_saver_label" = "Economia de Bateria";
+"general.available_languages" = "Idiomas Disponíveis (%d)";
+
+/* ==================== */
+/* MARK: - Badges */
+/* ==================== */
+"badge.new" = "NOVO";
+"badge.beta" = "BETA";
+"badge.pro" = "PRO";
+
+/* ==================== */
+/* MARK: - Appearance (Additional) */
+/* ==================== */
+"appearance.title" = "Aparência da Barra de Menu";
+"appearance.subtitle" = "Personalize seus ícones e métricas da barra de menu";
+"appearance.global_settings" = "Configurações Globais";
+"appearance.menu_bar_metrics" = "Métricas da Barra de Menu";
+"appearance.monochrome_title" = "Monocromático";
+"appearance.monochrome_description" = "Usar cor adaptativa em vez de cores de status (verde/laranja/vermelho)";
+"appearance.show_labels_title" = "Mostrar Rótulos dos Ícones";
+"appearance.show_labels_description" = "Exibir rótulos de prefixo (S:, W:, API:) para cada métrica";
+"appearance.show_remaining_title" = "Mostrar Porcentagem Restante";
+"appearance.show_remaining_description" = "Exibir capacidade restante em vez da porcentagem usada (como a bateria do macOS)";
+"appearance.pace_marker_section_title" = "Marcador de Ritmo";
+"appearance.pace_marker_section_subtitle" = "Acompanhe o ritmo de uso em relação aos períodos de reinício";
+"appearance.show_time_marker_title" = "Mostrar marcador de tempo";
+"appearance.show_time_marker_description" = "Exibir uma marca nas barras de progresso mostrando quanto do período de tempo já passou";
+"appearance.show_pace_marker_title" = "Colorir marcador por ritmo";
+"appearance.show_pace_marker_description" = "Colore o marcador de tempo pelo ritmo de uso projetado (verde → roxo). Aplica-se a métricas de sessão e semanais.";
+"appearance.pace_coloring_title" = "Cores de barra por ritmo";
+"appearance.pace_coloring_description" = "Colorir barras de progresso com base no ritmo projetado em vez do nível de uso atual. Projeta se você atingirá os limites até o final do período.";
+"appearance.multiprofile_locked_title" = "Configurações de Aparência Bloqueadas";
+"appearance.multiprofile_locked_description" = "Estas configurações estão desativadas enquanto a Exibição Multi-Perfil está ativa. Cada perfil usa sua própria aparência no modo multi-perfil.";
+"appearance.disable_multiprofile" = "Desativar Exibição Multi-Perfil";
+
+/* ==================== */
+/* MARK: - Setup Wizard (Additional) */
+/* ==================== */
+"setup.step_number_1" = "1";
+"setup.step_number_2" = "2";
+"setup.step_title_get_key" = "Obtenha Sua Chave de Sessão";
+"setup.step_title_enter_key" = "Digite Sua Chave de Sessão";
+"setup.step_description_get_key" = "Você precisará extrair sua chave de sessão do claude.ai";
+"setup.button_open_claude" = "Abrir claude.ai";
+"setup.paste_instruction" = "Cole o valor de sessionKey que você copiou";
+
+/* ==================== */
+/* MARK: - Component Preview */
+/* ==================== */
+"preview.sample_text_claude" = "Claude";
+"preview.sample_percentage" = "60%";
+"preview.sample_card_content" = "O conteúdo do card vai aqui";
+"preview.sample_more_content" = "Mais conteúdo";
+"preview.sample_update_every" = "Atualizar a cada:";
+"preview.sample_5_minutes" = "5 minutos";
+
+/* ==================== */
+/* MARK: - New Keys Added */
+/* ==================== */
+"api.single_organization" = "Organização única encontrada e selecionada automaticamente";
+"claudecode.button_apply" = "Aplicar";
+"claudecode.button_reset" = "Redefinir";
+"claudecode.component_profile" = "Nome do perfil";
+"claudecode.context_info" = "O contexto pode mostrar ~80-95% em vez de 100% — o Claude comprime automaticamente antes do limite, e os tokens de saída também usam espaço de contexto.";
+"error.generic" = "Erro: %@";
+"personal.button_saving" = "Salvando...";
+"personal.button_setup_wizard" = "Assistente de Configuração";
+"personal.button_open_claude" = "Abrir claude.ai";
+"personal.success_key_saved" = "Chave de sessão salva com sucesso";
+
+/* ==================== */
+/* MARK: - Updates Settings */
+/* ==================== */
+"settings.updates.title" = "Atualizações de Software";
+"settings.updates.current_version" = "Versão Atual";
+"settings.updates.last_check" = "Última Verificação";
+"settings.updates.never_checked" = "Nunca";
+"settings.updates.automatic" = "Atualizações Automáticas";
+"settings.updates.automatic.description" = "Verificar e baixar atualizações automaticamente todos os dias";
+"settings.updates.check_now" = "Verificar Atualizações";
+"settings.updates.info.title" = "Atualizações Seguras";
+"settings.updates.info.description" = "Todas as atualizações são assinadas criptograficamente e verificadas antes da instalação";
+"about.check_updates" = "Verificar Atualizações";
+
+/* ==================== */
+/* MARK: - Manage Profiles */
+/* ==================== */
+"profiles.title" = "Gerenciar Perfis";
+"profiles.subtitle" = "Criar e gerenciar várias contas Claude";
+"profiles.create_new" = "Criar Novo Perfil";
+"profiles.about_title" = "Sobre Perfis";
+"profiles.about_description" = "Cada perfil tem seu próprio:";
+"profiles.about_credentials" = "Credenciais Claude.ai";
+"profiles.about_api" = "Credenciais do Console API";
+"profiles.about_cli" = "Sincronização de conta CLI";
+"profiles.about_appearance" = "Aparência da barra de menu";
+"profiles.about_notifications" = "Configurações de notificação";
+"profiles.about_refresh" = "Intervalo de atualização";
+"profiles.active_badge" = "Ativo";
+"profiles.created" = "Criado";
+"profiles.cli_synced" = "CLI Sincronizado";
+"profiles.rename" = "Renomear perfil";
+"profiles.activate" = "Ativar perfil";
+"profiles.delete" = "Excluir perfil";
+"profiles.delete_title" = "Excluir Perfil";
+"profiles.delete_confirm" = "Tem certeza que deseja excluir \"%@\"? Isso removerá todas as credenciais e configurações associadas.";
+"profiles.create_title" = "Criar Novo Perfil";
+"profiles.name_label" = "Nome do Perfil (opcional)";
+"profiles.name_placeholder" = "Deixe vazio para nome aleatório";
+"profiles.name_hint" = "Se deixado vazio, um nome aleatório divertido será gerado!";
+
+/* ==================== */
+/* MARK: - Multi-Profile Display */
+/* ==================== */
+"multiprofile.title" = "Exibição Multi-Perfil";
+"multiprofile.subtitle" = "Mostrar múltiplos perfis na barra de menu";
+"multiprofile.enable_title" = "Mostrar Múltiplos Perfis";
+"multiprofile.enable_description" = "Exibir perfis selecionados como ícones compactos lado a lado";
+"multiprofile.select_profiles" = "Selecionar perfis para exibir:";
+"multiprofile.info" = "Cada perfil mostra sessão (anel interno) e semana (anel externo) com nome do perfil";
+"multiprofile.active_badge" = "Ativo";
+"multiprofile.at_least_one" = "Pelo menos um perfil deve estar selecionado";
+"multiprofile.icon_style" = "Estilo do Ícone";
+"multiprofile.show_week" = "Mostrar Uso Semanal";
+"multiprofile.show_week_description" = "Exibir uso semanal além da sessão";
+"multiprofile.show_label" = "Mostrar Nome do Perfil";
+"multiprofile.show_label_description" = "Exibir nome do perfil abaixo do ícone";
+"multiprofile.use_system_color" = "Usar Cor do Sistema";
+"multiprofile.use_system_color_description" = "Usar a cor de destaque do Mac em vez das cores de status";
+
+/* ==================== */
+/* MARK: - General Settings (Profile-Level) */
+/* ==================== */
+"general.title" = "Geral";
+"general.subtitle" = "Intervalo de atualização, início automático e notificações";
+"general.refresh_title" = "Intervalo de Atualização";
+"general.refresh_subtitle" = "Frequência de verificação de atualizações de uso";
+"general.refresh_seconds" = "%d segundos";
+"general.refresh_min" = "10s";
+"general.refresh_max" = "300s";
+"general.autostart_title" = "Início Automático de Sessão";
+"general.autostart_subtitle" = "Iniciar automaticamente uma nova sessão quando necessário";
+"general.autostart_toggle" = "Início Automático de Nova Sessão";
+"general.autostart_description" = "Enviar automaticamente uma mensagem quando a sessão for redefinida";
+"general.autostart_requirement" = "• Chave de sessão configurada em Credenciais → aba Claude.ai";
+"general.notifications_title" = "Notificações";
+"general.notifications_subtitle" = "Receber notificações sobre marcos de uso";
+"general.connected" = "Conectado";
+"general.not_connected" = "Não Conectado";
+
+/* ==================== */
+/* MARK: - Updates Settings */
+/* ==================== */
+"updates.version_info" = "Informações da Versão";
+"updates.update_preferences" = "Preferências de Atualização";
+"updates.version_label" = "v%@ (%@)";
+
+/* ==================== */
+/* MARK: - Appearance (Additional) */
+/* ==================== */
+"appearance.global_subtitle" = "Personalizar comportamento do ícone da barra de menu";
+"appearance.metrics_subtitle" = "Selecionar quais métricas exibir na barra de menu";
+
+/* ==================== */
+/* MARK: - Metric Card */
+/* ==================== */
+"metric.show_countdown" = "Mostrar tempo até a próxima sessão";
+"metric.countdown_description" = "Exibir tempo restante (ex., →2H) no ícone";
+
+/* ==================== */
+/* MARK: - Personal Usage (Additional) */
+/* ==================== */
+"personal.configuration_title" = "Configuração";
+"personal.status_connected" = "Conectado";
+"personal.status_not_connected" = "Não Conectado";
+
+/* ==================== */
+/* MARK: - Language Settings */
+/* ==================== */
+"language.title" = "Idioma";
+"language.subtitle" = "Escolha seu idioma preferido";
+"language.select_language" = "Selecionar Idioma";
+"language.available" = "Idiomas Disponíveis";
+"language.restart_required" = "Reinício Necessário";
+"language.restart_message" = "O app precisa ser reiniciado para que as alterações de idioma tenham efeito.";
+"language.restart_now" = "Reiniciar Agora";
+"language.restart_later" = "Mais Tarde";
+
+/* ==================== */
+/* MARK: - Common Actions (Additional) */
+/* ==================== */
+"common.create" = "Criar";
+"common.rename" = "Renomear";
+"common.activate" = "Ativar";
+"common.connected" = "Conectado";
+"common.not_connected" = "Não Conectado";
+"common.back" = "Voltar";
+"common.next" = "Próximo";
+"common.remove" = "Remover";
+"common.switch" = "Alternar";
+
+/* ==================== */
+/* MARK: - Popover/Menu Bar */
+/* ==================== */
+"popover.manage_profiles" = "Gerenciar Perfis";
+"popover.no_profile" = "Sem Perfil";
+"popover.profiles_count" = "%d perfis";
+"popover.profile_count_singular" = "1 perfil";
+
+/* ==================== */
+/* MARK: - Setup Wizard */
+/* ==================== */
+"setup.step.enter_session_key" = "Inserir Chave";
+"wizard.test_connection" = "Testar Conexão";
+"wizard.select_org_title" = "Qual organização você quer rastrear?";
+"wizard.select_org_subtitle" = "Selecione a organização Claude para monitoramento de uso";
+"wizard.config_summary" = "Resumo da Configuração";
+"wizard.session_key" = "Chave de Sessão";
+"wizard.api_session_key" = "Chave de Sessão API";
+"wizard.organization" = "Organização";
+"wizard.organization_id" = "ID: %@";
+"wizard.select_organization" = "Selecionar Organização";
+"wizard.choose_organization" = "Escolha qual organização rastrear";
+"wizard.review_config" = "Revisar Configuração";
+"wizard.confirm_settings" = "Confirme suas configurações antes de salvar";
+"wizard.key_will_update" = "A chave de sessão será atualizada";
+"wizard.api_key_will_update" = "A chave de sessão API será atualizada";
+
+/* ==================== */
+/* MARK: - CLI Account */
+/* ==================== */
+"cli.access_token" = "Token de Acesso";
+"cli.subscription" = "Assinatura";
+"cli.scopes" = "Escopos";
+"cli.sync_instructions" = "Clique em 'Sincronizar do Claude Code' abaixo para importar suas credenciais";
+"cli.about_title" = "Sobre Sincronização de Conta CLI";
+"cli.benefits" = "Benefícios:";
+"cli.tracking_note" = "Nota: O rastreamento de uso usa credenciais Claude.ai. As credenciais CLI são apenas para troca de conta.";
+
+/* ==================== */
+/* MARK: - Settings Sections (Titles & Descriptions) */
+/* ==================== */
+"section.credentials" = "CREDENCIAIS";
+"section.active_profile" = "Perfil Ativo";
+"section.settings" = "CONFIGURAÇÕES";
+"section.app" = "APLICATIVO";
+
+"section.claudeai_title" = "Claude.ai";
+"section.claudeai_desc" = "Credenciais Claude.ai";
+"section.api_console_title" = "Console API";
+"section.api_console_desc" = "Credenciais do Console API";
+"section.cli_account_title" = "Conta CLI";
+"section.cli_account_desc" = "Sincronização de conta CLI";
+"section.appearance_title" = "Aparência";
+"section.appearance_desc" = "Aparência da barra de menu";
+"section.general_title" = "Geral";
+"section.general_desc" = "Configurações gerais";
+"section.manage_profiles_title" = "Gerenciar Perfis";
+"section.manage_profiles_desc" = "Gerenciar perfis";
+"section.history_title" = "Histórico";
+"section.history_desc" = "Ver histórico de uso";
+"section.support_title" = "Suporte";
+"section.support_desc" = "Apoiar o desenvolvimento do projeto";
+"section.debug_title" = "Ferramentas de Depuração";
+"section.debug_desc" = "Registro de rede e diagnósticos";
+
+/* ==================== */
+/* MARK: - Creator Info */
+/* ==================== */
+"creator.name" = "Hamed Elfayome";
+"creator.username" = "@hamed-elfayome";
+
+/* ==================== */
+/* MARK: - Wizard Steps & Actions */
+/* ==================== */
+"wizard.enter_key" = "Inserir Chave";
+"wizard.select_org" = "Selecionar Org";
+"wizard.confirm" = "Confirmar";
+"wizard.testing" = "Testando...";
+"wizard.test_connection" = "Testar Conexão";
+"wizard.fetching" = "Buscando...";
+"wizard.fetch_organizations" = "Buscar Organizações";
+"wizard.saving" = "Salvando...";
+"wizard.save_configuration" = "Salvar Configuração";
+
+/* ==================== */
+/* MARK: - CLI Account Sync */
+/* ==================== */
+"cli.title" = "Conta CLI";
+"cli.subtitle" = "Sincronize sua conta Claude Code conectada";
+"cli.synced" = "Conta CLI Sincronizada";
+"cli.not_synced" = "Não Sincronizada";
+"cli.account_details" = "Detalhes da Conta";
+"cli.credentials_synced" = "Suas credenciais CLI sincronizadas";
+"cli.no_credentials" = "Nenhuma credencial sincronizada ainda";
+"cli.resync" = "Re-sincronizar";
+"cli.sync_from_code" = "Sincronizar do Claude Code";
+"cli.benefit_1" = "Troca automática de login do Claude Code com perfis";
+"cli.benefit_2" = "Manter CLI e contas do aplicativo sincronizadas";
+"cli.benefit_3" = "Atualizar credenciais automaticamente ao trocar de perfil";
+
+/* ==================== */
+/* MARK: - Additional Keys */
+/* ==================== */
+"api.single_organization" = "Organização única encontrada e selecionada automaticamente";
+"api.remove_title" = "Remover Credenciais";
+"api.remove_subtitle" = "Excluir permanentemente sua chave de sessão do Console API deste perfil";
+"claudecode.button_apply" = "Aplicar";
+"claudecode.button_reset" = "Redefinir";
+"claudecode.actions_title" = "Ações";
+"error.generic" = "Erro: %@";
+"personal.button_saving" = "Salvando...";
+"personal.button_setup_wizard" = "Assistente de Configuração";
+"personal.button_open_claude" = "Abrir claude.ai";
+"personal.success_key_saved" = "Chave de sessão salva com sucesso";
+"personal.remove_title" = "Remover Credenciais";
+"personal.remove_subtitle" = "Excluir permanentemente sua chave de sessão do Claude.ai deste perfil";
+"personal.signin_description" = "Faça login para extrair sua chave de sessão automaticamente.";
+"personal.signin_button" = "Entrar no Claude.ai";
+"personal.signin_sheet_title" = "Entrar no Claude.ai";
+"personal.advanced_manual_key" = "Avançado: Chave de sessão manual";
+"about.run_setup_wizard" = "Executar Assistente de Configuração";
+
+/* Migration & Reset */
+"wizard.migrate_old_data" = "Tem dados de uma versão anterior?";
+"wizard.migrate_description" = "Se você tinha uma versão anterior instalada, clique abaixo para importar seus perfis e configurações antigos. Isso solicitará permissão do sistema para acessar os dados.";
+"wizard.migrate_button" = "Migrar dados";
+"wizard.skip_migration" = "Pular";
+"wizard.migration_success" = "✅ %d itens migrados com sucesso";
+"wizard.migration_failed" = "⚠️ Falha na migração: %@";
+"wizard.migration_skipped" = "Migração ignorada. Você pode sincronizar dados antigos manualmente mais tarde.";
+"about.reset_app_data" = "Redefinir dados do app";
+"about.reset_confirmation_title" = "Redefinir todos os dados do app?";
+"about.reset_confirm" = "Redefinir";
+"about.reset_confirmation_message" = "Isso excluirá permanentemente todos os perfis, credenciais e configurações. O aplicativo será encerrado e você precisará configurá-lo novamente. Isso não pode ser desfeito.";
+
+/* Claude Code Info */
+"wizard.claude_code_info_title" = "Usando Claude Code?";
+"wizard.claude_code_info_description" = "O rastreamento de uso funcionará, mas a linha de status CLI e o início automático de sessão não funcionarão sem a chave de sessão";
+"wizard.claude_code_skip_setup" = "Pular configuração";
+
+/* Migration Strings */
+"wizard.migrate_description_short" = "Importar seus dados de perfis antigos da versão anterior do aplicativo";
+"wizard.skip_migration" = "Pular";
+"wizard.migration_skipped" = "Pulado";
+
+// History
+"history.title" = "Histórico de Uso";
+"history.subtitle" = "Acompanhe seu uso ao longo do tempo";
+"history.tab.session" = "Sessões";
+"history.tab.weekly" = "Semanal";
+"history.tab.billing" = "Faturamento";
+"history.chart.session_title" = "Histórico de Uso de Sessão";
+"history.chart.weekly_title" = "Tendência de Uso Semanal";
+"history.chart.billing_title" = "Gastos Mensais de API";
+"history.chart.now" = "Agora";
+"history.empty.session_title" = "Sem Histórico de Sessão";
+"history.empty.session_description" = "O uso da sessão será registrado após cada reinicialização de 5 horas";
+"history.empty.weekly_title" = "Sem Histórico Semanal";
+"history.empty.weekly_description" = "O uso semanal será registrado após cada reinicialização de segunda-feira";
+"history.empty.billing_title" = "Sem Histórico de Faturamento";
+"history.empty.billing_description" = "Os dados de faturamento serão registrados após cada reinicialização mensal";
+"history.list.title" = "Registros de Histórico";
+"history.list.count" = "%d registros";
+"history.list.empty" = "Ainda sem registros. O histórico será registrado automaticamente a cada reinicialização.";
+"history.list.more" = "+%d registros a mais";
+"history.export_button" = "Exportar";
+"history.clear_button" = "Limpar";
+"history.no_profile" = "Nenhum perfil ativo";
+"history.reset_type.session" = "Reinicialização de Sessão";
+"history.reset_type.weekly" = "Reinicialização Semanal";
+"history.reset_type.billing" = "Ciclo de Faturamento";
+"history.label.total" = "Total";
+"history.label.spent" = "Gasto";
+"history.label.session" = "Sessão";
+"history.time_scale.5_hours" = "5 Horas";
+"history.time_scale.24_hours" = "24 Horas";
+"history.time_scale.7_days" = "7 Dias";
+"history.time_scale.30_days" = "30 Dias";
+"history.chart.session_usage" = "Uso de Sessão";
+"history.chart.weekly_usage" = "Uso Semanal";
+"history.chart.api_billing" = "Faturamento da API";
+"history.chart.no_data" = "Sem dados no intervalo selecionado";
+"history.export.title" = "Exportar Dados";
+"history.export.json" = "Exportar como JSON";
+"history.export.csv" = "Exportar como CSV";
+"history.chart.now" = "Agora";
+"support.title" = "Apoiar o Projeto";
+"support.subtitle" = "Claude Usage Tracker é gratuito e de código aberto";
+"support.all_features_free" = "Todos os Recursos São Gratuitos";
+"support.all_features_desc" = "Cada recurso neste aplicativo é completamente gratuito. Sem níveis premium, sem paywalls, sem assinaturas.";
+"support.open_source" = "Código Aberto";
+"support.open_source_desc" = "O código-fonte está disponível publicamente no GitHub. Você pode inspecionar, modificar e contribuir para o projeto.";
+"support.no_tracking" = "Sem Rastreamento";
+"support.no_tracking_desc" = "Sua privacidade importa. Sem análises, sem telemetria, sem coleta de dados. Tudo fica no seu Mac.";
+"support.message" = "Se você achar este aplicativo útil, considere apoiar seu desenvolvimento";
+"support.buy_coffee" = "Pague-me um Café";
+"support.footer" = "Seu apoio ajuda a manter este projeto vivo e crescendo";
+"support.also_support" = "Você também pode apoiar";
+"support.star_github" = "Dando Estrela no GitHub";
+"debug.title" = "Ferramentas de Depuração";
+"debug.subtitle" = "Registrar solicitações de rede para solução de problemas e diagnósticos";
+"debug.network_logger" = "Registrador de Solicitações de Rede";
+"debug.network_logger_desc" = "Capturar todas as solicitações de API com informações detalhadas";
+"debug.logging_duration" = "Duração do Registro";
+"debug.logging_active" = "Registro Ativo";
+"debug.logging_inactive" = "Registro Inativo";
+"debug.stops_in" = "Para em %@";
+"debug.start_logging" = "Iniciar Registro";
+"debug.stop_logging" = "Parar Registro";
+"debug.clear_logs" = "Limpar Logs";
+"debug.clear_all_logs" = "Limpar Todos os Logs?";
+"debug.clear_logs_message" = "Isso excluirá permanentemente todas as solicitações de rede registradas.";
+"debug.captured_requests" = "Solicitações Capturadas";
+"debug.requests_logged" = "%d solicitações registradas";
+"debug.no_requests" = "Nenhuma solicitação registrada ainda";
+"debug.request_details" = "Detalhes da Solicitação";
+"debug.basic_information" = "Informações Básicas";
+"debug.request_body" = "Corpo da Solicitação";
+"debug.response_preview" = "Visualização da Resposta";
+"debug.full_size" = "Tamanho completo: %@";
+"debug.error" = "Erro";
+"debug.url" = "URL";
+"debug.method" = "Método";
+"debug.status_code" = "Código de Status";
+"debug.duration" = "Duração";
+"debug.timestamp" = "Carimbo de Data/Hora";
+"debug.duration_seconds" = "%.3f segundos";
+
+/* ==================== */
+/* MARK: - Combined Usage Chart */
+/* ==================== */
+"history.chart.usage_overview" = "Visão geral de uso";
+
+/* ==================== */
+/* MARK: - Keyboard Shortcuts */
+/* ==================== */
+"section.shortcuts_title" = "Atalhos";
+"section.shortcuts_desc" = "Configurar atalhos de teclado";
+"shortcuts.title" = "Atalhos de Teclado";
+"shortcuts.subtitle" = "Defina teclas de atalho globais para ações comuns";
+"shortcuts.open_popover" = "Alternar painel";
+"shortcuts.open_popover_desc" = "Mostrar ou ocultar o painel de uso";
+"shortcuts.refresh" = "Atualizar uso";
+"shortcuts.refresh_desc" = "Obter os dados de uso mais recentes";
+"shortcuts.open_settings" = "Abrir configurações";
+"shortcuts.open_settings_desc" = "Abrir a janela de configurações";
+"shortcuts.next_profile" = "Próximo perfil";
+"shortcuts.next_profile_desc" = "Mudar para o próximo perfil";
+"shortcuts.record" = "Clique para gravar";
+"shortcuts.recording" = "Pressione um atalho...";
+"shortcuts.clear" = "Limpar";
+"shortcuts.none" = "Nenhum";
+"shortcuts.info_title" = "Atalhos globais";
+"shortcuts.info_desc" = "Os atalhos funcionam em qualquer aplicativo. Cada atalho deve incluir pelo menos uma tecla modificadora (Command, Option, Control ou Shift). Evite conflitos com atalhos do sistema.";
+
+/* ==================== */
+/* MARK: - Mobile App (Coming Soon) */
+/* ==================== */
+"section.mobile_app_title" = "App Móvel";
+"section.mobile_app_desc" = "App móvel em breve";
+"mobile.title" = "App Móvel";
+"mobile.subtitle" = "Acompanhe seu uso do Claude em qualquer lugar";
+"mobile.coming_soon_badge" = "EM BREVE";
+"mobile.cta_message" = "Interessado? Nos avise e te notificaremos quando estiver pronto.";
+"mobile.notify_me" = "Me avise";
+"mobile.submitting" = "Enviando...";
+"mobile.notified" = "Você está na lista!";
+"mobile.notified_desc" = "Avisaremos quando o app móvel estiver disponível.";
+"mobile.privacy_note" = "Nenhum dado pessoal é coletado. Isso apenas registra seu interesse.";
+"mobile.error_title" = "Falha na solicitação";
+"mobile.error_message" = "Não foi possível registrar seu interesse. Verifique sua conexão com a internet e tente novamente.";
+
+/* ==================== */
+/* MARK: - Popover Settings */
+/* ==================== */
+"section.popover_title" = "Popover";
+"section.popover_desc" = "Personalizar exibição do popover";
+"section.app_settings_title" = "Configurações";
+"section.app_settings_desc" = "Configurações do app e inicialização";
+"popover.title" = "Popover";
+"popover.subtitle" = "Personalize como o popover exibe as informações de uso";
+"popover.display_section" = "Exibição";
+"popover.time_display" = "Exibição de tempo";
+"popover.time_display_desc" = "Escolha o que exibir para os tempos de reinício";
+"popover.time_display_reset" = "Horário";
+"popover.time_display_remaining" = "Restante";
+"popover.time_display_both" = "Ambos";
+"popover.time_format" = "Formato de hora";
+"popover.time_format_desc" = "Escolha como os horários são exibidos no aplicativo";
+"popover.time_format_system" = "Sistema";
+"popover.time_format_12h" = "12 horas";
+"popover.time_format_24h" = "24 horas";
+
+/* ==================== */
+/* MARK: - Feedback Prompt */
+/* ==================== */
+"feedback.title" = "Ajude-nos a Melhorar";
+"feedback.subtitle" = "Seu feedback molda o futuro deste app";
+"feedback.name_placeholder" = "Nome";
+"feedback.title_label" = "Função";
+"feedback.contact_placeholder" = "Email";
+"feedback.message_placeholder" = "Conte-nos qualquer coisa — opiniões, ideias, sugestões...";
+"feedback.submit" = "Enviar";
+"feedback.submitting" = "Enviando...";
+"feedback.remind_later" = "Lembrar Depois";
+"feedback.never_show" = "Não Perguntar Mais";
+"feedback.thanks" = "Obrigado pelo seu feedback!";
+"feedback.error_title" = "Falha no Envio";
+"feedback.error_message" = "Não foi possível enviar seu feedback. Tente novamente mais tarde.";
+"feedback.role_developer" = "Desenvolvedor";
+"feedback.role_designer" = "Designer";
+"feedback.role_manager" = "Gerente";
+"feedback.role_student" = "Estudante";
+"feedback.role_researcher" = "Pesquisador";
+"feedback.role_other" = "Outro";
+
+// MARK: - Status Banners
+"popover.banner.credentials_expired" = "Credenciais expiradas. Atualize em Configurações.";
+"popover.banner.refresh_failed" = "Atualização falhou %d vezes";
+"popover.banner.updated_ago" = "Atualizado há %dm";
+
+// MARK: - Overage Balance
+"popover.overage_balance" = "Saldo";
+
+// MARK: - Setup Wizard CLI Detection
+"setup.cli_detecting" = "Verificando credenciais CLI...";
+"setup.cli_detected.title" = "CLI Detectado!";
+"setup.cli_detected.description" = "Credenciais do Claude Code CLI encontradas no seu sistema. Comece o rastreamento com um clique.";
+"setup.cli_detected.start" = "Iniciar Rastreamento";
+"setup.cli_detected.manual" = "Configurar Manualmente";
+
+// MARK: - Custom Notification Settings
+"notifications.custom_thresholds" = "Limites Personalizados";
+"notifications.custom_threshold" = "Alerta personalizado";
+"notifications.custom_placeholder" = "ex. 50";
+"notifications.custom_add" = "Adicionar";
+"notifications.sound" = "Som";
+"notifications.sound.default" = "Padrão";
+"notifications.sound.none" = "Nenhum";
+"notifications.sound.preview" = "Pré-visualizar som";

--- a/Claude Usage/Shared/Localization/LanguageManager.swift
+++ b/Claude Usage/Shared/Localization/LanguageManager.swift
@@ -27,8 +27,13 @@ class LanguageManager: ObservableObject {
             currentLanguage = language
         } else {
             // Detect system language and match to supported languages
-            let systemLanguage = Locale.current.language.languageCode?.identifier ?? "en"
-            currentLanguage = SupportedLanguage.allCases.first { $0.code == systemLanguage } ?? .english
+            let langCode = Locale.current.language.languageCode?.identifier ?? "en"
+            let regionCode = Locale.current.language.region?.identifier ?? ""
+            // Build full locale identifier for region-specific matching (e.g. pt-BR)
+            let fullCode = regionCode.isEmpty ? langCode : "\(langCode)-\(regionCode)"
+            currentLanguage = SupportedLanguage.allCases.first { $0.code == fullCode }
+                ?? SupportedLanguage.allCases.first { $0.code == langCode }
+                ?? .english
         }
 
         applyLanguage()
@@ -51,6 +56,7 @@ class LanguageManager: ObservableObject {
         case german = "de"
         case italian = "it"
         case portuguese = "pt"
+        case brazilianPortuguese = "pt-BR"
         case japanese = "ja"
         case korean = "ko"
         case zhCn = "zh-cn"
@@ -69,6 +75,7 @@ class LanguageManager: ObservableObject {
             case .german: return "Deutsch"
             case .italian: return "Italiano"
             case .portuguese: return "Português"
+            case .brazilianPortuguese: return "Português (Brasil)"
             case .japanese: return "日本語"
             case .korean: return "한국어"
             case .zhCn: return "简体中文"
@@ -84,6 +91,7 @@ class LanguageManager: ObservableObject {
             case .german: return "German"
             case .italian: return "Italian"
             case .portuguese: return "Portuguese"
+            case .brazilianPortuguese: return "Brazilian Portuguese"
             case .japanese: return "Japanese"
             case .korean: return "Korean"
             case .zhCn: return "Simplified Chinese"
@@ -99,6 +107,7 @@ class LanguageManager: ObservableObject {
             case .german: return "🇩🇪"
             case .italian: return "🇮🇹"
             case .portuguese: return "🇵🇹"
+            case .brazilianPortuguese: return "🇧🇷"
             case .japanese: return "🇯🇵"
             case .korean: return "🇰🇷"
             case .zhCn: return "🇨🇳"


### PR DESCRIPTION
## Description

Adds Brazilian Portuguese (`pt-BR`) as a new supported language. While Portuguese (`pt`) already exists targeting Portugal (🇵🇹), Brazilian Portuguese has distinct vocabulary, expressions, and idioms. Brazil is the largest Portuguese-speaking country and a significant portion of Claude users.

## Changes

- `Claude Usage/Resources/pt-BR.lproj/Localizable.strings` — new localization file with Brazilian Portuguese translations for all UI strings
- `Claude Usage/Shared/Localization/LanguageManager.swift` — added `brazilianPortuguese = "pt-BR"` case to `SupportedLanguage` enum with 🇧🇷 flag, native name "Português (Brasil)" and improved system language detection to distinguish `pt-BR` from `pt`
- `Claude Usage.xcodeproj/project.pbxproj` — registered `pt-BR` in `knownRegions`

## Screenshots / Screen Recordings

N/A - no visual changes (language picker UI update is text-only)

## Important Guidelines

- No App Groups or grouped Keychain usage introduced
- Followed existing MVVM architecture and code patterns
- All new user-facing strings are localized in the new `pt-BR.lproj` file
- Tested structure on macOS 14.0+

## Checklist

- [x] I have tested these changes on a running build
- [x] I have attached screenshots/recordings for any visual changes
- [x] I have not introduced App Group or grouped Keychain usage
- [x] I have added localization keys for any new user-facing strings
