### PR TITLE
fix(popover): Fix popover positioning offset and menubar overlap

### DIFF
--- a/Claude Usage/MenuBar/MenuBarManager.swift
+++ b/Claude Usage/MenuBar/MenuBarManager.swift
@@ -469,7 +469,10 @@ class MenuBarManager: NSObject, ObservableObject {
             }
         )
 
-        return NSHostingController(rootView: contentView)
+        let hostingController = NSHostingController(rootView: contentView)
+        hostingController.preferredContentSize = Constants.WindowSizes.popoverSize
+        hostingController.sizingOptions = .preferredContentSize
+        return hostingController
     }
 
     @objc private func togglePopover(_ sender: Any?) {

--- a/Claude Usage/MenuBar/PopoverContentView.swift
+++ b/Claude Usage/MenuBar/PopoverContentView.swift
@@ -198,6 +198,7 @@ struct PopoverContentView: View {
             }
 
         }
+        .padding(.top, Constants.WindowSizes.popoverArrowHeight)
         .padding(.bottom, 8)
         .frame(width: 280)
         .background(VisualEffectBackground())

--- a/Claude Usage/Shared/Utilities/Constants.swift
+++ b/Claude Usage/Shared/Utilities/Constants.swift
@@ -143,6 +143,8 @@ enum Constants {
     enum WindowSizes {
         static let settingsWindow = NSSize(width: 720, height: 750)
         static let popoverSize = NSSize(width: 320, height: 600)
+        /// Height of the system NSPopover arrow (macOS standard ~13pt)
+        static let popoverArrowHeight: CGFloat = 13
     }
 
     // GitHub Repository Info


### PR DESCRIPTION
## Description

Fixes the issue with the menubar popover being vertically offset far below the menu bar. (https://github.com/hamed-elfayome/Claude-Usage-Tracker/issues/165)

## Changes

The popover now shows up in the right position directly under the menu bar.

- Set `preferredContentSize` and `sizingOptions` on `NSHostingController` to fix popover positioning
- Added shared `popoverArrowHeight` constant to `Constants.WindowSizes`
- Added top padding to `PopoverContentView` to prevent header clipping into menubar

## Screenshots / Screen Recordings

<!-- REQUIRED for any visual/UI changes. Please attach screenshots or screen recordings of the running app showing your changes. PRs with visual changes that don't include screenshots will not be reviewed. -->

Original bug appearance:
<img width="298" height="651" alt="image" src="https://github.com/user-attachments/assets/1def5bfa-ea59-453d-b6ad-a574488618c2" />

New fix appearance:
<img width="291" height="331" alt="image" src="https://github.com/user-attachments/assets/6dded86f-8f28-4d4d-ac42-4654063abd9d" />


## Important Guidelines

- **Do NOT use App Groups Keychain with app group identifiers.** This app is distributed outside the App Store via a Developer ID certificate. App Group entitlements require Keychain access prompts on every launch, which breaks the user experience. Use standard `UserDefaults` and standard Keychain access (without group identifiers) instead.
- Follow existing code patterns and architecture (MVVM, protocol-oriented)
- Add localization keys for any new user-facing strings (9 languages supported)
- Test on macOS 14.0+ (Sonoma)

## Checklist

- [x] I have tested these changes on a running build
- [x] I have attached screenshots/recordings for any visual changes
- [x] I have not introduced App Group or grouped Keychain usage
- [x] I have added localization keys for any new user-facing strings
