### PR TITLE
fix(auth): Add browser headers to claude.ai requests to fix E3000 unauthorized error

### DIFF
--- a/Claude Usage/Shared/Services/ClaudeAPIService.swift
+++ b/Claude Usage/Shared/Services/ClaudeAPIService.swift
@@ -135,6 +135,9 @@ class ClaudeAPIService: APIServiceProtocol {
             // Existing claude.ai authentication
             request.setValue("sessionKey=\(sessionKey)", forHTTPHeaderField: "Cookie")
             request.setValue("application/json", forHTTPHeaderField: "Accept")
+            request.setValue("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15", forHTTPHeaderField: "User-Agent")
+            request.setValue("https://claude.ai", forHTTPHeaderField: "Referer")
+            request.setValue("https://claude.ai", forHTTPHeaderField: "Origin")
 
         case .cliOAuth(let accessToken):
             // CLI OAuth authentication (requires specific headers)
@@ -242,6 +245,9 @@ class ClaudeAPIService: APIServiceProtocol {
             var request = URLRequest(url: url)
             request.setValue("sessionKey=\(sessionKey)", forHTTPHeaderField: "Cookie")
             request.setValue("application/json", forHTTPHeaderField: "Accept")
+            request.setValue("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15", forHTTPHeaderField: "User-Agent")
+            request.setValue("https://claude.ai", forHTTPHeaderField: "Referer")
+            request.setValue("https://claude.ai", forHTTPHeaderField: "Origin")
             request.httpMethod = "GET"
             request.timeoutInterval = 30
 
@@ -586,6 +592,9 @@ class ClaudeAPIService: APIServiceProtocol {
         var request = URLRequest(url: url)
         request.setValue("sessionKey=\(sessionKey)", forHTTPHeaderField: "Cookie")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15", forHTTPHeaderField: "User-Agent")
+        request.setValue("https://claude.ai", forHTTPHeaderField: "Referer")
+        request.setValue("https://claude.ai", forHTTPHeaderField: "Origin")
         request.httpMethod = "GET"
         request.timeoutInterval = 30
 
@@ -919,6 +928,10 @@ class ClaudeAPIService: APIServiceProtocol {
         var conversationRequest = URLRequest(url: conversationURL)
         conversationRequest.setValue("sessionKey=\(sessionKey)", forHTTPHeaderField: "Cookie")
         conversationRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        conversationRequest.setValue("application/json", forHTTPHeaderField: "Accept")
+        conversationRequest.setValue("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15", forHTTPHeaderField: "User-Agent")
+        conversationRequest.setValue("https://claude.ai", forHTTPHeaderField: "Referer")
+        conversationRequest.setValue("https://claude.ai", forHTTPHeaderField: "Origin")
         conversationRequest.httpMethod = "POST"
 
         let conversationBody: [String: Any] = [
@@ -963,6 +976,10 @@ class ClaudeAPIService: APIServiceProtocol {
         var messageRequest = URLRequest(url: messageURL)
         messageRequest.setValue("sessionKey=\(sessionKey)", forHTTPHeaderField: "Cookie")
         messageRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        messageRequest.setValue("application/json", forHTTPHeaderField: "Accept")
+        messageRequest.setValue("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15", forHTTPHeaderField: "User-Agent")
+        messageRequest.setValue("https://claude.ai", forHTTPHeaderField: "Referer")
+        messageRequest.setValue("https://claude.ai", forHTTPHeaderField: "Origin")
         messageRequest.httpMethod = "POST"
 
         let messageBody: [String: Any] = [
@@ -1001,6 +1018,9 @@ class ClaudeAPIService: APIServiceProtocol {
 
         var deleteRequest = URLRequest(url: deleteURL)
         deleteRequest.setValue("sessionKey=\(sessionKey)", forHTTPHeaderField: "Cookie")
+        deleteRequest.setValue("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15", forHTTPHeaderField: "User-Agent")
+        deleteRequest.setValue("https://claude.ai", forHTTPHeaderField: "Referer")
+        deleteRequest.setValue("https://claude.ai", forHTTPHeaderField: "Origin")
         deleteRequest.httpMethod = "DELETE"
 
         // Attempt to delete, but don't fail if deletion fails


### PR DESCRIPTION
## Description

This PR fixes a critical authentication failure (error **E3000 / `apiUnauthorized`**) that renders the app unable to authenticate, affecting both the embedded browser login flow and manual session key entry.

### Background

In early 2026, Anthropic tightened server-side validation of requests to the `claude.ai` API — likely as part of their broader crackdown on unauthorized third-party tool access (announced January–February 2026). As a result, `URLSession` requests that do not include standard browser headers are now rejected with **HTTP 401**, which the app maps to `AppError.apiUnauthorized` (E3000), displaying the misleading message *"Your session key may have expired"*.

This is tracked in issue **#194**.

### Why it breaks

The authentication flow works like this:

1. User logs in via WKWebView (or pastes session key manually)
2. App extracts `sessionKey` cookie
3. App calls `testSessionKey()` → `fetchAllOrganizations()` via `URLSession`
4. Server returns **401** → app shows E3000

Step 3 is where the failure occurs. The `URLSession` requests were sent with only two headers:

```
Cookie: sessionKey=sk-ant-...
Accept: application/json
```

No `User-Agent`, `Referer`, or `Origin` — making the request look like a bot/script rather than a browser. Claude's API (behind Cloudflare) now rejects such requests.

Notably, the session key itself is **perfectly valid** — it works fine in Safari. The issue is purely in how the app presents the request to the server.

### Why it started happening after v3.0.2

Before v3.0.2, users entered session keys manually by copying from DevTools. This was cumbersome but worked because the underlying `URLSession` request pattern hadn't been challenged by the server yet.

v3.0.2 introduced WKWebView-based login — a great UX improvement. But it also coincided with Anthropic's server-side enforcement becoming stricter, exposing the missing-headers issue for all users regardless of auth method.

## Changes

- Added `User-Agent`, `Referer`, and `Origin` headers to all `URLSession` requests that use `claudeAISession` authentication in `ClaudeAPIService.swift`:
  - `buildAuthenticatedRequest()` — `.claudeAISession` case (covers all requests routed through this method)
  - `fetchAllOrganizations()` — used by `testSessionKey()` during login
  - `performRequest()` — used for all usage data fetches after login
  - Conversation create/message/delete methods — used by session initialization flow

- **Not changed:** `ClaudeAPIService+ConsoleAPI.swift` (different domain: `console.anthropic.com`, was working fine), `AutoStartSessionService.swift` (independent service, separate concern), `StatuslineService.swift` (generates a standalone terminal script, separate deployment)

## Screenshots / Screen Recordings

N/A - no visual changes

## Important Guidelines

- No App Groups or grouped Keychain usage introduced
- No new user-facing strings (no localization changes needed)
- Follows existing code patterns — only header additions to existing `URLRequest` construction

## Checklist

- [x] I have tested these changes on a running build
- [x] I have attached screenshots/recordings for any visual changes (N/A)
- [x] I have not introduced App Group or grouped Keychain usage
- [x] I have added localization keys for any new user-facing strings (N/A)