### PR TITLE
fix(settings): replace segmented picker with 2x2 grid for icon style selection

### DIFF
--- a/Claude Usage/Views/Settings/App/ManageProfilesView.swift
+++ b/Claude Usage/Views/Settings/App/ManageProfilesView.swift
@@ -116,21 +116,40 @@ struct ManageProfilesView: View {
                                     .font(DesignTokens.Typography.caption)
                                     .foregroundColor(.secondary)
 
-                                Picker("", selection: Binding(
-                                    get: { profileManager.multiProfileConfig.iconStyle },
-                                    set: { newStyle in
-                                        var config = profileManager.multiProfileConfig
-                                        config.iconStyle = newStyle
-                                        profileManager.updateMultiProfileConfig(config)
-                                        NotificationCenter.default.post(name: .displayModeChanged, object: nil)
-                                    }
-                                )) {
+                                let columns = [
+                                    GridItem(.flexible(), spacing: 8),
+                                    GridItem(.flexible(), spacing: 8)
+                                ]
+                                LazyVGrid(columns: columns, spacing: 8) {
                                     ForEach(MultiProfileIconStyle.allCases, id: \.self) { style in
-                                        Text(style.shortNameKey.localized).tag(style)
+                                        let isSelected = profileManager.multiProfileConfig.iconStyle == style
+                                        Button {
+                                            var config = profileManager.multiProfileConfig
+                                            config.iconStyle = style
+                                            profileManager.updateMultiProfileConfig(config)
+                                            NotificationCenter.default.post(name: .displayModeChanged, object: nil)
+                                        } label: {
+                                            HStack(spacing: 6) {
+                                                Image(systemName: style.icon)
+                                                    .font(.system(size: 11))
+                                                Text(style.shortNameKey.localized)
+                                                    .font(.system(size: 11, weight: .medium))
+                                            }
+                                            .frame(maxWidth: .infinity)
+                                            .padding(.vertical, 6)
+                                            .background(
+                                                RoundedRectangle(cornerRadius: 6)
+                                                    .fill(isSelected ? Color.accentColor.opacity(0.15) : Color.primary.opacity(0.05))
+                                            )
+                                            .overlay(
+                                                RoundedRectangle(cornerRadius: 6)
+                                                    .strokeBorder(isSelected ? Color.accentColor : Color.clear, lineWidth: 1.5)
+                                            )
+                                            .foregroundColor(isSelected ? .accentColor : .secondary)
+                                        }
+                                        .buttonStyle(.plain)
                                     }
                                 }
-                                .pickerStyle(.segmented)
-                                .labelsHidden()
                             }
                             .frame(maxWidth: .infinity, alignment: .leading)
 


### PR DESCRIPTION
## Description

Fixes #201

The multi-profile icon style picker uses a horizontal segmented control with 4 options that overflows the available content width (~530px after sidebar and padding), causing the last option to be clipped and unreadable.

## Changes

- Replaced the single-row `.segmented` Picker with a 2×2 `LazyVGrid` layout
- Each grid cell shows the style icon + localized label as a selectable button
- Selected state uses accent color highlight with border, matching the app's existing design language

## Screenshots / Screen Recordings

**Before:** Segmented picker overflows — last option clipped

<img width="766" height="796" alt="스크린샷 2026-03-31 16 13 15" src="https://github.com/user-attachments/assets/8558caae-fa59-4378-8fc9-94b060359167" />


**After:** 2×2 grid fits within content area, all options visible and selectable

<img width="766" height="796" alt="스크린샷 2026-03-31 16 12 29" src="https://github.com/user-attachments/assets/a5f89a2a-84c1-4afd-8fc0-761d9e5c5cb4" />


## Important Guidelines

- **Do NOT use App Groups Keychain with app group identifiers.** This app is distributed outside the App Store via a Developer ID certificate. App Group entitlements require Keychain access prompts on every launch, which breaks the user experience. Use standard `UserDefaults` and standard Keychain access (without group identifiers) instead.