### PR TITLE
Add OpenAI API and Codex tracking, rebrand to AI Usage Tracker

### DIFF
--- a/Claude Usage/App/ClaudeUsageTrackerApp.swift
+++ b/Claude Usage/App/ClaudeUsageTrackerApp.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 @main
-struct ClaudeUsageTrackerApp: App {
+struct AIUsageTrackerApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
 
     var body: some Scene {

--- a/Claude Usage/MenuBar/MenuBarManager.swift
+++ b/Claude Usage/MenuBar/MenuBarManager.swift
@@ -10,6 +10,7 @@ class MenuBarManager: NSObject, ObservableObject {
     @Published private(set) var status: ClaudeStatus = .unknown
     @Published private(set) var apiUsage: APIUsage?
     @Published private(set) var isRefreshing: Bool = false
+    @Published private(set) var allProfileUsages: [UUID: ProfileUsageUpdate] = [:]
 
     // Error tracking for stale data / credential banners
     @Published private(set) var hasCredentialError: Bool = false
@@ -290,6 +291,48 @@ class MenuBarManager: NSObject, ObservableObject {
         lastKnownAPIResetTime.removeValue(forKey: profileId)
         resetJustRecorded.removeValue(forKey: profileId)
         autoSwitchedProfileIds.remove(profileId)
+    }
+
+    // MARK: - Multi-Provider Support
+
+    func profileUsageDidUpdate(profileId: UUID, update: ProfileUsageUpdate) {
+        allProfileUsages[profileId] = update
+
+        // Update the profile's stored usage data
+        if var profile = profileManager.profiles.first(where: { $0.id == profileId }) {
+            if let claudeUsage = update.claudeUsage {
+                profile.claudeUsage = claudeUsage
+            }
+            if let apiUsage = update.apiUsage {
+                profile.apiUsage = apiUsage
+            }
+            if let openaiUsage = update.openaiUsage {
+                profile.openaiUsage = openaiUsage
+            }
+            if let codexUsage = update.codexUsage {
+                profile.codexUsage = codexUsage
+            }
+            profileManager.updateProfile(profile)
+        }
+
+        updateSmartStatusBar()
+    }
+
+    func profileRefreshDidFail(profileId: UUID, error: Error) {
+        LoggingService.shared.logError("Refresh failed for profile \(profileId): \(error.localizedDescription)")
+    }
+
+    private func updateSmartStatusBar() {
+        let threshold = UserDefaults.standard.double(forKey: "statusBarThreshold")
+        let maxItems = UserDefaults.standard.integer(forKey: "statusBarMaxItems")
+
+        let _ = SmartStatusBarRenderer.profilesForStatusBar(
+            profileManager.profiles,
+            threshold: threshold > 0 ? threshold : 60,
+            maxItems: maxItems > 0 ? maxItems : 4
+        )
+
+        objectWillChange.send()
     }
 
     // MARK: - Profile Observation

--- a/Claude Usage/MenuBar/PopoverSections.swift
+++ b/Claude Usage/MenuBar/PopoverSections.swift
@@ -1,0 +1,97 @@
+import SwiftUI
+
+/// Section showing OpenAI API billing in the popover
+struct OpenAIBillingSection: View {
+    let profile: Profile
+
+    var body: some View {
+        if let usage = profile.openaiUsage {
+            VStack(alignment: .leading, spacing: 6) {
+                HStack {
+                    Text(profile.name)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(.blue)
+                    Spacer()
+                    Text("Resets \(usage.resetsAt, style: .relative)")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+
+                HStack {
+                    Text("This month")
+                    Spacer()
+                    Text(usage.formattedUsed)
+                        .foregroundStyle(.blue)
+                }
+                .font(.caption)
+
+                if let budget = profile.spendBudgetCents, budget > 0 {
+                    let remaining = Double(budget - usage.currentSpendCents) / 100.0
+                    HStack {
+                        Text("Budget remaining")
+                        Spacer()
+                        Text("$\(String(format: "%.2f", remaining))")
+                    }
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 8)
+        }
+    }
+}
+
+/// Section showing Codex rate limits in the popover
+struct CodexSection: View {
+    let profile: Profile
+
+    var body: some View {
+        if let usage = profile.codexUsage {
+            VStack(alignment: .leading, spacing: 6) {
+                HStack {
+                    Text(profile.name)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(.purple)
+                    Spacer()
+                    Text("Resets \(usage.requestResetTime, style: .relative)")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+
+                VStack(alignment: .leading, spacing: 2) {
+                    HStack {
+                        Text("Requests")
+                            .font(.caption2)
+                            .foregroundStyle(.purple)
+                        Spacer()
+                        Text("\(String(format: "%.0f", usage.requestPercentageUsed))%")
+                            .font(.caption2)
+                    }
+                    ProgressView(value: usage.requestPercentageUsed, total: 100)
+                        .tint(.purple)
+                }
+
+                VStack(alignment: .leading, spacing: 2) {
+                    HStack {
+                        Text("Tokens")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        Text("\(String(format: "%.0f", usage.tokenPercentageUsed))%")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                    ProgressView(value: usage.tokenPercentageUsed, total: 100)
+                        .tint(.secondary)
+                }
+
+                Text("OpenAI API Rate Limits")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 8)
+        }
+    }
+}

--- a/Claude Usage/MenuBar/SmartStatusBarRenderer.swift
+++ b/Claude Usage/MenuBar/SmartStatusBarRenderer.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+enum SmartStatusBarRenderer {
+
+    enum AlertLevel: Equatable {
+        case none
+        case warning
+        case critical
+    }
+
+    static func profilesForStatusBar(
+        _ profiles: [Profile],
+        threshold: Double = 60,
+        maxItems: Int = 4
+    ) -> [Profile] {
+        profiles
+            .compactMap { profile -> (Profile, Double)? in
+                guard let pct = profile.effectivePercentageForThreshold,
+                      pct >= threshold else { return nil }
+                return (profile, pct)
+            }
+            .sorted { $0.1 > $1.1 }
+            .prefix(maxItems)
+            .map(\.0)
+    }
+
+    static func alertLevel(for percentage: Double) -> AlertLevel {
+        if percentage >= 90 { return .critical }
+        if percentage >= 60 { return .warning }
+        return .none
+    }
+
+    static func statusBarLabel(for profile: Profile) -> String {
+        let pct = profile.effectivePercentageForThreshold ?? 0
+        let pctStr = String(format: "%.0f%%", pct)
+
+        switch profile.providerType {
+        case .claudeMax:
+            let model = profile.primaryModel ?? "opus"
+            return "\(profile.name) \(model) \(pctStr)"
+        case .codex:
+            return "Codex \(pctStr)"
+        case .claudeAPI, .openaiAPI:
+            if profile.providerType == .claudeAPI, let usage = profile.apiUsage {
+                return "\(profile.name) $\(String(format: "%.0f", usage.usedAmount))"
+            } else if profile.providerType == .openaiAPI, let usage = profile.openaiUsage {
+                return "\(profile.name) $\(String(format: "%.0f", usage.usedAmount))"
+            }
+            return "\(profile.name) \(pctStr)"
+        }
+    }
+}

--- a/Claude Usage/MenuBar/UsageRefreshCoordinator.swift
+++ b/Claude Usage/MenuBar/UsageRefreshCoordinator.swift
@@ -12,6 +12,7 @@ import Combine
 final class UsageRefreshCoordinator {
     private var refreshTimer: Timer?
     private var refreshIntervalObserver: NSKeyValueObservation?
+    private var profileTimers: [UUID: Timer] = [:]
 
     private let apiService: APIServiceProtocol
     private let statusService: ClaudeStatusService
@@ -107,6 +108,47 @@ final class UsageRefreshCoordinator {
         LoggingService.shared.logInfo("Auto-refresh started with interval: \(interval)s")
     }
 
+    // MARK: - Multi-Provider Refresh
+
+    /// Start refresh timers for all enabled profiles with variable intervals
+    func startMultiProviderRefresh(profiles: [Profile]) {
+        stopAllTimers()
+        for profile in profiles where profile.isSelectedForDisplay {
+            let interval = profile.refreshInterval > 0
+                ? profile.refreshInterval
+                : profile.providerType.defaultRefreshInterval
+            let timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
+                Task { [weak self] in
+                    await self?.refreshProfile(profile)
+                }
+            }
+            profileTimers[profile.id] = timer
+            // Immediate first refresh
+            Task { [weak self] in
+                await self?.refreshProfile(profile)
+            }
+        }
+    }
+
+    private func refreshProfile(_ profile: Profile) async {
+        let provider = UsageProviderFactory.makeProvider(for: profile)
+        do {
+            let update = try await provider.fetchUsage(for: profile)
+            await MainActor.run {
+                delegate?.profileUsageDidUpdate(profileId: profile.id, update: update)
+            }
+        } catch {
+            await MainActor.run {
+                delegate?.profileRefreshDidFail(profileId: profile.id, error: error)
+            }
+        }
+    }
+
+    func stopAllTimers() {
+        profileTimers.values.forEach { $0.invalidate() }
+        profileTimers.removeAll()
+    }
+
     private func observeRefreshIntervalChanges() {
         // Observe using DataStore.shared directly for KVO
         refreshIntervalObserver = DataStore.shared.userDefaults.observe(\.refreshIntervalValue, options: [.new]) { [weak self] _, change in
@@ -132,4 +174,11 @@ protocol UsageRefreshCoordinatorDelegate: AnyObject {
     func usageRefreshDidComplete(usage: ClaudeUsage)
     func statusRefreshDidComplete(status: ClaudeStatus)
     func apiUsageRefreshDidComplete(apiUsage: APIUsage)
+    func profileUsageDidUpdate(profileId: UUID, update: ProfileUsageUpdate)
+    func profileRefreshDidFail(profileId: UUID, error: Error)
+}
+
+extension UsageRefreshCoordinatorDelegate {
+    func profileUsageDidUpdate(profileId: UUID, update: ProfileUsageUpdate) {}
+    func profileRefreshDidFail(profileId: UUID, error: Error) {}
 }

--- a/Claude Usage/Shared/Models/CodexUsage.swift
+++ b/Claude Usage/Shared/Models/CodexUsage.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+struct CodexUsage: Codable, Equatable {
+    let requestLimit: Int
+    let requestsRemaining: Int
+    let tokenLimit: Int
+    let tokensRemaining: Int
+    let requestResetTime: Date
+    let tokenResetTime: Date
+    let lastUpdated: Date
+
+    var requestPercentageUsed: Double {
+        guard requestLimit > 0 else { return 0 }
+        return Double(requestLimit - requestsRemaining) / Double(requestLimit) * 100.0
+    }
+
+    var tokenPercentageUsed: Double {
+        guard tokenLimit > 0 else { return 0 }
+        return Double(tokenLimit - tokensRemaining) / Double(tokenLimit) * 100.0
+    }
+
+    var requestsUsed: Int {
+        requestLimit - requestsRemaining
+    }
+
+    var tokensUsed: Int {
+        tokenLimit - tokensRemaining
+    }
+
+    static func parseResetDuration(_ value: String) -> TimeInterval? {
+        var total: TimeInterval = 0
+        let scanner = Scanner(string: value)
+        scanner.charactersToBeSkipped = nil
+
+        while !scanner.isAtEnd {
+            guard let number = scanner.scanDouble() else { return nil }
+            if scanner.scanString("h") != nil {
+                total += number * 3600
+            } else if scanner.scanString("ms") != nil {
+                total += number / 1000
+            } else if scanner.scanString("m") != nil {
+                total += number * 60
+            } else if scanner.scanString("s") != nil {
+                total += number
+            } else {
+                return nil
+            }
+        }
+        return total
+    }
+
+    static func fromHeaders(_ headers: [String: String], at date: Date = Date()) -> CodexUsage? {
+        guard let limitReq = headers["x-ratelimit-limit-requests"].flatMap(Int.init),
+              let remainReq = headers["x-ratelimit-remaining-requests"].flatMap(Int.init),
+              let limitTok = headers["x-ratelimit-limit-tokens"].flatMap(Int.init),
+              let remainTok = headers["x-ratelimit-remaining-tokens"].flatMap(Int.init),
+              let resetReqStr = headers["x-ratelimit-reset-requests"],
+              let resetTokStr = headers["x-ratelimit-reset-tokens"],
+              let resetReqDuration = parseResetDuration(resetReqStr),
+              let resetTokDuration = parseResetDuration(resetTokStr)
+        else { return nil }
+
+        return CodexUsage(
+            requestLimit: limitReq,
+            requestsRemaining: remainReq,
+            tokenLimit: limitTok,
+            tokensRemaining: remainTok,
+            requestResetTime: date.addingTimeInterval(resetReqDuration),
+            tokenResetTime: date.addingTimeInterval(resetTokDuration),
+            lastUpdated: date
+        )
+    }
+}

--- a/Claude Usage/Shared/Models/OpenAIUsage.swift
+++ b/Claude Usage/Shared/Models/OpenAIUsage.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+struct OpenAIUsage: Codable, Equatable {
+    let currentSpendCents: Int
+    let currency: String
+    let resetsAt: Date
+    let dailyCostCents: [String: Double]
+    let tokensByModel: [String: OpenAIModelTokens]?
+    let lastUpdated: Date
+
+    var usedAmount: Double {
+        Double(currentSpendCents) / 100.0
+    }
+
+    var formattedUsed: String {
+        formatCurrency(usedAmount)
+    }
+
+    var sortedDailyCosts: [(date: Date, cents: Double)] {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        return dailyCostCents.compactMap { key, value in
+            guard let date = formatter.date(from: key) else { return nil }
+            return (date: date, cents: value)
+        }.sorted { $0.date < $1.date }
+    }
+
+    var sortedModelTokens: [(model: String, tokens: OpenAIModelTokens)] {
+        guard let byModel = tokensByModel else { return [] }
+        return byModel.sorted { $0.value.totalTokens > $1.value.totalTokens }
+            .map { (model: $0.key, tokens: $0.value) }
+    }
+
+    private func formatCurrency(_ amount: Double) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.currencyCode = currency
+        formatter.minimumFractionDigits = 2
+        formatter.maximumFractionDigits = 2
+        return formatter.string(from: NSNumber(value: amount))
+            ?? "\(currency) \(String(format: "%.2f", amount))"
+    }
+}
+
+struct OpenAIModelTokens: Codable, Equatable {
+    let inputTokens: Int
+    let outputTokens: Int
+    let cachedTokens: Int
+
+    var totalTokens: Int {
+        inputTokens + outputTokens
+    }
+}

--- a/Claude Usage/Shared/Models/Profile.swift
+++ b/Claude Usage/Shared/Models/Profile.swift
@@ -47,6 +47,23 @@ struct Profile: Codable, Identifiable, Equatable {
     var createdAt: Date
     var lastUsedAt: Date
 
+    // MARK: - Provider Type (NEW)
+    var providerType: ProfileProviderType
+    var primaryModel: String?
+
+    // MARK: - OpenAI Credentials (NEW)
+    var openaiAdminKey: String?
+    var openaiApiKey: String?
+    var openaiOrganizationId: String?
+
+    // MARK: - OpenAI Usage Data (NEW)
+    var openaiUsage: OpenAIUsage?
+    var codexUsage: CodexUsage?
+
+    // MARK: - Budget Settings (NEW)
+    var spendBudgetCents: Int?
+    var spendBudgetCurrency: String?
+
     init(
         id: UUID = UUID(),
         name: String,
@@ -67,7 +84,16 @@ struct Profile: Codable, Identifiable, Equatable {
         notificationSettings: NotificationSettings = NotificationSettings(),
         isSelectedForDisplay: Bool = true,
         createdAt: Date = Date(),
-        lastUsedAt: Date = Date()
+        lastUsedAt: Date = Date(),
+        providerType: ProfileProviderType = .claudeMax,
+        primaryModel: String? = nil,
+        openaiAdminKey: String? = nil,
+        openaiApiKey: String? = nil,
+        openaiOrganizationId: String? = nil,
+        openaiUsage: OpenAIUsage? = nil,
+        codexUsage: CodexUsage? = nil,
+        spendBudgetCents: Int? = nil,
+        spendBudgetCurrency: String? = nil
     ) {
         self.id = id
         self.name = name
@@ -89,6 +115,52 @@ struct Profile: Codable, Identifiable, Equatable {
         self.isSelectedForDisplay = isSelectedForDisplay
         self.createdAt = createdAt
         self.lastUsedAt = lastUsedAt
+        self.providerType = providerType
+        self.primaryModel = primaryModel
+        self.openaiAdminKey = openaiAdminKey
+        self.openaiApiKey = openaiApiKey
+        self.openaiOrganizationId = openaiOrganizationId
+        self.openaiUsage = openaiUsage
+        self.codexUsage = codexUsage
+        self.spendBudgetCents = spendBudgetCents
+        self.spendBudgetCurrency = spendBudgetCurrency
+    }
+
+    // MARK: - Backward-Compatible Decoding
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        id = try container.decode(UUID.self, forKey: .id)
+        name = try container.decode(String.self, forKey: .name)
+        claudeSessionKey = try container.decodeIfPresent(String.self, forKey: .claudeSessionKey)
+        organizationId = try container.decodeIfPresent(String.self, forKey: .organizationId)
+        apiSessionKey = try container.decodeIfPresent(String.self, forKey: .apiSessionKey)
+        apiOrganizationId = try container.decodeIfPresent(String.self, forKey: .apiOrganizationId)
+        apiSessionKeyExpiry = try container.decodeIfPresent(Date.self, forKey: .apiSessionKeyExpiry)
+        cliCredentialsJSON = try container.decodeIfPresent(String.self, forKey: .cliCredentialsJSON)
+        hasCliAccount = try container.decodeIfPresent(Bool.self, forKey: .hasCliAccount) ?? false
+        cliAccountSyncedAt = try container.decodeIfPresent(Date.self, forKey: .cliAccountSyncedAt)
+        claudeUsage = try container.decodeIfPresent(ClaudeUsage.self, forKey: .claudeUsage)
+        apiUsage = try container.decodeIfPresent(APIUsage.self, forKey: .apiUsage)
+        iconConfig = try container.decodeIfPresent(MenuBarIconConfiguration.self, forKey: .iconConfig) ?? .default
+        refreshInterval = try container.decodeIfPresent(TimeInterval.self, forKey: .refreshInterval) ?? 30.0
+        autoStartSessionEnabled = try container.decodeIfPresent(Bool.self, forKey: .autoStartSessionEnabled) ?? false
+        checkOverageLimitEnabled = try container.decodeIfPresent(Bool.self, forKey: .checkOverageLimitEnabled) ?? true
+        notificationSettings = try container.decodeIfPresent(NotificationSettings.self, forKey: .notificationSettings) ?? NotificationSettings()
+        isSelectedForDisplay = try container.decodeIfPresent(Bool.self, forKey: .isSelectedForDisplay) ?? true
+        createdAt = try container.decodeIfPresent(Date.self, forKey: .createdAt) ?? Date()
+        lastUsedAt = try container.decodeIfPresent(Date.self, forKey: .lastUsedAt) ?? Date()
+
+        // New fields — default gracefully when absent
+        providerType = try container.decodeIfPresent(ProfileProviderType.self, forKey: .providerType) ?? .claudeMax
+        primaryModel = try container.decodeIfPresent(String.self, forKey: .primaryModel)
+        openaiAdminKey = try container.decodeIfPresent(String.self, forKey: .openaiAdminKey)
+        openaiApiKey = try container.decodeIfPresent(String.self, forKey: .openaiApiKey)
+        openaiOrganizationId = try container.decodeIfPresent(String.self, forKey: .openaiOrganizationId)
+        openaiUsage = try container.decodeIfPresent(OpenAIUsage.self, forKey: .openaiUsage)
+        codexUsage = try container.decodeIfPresent(CodexUsage.self, forKey: .codexUsage)
+        spendBudgetCents = try container.decodeIfPresent(Int.self, forKey: .spendBudgetCents)
+        spendBudgetCurrency = try container.decodeIfPresent(String.self, forKey: .spendBudgetCurrency)
     }
 
     // MARK: - Computed Properties
@@ -114,6 +186,33 @@ struct Profile: Codable, Identifiable, Equatable {
 
     var hasAnyCredentials: Bool {
         hasClaudeAI || hasAPIConsole || cliCredentialsJSON != nil
+    }
+
+    var hasOpenAIAPI: Bool {
+        openaiAdminKey != nil
+    }
+
+    var hasCodexProbe: Bool {
+        openaiApiKey != nil
+    }
+
+    /// The percentage to use for status bar threshold comparisons
+    var effectivePercentageForThreshold: Double? {
+        switch providerType {
+        case .claudeMax:
+            if primaryModel == "sonnet" {
+                return claudeUsage?.sonnetWeeklyPercentage
+            }
+            return claudeUsage?.opusWeeklyPercentage ?? claudeUsage?.effectiveSessionPercentage
+        case .codex:
+            return codexUsage?.requestPercentageUsed
+        case .claudeAPI:
+            guard let budget = spendBudgetCents, budget > 0, let usage = apiUsage else { return nil }
+            return Double(usage.currentSpendCents) / Double(budget) * 100.0
+        case .openaiAPI:
+            guard let budget = spendBudgetCents, budget > 0, let usage = openaiUsage else { return nil }
+            return Double(usage.currentSpendCents) / Double(budget) * 100.0
+        }
     }
 }
 

--- a/Claude Usage/Shared/Models/ProfileProviderType.swift
+++ b/Claude Usage/Shared/Models/ProfileProviderType.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+enum ProfileProviderType: String, Codable, CaseIterable {
+    case claudeMax
+    case claudeAPI
+    case openaiAPI
+    case codex
+
+    var displayName: String {
+        switch self {
+        case .claudeMax: return "Claude Max"
+        case .claudeAPI: return "Claude API"
+        case .openaiAPI: return "OpenAI API"
+        case .codex: return "Codex"
+        }
+    }
+
+    var iconSystemName: String {
+        switch self {
+        case .claudeMax: return "brain.head.profile"
+        case .claudeAPI: return "server.rack"
+        case .openaiAPI: return "cloud"
+        case .codex: return "terminal"
+        }
+    }
+
+    var defaultRefreshInterval: TimeInterval {
+        switch self {
+        case .claudeMax: return 30
+        case .claudeAPI: return 300
+        case .openaiAPI: return 300
+        case .codex: return 60
+        }
+    }
+
+    var isPercentageBased: Bool {
+        switch self {
+        case .claudeMax, .codex: return true
+        case .claudeAPI, .openaiAPI: return false
+        }
+    }
+}

--- a/Claude Usage/Shared/Models/UsageHistory.swift
+++ b/Claude Usage/Shared/Models/UsageHistory.swift
@@ -48,6 +48,10 @@ struct UsageSnapshot: Codable, Identifiable, Equatable {
     let apiPrepaidCreditsCents: Int?
     let apiCurrency: String?
 
+    // Multi-provider snapshot type (e.g. "openaiCost", "codexRateLimit")
+    // nil for legacy Claude snapshots (backward compatible)
+    let snapshotType: String?
+
     // The reset time that triggered this snapshot
     let triggeringResetTime: Date
 
@@ -66,6 +70,7 @@ struct UsageSnapshot: Codable, Identifiable, Equatable {
         apiSpendCents: Int? = nil,
         apiPrepaidCreditsCents: Int? = nil,
         apiCurrency: String? = nil,
+        snapshotType: String? = nil,
         triggeringResetTime: Date
     ) {
         self.id = id
@@ -82,7 +87,29 @@ struct UsageSnapshot: Codable, Identifiable, Equatable {
         self.apiSpendCents = apiSpendCents
         self.apiPrepaidCreditsCents = apiPrepaidCreditsCents
         self.apiCurrency = apiCurrency
+        self.snapshotType = snapshotType
         self.triggeringResetTime = triggeringResetTime
+    }
+
+    // Backward-compatible decoding: snapshotType is nil for legacy data
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        timestamp = try container.decode(Date.self, forKey: .timestamp)
+        resetType = try container.decode(ResetType.self, forKey: .resetType)
+        sessionTokensUsed = try container.decodeIfPresent(Int.self, forKey: .sessionTokensUsed)
+        sessionPercentage = try container.decodeIfPresent(Double.self, forKey: .sessionPercentage)
+        weeklyTokensUsed = try container.decodeIfPresent(Int.self, forKey: .weeklyTokensUsed)
+        weeklyPercentage = try container.decodeIfPresent(Double.self, forKey: .weeklyPercentage)
+        opusWeeklyTokensUsed = try container.decodeIfPresent(Int.self, forKey: .opusWeeklyTokensUsed)
+        opusWeeklyPercentage = try container.decodeIfPresent(Double.self, forKey: .opusWeeklyPercentage)
+        sonnetWeeklyTokensUsed = try container.decodeIfPresent(Int.self, forKey: .sonnetWeeklyTokensUsed)
+        sonnetWeeklyPercentage = try container.decodeIfPresent(Double.self, forKey: .sonnetWeeklyPercentage)
+        apiSpendCents = try container.decodeIfPresent(Int.self, forKey: .apiSpendCents)
+        apiPrepaidCreditsCents = try container.decodeIfPresent(Int.self, forKey: .apiPrepaidCreditsCents)
+        apiCurrency = try container.decodeIfPresent(String.self, forKey: .apiCurrency)
+        snapshotType = try container.decodeIfPresent(String.self, forKey: .snapshotType)
+        triggeringResetTime = try container.decode(Date.self, forKey: .triggeringResetTime)
     }
 
     /// Creates a snapshot from ClaudeUsage data (for session reset)

--- a/Claude Usage/Shared/Protocols/UsageProviderProtocol.swift
+++ b/Claude Usage/Shared/Protocols/UsageProviderProtocol.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+struct ProfileUsageUpdate {
+    var claudeUsage: ClaudeUsage?
+    var apiUsage: APIUsage?
+    var openaiUsage: OpenAIUsage?
+    var codexUsage: CodexUsage?
+}
+
+protocol UsageProvider {
+    var providerType: ProfileProviderType { get }
+    var profileId: UUID { get }
+    var displayName: String { get }
+    func fetchUsage(for profile: Profile) async throws -> ProfileUsageUpdate
+    func validateCredentials(for profile: Profile) async throws -> Bool
+}

--- a/Claude Usage/Shared/Services/ClaudeAPIBillingProvider.swift
+++ b/Claude Usage/Shared/Services/ClaudeAPIBillingProvider.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+struct ClaudeAPIBillingProvider: UsageProvider {
+    let providerType: ProfileProviderType = .claudeAPI
+    let profileId: UUID
+    let displayName: String
+
+    init(profile: Profile) {
+        self.profileId = profile.id
+        self.displayName = profile.name
+    }
+
+    func fetchUsage(for profile: Profile) async throws -> ProfileUsageUpdate {
+        let apiService = ClaudeAPIService()
+        guard let apiOrgId = profile.apiOrganizationId,
+              let apiKey = profile.apiSessionKey else {
+            throw ClaudeAPIService.APIError.noSessionKey
+        }
+        let apiUsage = try await apiService.fetchAPIUsageData(
+            organizationId: apiOrgId,
+            apiSessionKey: apiKey
+        )
+        return ProfileUsageUpdate(apiUsage: apiUsage)
+    }
+
+    func validateCredentials(for profile: Profile) async throws -> Bool {
+        return profile.hasAPIConsole
+    }
+}

--- a/Claude Usage/Shared/Services/ClaudeMaxProvider.swift
+++ b/Claude Usage/Shared/Services/ClaudeMaxProvider.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+struct ClaudeMaxProvider: UsageProvider {
+    let providerType: ProfileProviderType = .claudeMax
+    let profileId: UUID
+    let displayName: String
+
+    init(profile: Profile) {
+        self.profileId = profile.id
+        self.displayName = profile.name
+    }
+
+    func fetchUsage(for profile: Profile) async throws -> ProfileUsageUpdate {
+        let apiService = ClaudeAPIService()
+        let usage = try await apiService.fetchUsageData()
+        return ProfileUsageUpdate(claudeUsage: usage)
+    }
+
+    func validateCredentials(for profile: Profile) async throws -> Bool {
+        return profile.hasUsageCredentials
+    }
+}

--- a/Claude Usage/Shared/Services/CodexProvider.swift
+++ b/Claude Usage/Shared/Services/CodexProvider.swift
@@ -25,12 +25,12 @@ struct CodexProvider: UsageProvider {
             if httpResponse.statusCode == 401 { throw CodexError.unauthorized }
             throw CodexError.serverError(statusCode: httpResponse.statusCode)
         }
-        let headers = Dictionary(
-            uniqueKeysWithValues: httpResponse.allHeaderFields.compactMap { key, value in
-                guard let k = key as? String, let v = value as? String else { return nil }
-                return (k.lowercased(), v)
+        var headers: [String: String] = [:]
+        for (key, value) in httpResponse.allHeaderFields {
+            if let k = key as? String, let v = value as? String {
+                headers[k.lowercased()] = v
             }
-        )
+        }
         guard let usage = CodexUsage.fromHeaders(headers) else {
             throw CodexError.missingRateLimitHeaders
         }

--- a/Claude Usage/Shared/Services/CodexProvider.swift
+++ b/Claude Usage/Shared/Services/CodexProvider.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+struct CodexProvider: UsageProvider {
+    let providerType: ProfileProviderType = .codex
+    let profileId: UUID
+    let displayName: String
+
+    private static let completionsURL = URL(string: "https://api.openai.com/v1/chat/completions")!
+
+    init(profile: Profile) {
+        self.profileId = profile.id
+        self.displayName = profile.name
+    }
+
+    func fetchUsage(for profile: Profile) async throws -> ProfileUsageUpdate {
+        guard let apiKey = profile.openaiApiKey else {
+            throw CodexError.noApiKey
+        }
+        let request = buildProbeRequest(apiKey: apiKey)
+        let (_, response) = try await URLSession.shared.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw CodexError.invalidResponse
+        }
+        guard httpResponse.statusCode == 200 || httpResponse.statusCode == 429 else {
+            if httpResponse.statusCode == 401 { throw CodexError.unauthorized }
+            throw CodexError.serverError(statusCode: httpResponse.statusCode)
+        }
+        let headers = Dictionary(
+            uniqueKeysWithValues: httpResponse.allHeaderFields.compactMap { key, value in
+                guard let k = key as? String, let v = value as? String else { return nil }
+                return (k.lowercased(), v)
+            }
+        )
+        guard let usage = CodexUsage.fromHeaders(headers) else {
+            throw CodexError.missingRateLimitHeaders
+        }
+        return ProfileUsageUpdate(codexUsage: usage)
+    }
+
+    func validateCredentials(for profile: Profile) async throws -> Bool {
+        guard let apiKey = profile.openaiApiKey else { return false }
+        let request = buildProbeRequest(apiKey: apiKey)
+        let (_, response) = try await URLSession.shared.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else { return false }
+        return httpResponse.statusCode == 200
+    }
+
+    func buildProbeRequest(apiKey: String) -> URLRequest {
+        var request = URLRequest(url: Self.completionsURL)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try? JSONSerialization.data(withJSONObject: [
+            "model": "gpt-4o-mini",
+            "max_tokens": 1,
+            "messages": [["role": "user", "content": "hi"]]
+        ])
+        return request
+    }
+
+    enum CodexError: Error, LocalizedError {
+        case noApiKey, invalidResponse, unauthorized, missingRateLimitHeaders
+        case serverError(statusCode: Int)
+        var errorDescription: String? {
+            switch self {
+            case .noApiKey: return "No OpenAI API key configured for Codex probe"
+            case .invalidResponse: return "Invalid response from OpenAI API"
+            case .unauthorized: return "OpenAI API key is invalid or expired"
+            case .missingRateLimitHeaders: return "Rate-limit headers missing from response"
+            case .serverError(let code): return "OpenAI API returned status \(code)"
+            }
+        }
+    }
+}

--- a/Claude Usage/Shared/Services/NotificationManager.swift
+++ b/Claude Usage/Shared/Services/NotificationManager.swift
@@ -310,6 +310,56 @@ class NotificationManager: NotificationServiceProtocol {
         }
     }
 
+    /// Check and notify for any provider type based on profile settings
+    func checkAndNotifyForProfile(_ profile: Profile) {
+        guard profile.notificationSettings.enabled else { return }
+        guard let percentage = profile.effectivePercentageForThreshold else { return }
+
+        let thresholds = profile.notificationSettings.sortedThresholds
+
+        for threshold in thresholds {
+            if percentage >= Double(threshold) {
+                let title: String
+                switch profile.providerType {
+                case .claudeMax:
+                    let model = profile.primaryModel ?? "opus"
+                    title = "\(profile.name) — \(model.capitalized) at \(Int(percentage))%"
+                case .claudeAPI:
+                    title = "\(profile.name) — Claude API spend alert"
+                case .openaiAPI:
+                    title = "\(profile.name) — OpenAI API spend alert"
+                case .codex:
+                    title = "\(profile.name) — Codex rate limit at \(Int(percentage))%"
+                }
+
+                // Dedup using profile ID + threshold (consistent with existing mechanism)
+                let identifier = "\(profile.id.uuidString)-\(threshold)"
+
+                // Check if we've already sent this notification
+                guard !sentNotifications.contains(identifier) else { continue }
+
+                let content = UNMutableNotificationContent()
+                content.title = title
+                content.body = "Usage has reached \(threshold)%"
+                content.categoryIdentifier = "USAGE_ALERT"
+
+                // Apply sound from profile notification settings
+                if let sound = profile.notificationSettings.notificationSound {
+                    content.sound = sound
+                }
+
+                let request = UNNotificationRequest(identifier: identifier, content: content, trigger: nil)
+                UNUserNotificationCenter.current().add(request) { [weak self] error in
+                    if error == nil {
+                        var updated = self?.sentNotifications ?? []
+                        updated.insert(identifier)
+                        self?.sentNotifications = updated
+                    }
+                }
+            }
+        }
+    }
+
     /// Clears notification tracking state for a specific profile
     func clearNotificationsForProfile(_ profileName: String) {
         sentNotifications = sentNotifications.filter { !$0.hasPrefix(profileName) }

--- a/Claude Usage/Shared/Services/OpenAIAPIProvider.swift
+++ b/Claude Usage/Shared/Services/OpenAIAPIProvider.swift
@@ -1,0 +1,194 @@
+import Foundation
+
+struct OpenAIAPIProvider: UsageProvider {
+    let providerType: ProfileProviderType = .openaiAPI
+    let profileId: UUID
+    let displayName: String
+
+    private static let baseURL = "https://api.openai.com/v1/organization"
+
+    init(profile: Profile) {
+        self.profileId = profile.id
+        self.displayName = profile.name
+    }
+
+    func fetchUsage(for profile: Profile) async throws -> ProfileUsageUpdate {
+        guard let adminKey = profile.openaiAdminKey else {
+            throw OpenAIError.noAdminKey
+        }
+
+        let now = Date()
+        let calendar = Calendar.current
+        let startOfMonth = calendar.date(from: calendar.dateComponents([.year, .month], from: now))!
+        let startOfNextMonth = calendar.date(byAdding: .month, value: 1, to: startOfMonth)!
+        let startTime = Int(startOfMonth.timeIntervalSince1970)
+        let endTime = Int(now.timeIntervalSince1970)
+
+        let costs = try await fetchAllCosts(adminKey: adminKey, startTime: startTime, endTime: endTime)
+        let completions = try await fetchAllCompletions(adminKey: adminKey, startTime: startTime, endTime: endTime)
+
+        var dailyCosts: [String: Double] = [:]
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+
+        var totalCents: Int = 0
+        var currency = "usd"
+
+        for bucket in costs {
+            let dateStr = dateFormatter.string(from: Date(timeIntervalSince1970: TimeInterval(bucket.startTime)))
+            let bucketTotal = bucket.results.reduce(0) { $0 + $1.amount.value }
+            dailyCosts[dateStr, default: 0] += Double(bucketTotal)
+            totalCents += bucketTotal
+            if let c = bucket.results.first?.amount.currency {
+                currency = c
+            }
+        }
+
+        var tokensByModel: [String: OpenAIModelTokens] = [:]
+        for bucket in completions {
+            for result in bucket.results {
+                let model = result.model ?? "unknown"
+                let existing = tokensByModel[model] ?? OpenAIModelTokens(inputTokens: 0, outputTokens: 0, cachedTokens: 0)
+                tokensByModel[model] = OpenAIModelTokens(
+                    inputTokens: existing.inputTokens + result.inputTokens,
+                    outputTokens: existing.outputTokens + result.outputTokens,
+                    cachedTokens: existing.cachedTokens + result.inputCachedTokens
+                )
+            }
+        }
+
+        let usage = OpenAIUsage(
+            currentSpendCents: totalCents,
+            currency: currency,
+            resetsAt: startOfNextMonth,
+            dailyCostCents: dailyCosts,
+            tokensByModel: tokensByModel.isEmpty ? nil : tokensByModel,
+            lastUpdated: now
+        )
+        return ProfileUsageUpdate(openaiUsage: usage)
+    }
+
+    func validateCredentials(for profile: Profile) async throws -> Bool {
+        guard let adminKey = profile.openaiAdminKey else { return false }
+        let now = Int(Date().timeIntervalSince1970)
+        let oneDayAgo = now - 86400
+        let url = URL(string: "\(Self.baseURL)/costs?start_time=\(oneDayAgo)&end_time=\(now)&bucket_width=1d&limit=1")!
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(adminKey)", forHTTPHeaderField: "Authorization")
+        let (_, response) = try await URLSession.shared.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else { return false }
+        return httpResponse.statusCode == 200
+    }
+
+    // MARK: - Pagination
+
+    private func fetchAllCosts(adminKey: String, startTime: Int, endTime: Int) async throws -> [CostBucket] {
+        var allBuckets: [CostBucket] = []
+        var nextPage: String? = nil
+        repeat {
+            var urlString = "\(Self.baseURL)/costs?start_time=\(startTime)&end_time=\(endTime)&bucket_width=1d&limit=7"
+            if let page = nextPage { urlString += "&page=\(page)" }
+            guard let url = URL(string: urlString) else { break }
+            var request = URLRequest(url: url)
+            request.setValue("Bearer \(adminKey)", forHTTPHeaderField: "Authorization")
+            let (data, _) = try await URLSession.shared.data(for: request)
+            let page = try JSONDecoder().decode(CostsPageResponse.self, from: data)
+            allBuckets.append(contentsOf: page.data)
+            nextPage = page.hasMore ? page.nextPage : nil
+        } while nextPage != nil
+        return allBuckets
+    }
+
+    private func fetchAllCompletions(adminKey: String, startTime: Int, endTime: Int) async throws -> [CompletionsBucket] {
+        var allBuckets: [CompletionsBucket] = []
+        var nextPage: String? = nil
+        repeat {
+            var urlString = "\(Self.baseURL)/usage/completions?start_time=\(startTime)&end_time=\(endTime)&bucket_width=1d&group_by[]=model&limit=7"
+            if let page = nextPage { urlString += "&page=\(page)" }
+            guard let url = URL(string: urlString) else { break }
+            var request = URLRequest(url: url)
+            request.setValue("Bearer \(adminKey)", forHTTPHeaderField: "Authorization")
+            let (data, _) = try await URLSession.shared.data(for: request)
+            let page = try JSONDecoder().decode(CompletionsPageResponse.self, from: data)
+            allBuckets.append(contentsOf: page.data)
+            nextPage = page.hasMore ? page.nextPage : nil
+        } while nextPage != nil
+        return allBuckets
+    }
+
+    // MARK: - Response Types
+
+    struct CostsPageResponse: Codable {
+        let data: [CostBucket]
+        let hasMore: Bool
+        let nextPage: String?
+        enum CodingKeys: String, CodingKey {
+            case data; case hasMore = "has_more"; case nextPage = "next_page"
+        }
+    }
+
+    struct CostBucket: Codable {
+        let startTime: Int
+        let endTime: Int
+        let results: [CostResult]
+        enum CodingKeys: String, CodingKey {
+            case startTime = "start_time"; case endTime = "end_time"; case results
+        }
+    }
+
+    struct CostResult: Codable {
+        let amount: CostAmount
+        let lineItem: String?
+        enum CodingKeys: String, CodingKey {
+            case amount; case lineItem = "line_item"
+        }
+    }
+
+    struct CostAmount: Codable {
+        let value: Int
+        let currency: String
+    }
+
+    struct CompletionsPageResponse: Codable {
+        let data: [CompletionsBucket]
+        let hasMore: Bool
+        let nextPage: String?
+        enum CodingKeys: String, CodingKey {
+            case data; case hasMore = "has_more"; case nextPage = "next_page"
+        }
+    }
+
+    struct CompletionsBucket: Codable {
+        let startTime: Int
+        let endTime: Int
+        let results: [CompletionsResult]
+        enum CodingKeys: String, CodingKey {
+            case startTime = "start_time"; case endTime = "end_time"; case results
+        }
+    }
+
+    struct CompletionsResult: Codable {
+        let inputTokens: Int
+        let outputTokens: Int
+        let inputCachedTokens: Int
+        let model: String?
+        enum CodingKeys: String, CodingKey {
+            case inputTokens = "input_tokens"; case outputTokens = "output_tokens"
+            case inputCachedTokens = "input_cached_tokens"; case model
+        }
+    }
+
+    enum OpenAIError: Error, LocalizedError {
+        case noAdminKey
+        case invalidResponse
+        case unauthorized
+        var errorDescription: String? {
+            switch self {
+            case .noAdminKey: return "No OpenAI Admin API key configured"
+            case .invalidResponse: return "Invalid response from OpenAI API"
+            case .unauthorized: return "OpenAI Admin API key is invalid or expired"
+            }
+        }
+    }
+}

--- a/Claude Usage/Shared/Services/ProfileManager.swift
+++ b/Claude Usage/Shared/Services/ProfileManager.swift
@@ -113,9 +113,9 @@ class ProfileManager: ObservableObject {
     func createClaudeAPIProfile(name: String, apiSessionKey: String, apiOrganizationId: String) -> Profile {
         let profile = Profile(
             name: name,
-            providerType: .claudeAPI,
             apiSessionKey: apiSessionKey,
-            apiOrganizationId: apiOrganizationId
+            apiOrganizationId: apiOrganizationId,
+            providerType: .claudeAPI
         )
         profiles.append(profile)
         saveAndBroadcast()

--- a/Claude Usage/Shared/Services/ProfileManager.swift
+++ b/Claude Usage/Shared/Services/ProfileManager.swift
@@ -82,6 +82,51 @@ class ProfileManager: ObservableObject {
         return newProfile
     }
 
+    // MARK: - Provider-Specific Factory Methods
+
+    /// Create a new OpenAI API profile
+    func createOpenAIAPIProfile(name: String, adminKey: String, organizationId: String? = nil) -> Profile {
+        let profile = Profile(
+            name: name,
+            providerType: .openaiAPI,
+            openaiAdminKey: adminKey,
+            openaiOrganizationId: organizationId
+        )
+        profiles.append(profile)
+        saveAndBroadcast()
+        return profile
+    }
+
+    /// Create a new Codex probe profile
+    func createCodexProfile(name: String, apiKey: String) -> Profile {
+        let profile = Profile(
+            name: name,
+            providerType: .codex,
+            openaiApiKey: apiKey
+        )
+        profiles.append(profile)
+        saveAndBroadcast()
+        return profile
+    }
+
+    /// Create a new Claude API billing profile
+    func createClaudeAPIProfile(name: String, apiSessionKey: String, apiOrganizationId: String) -> Profile {
+        let profile = Profile(
+            name: name,
+            providerType: .claudeAPI,
+            apiSessionKey: apiSessionKey,
+            apiOrganizationId: apiOrganizationId
+        )
+        profiles.append(profile)
+        saveAndBroadcast()
+        return profile
+    }
+
+    private func saveAndBroadcast() {
+        profileStore.saveProfiles(profiles)
+        objectWillChange.send()
+    }
+
     func updateProfile(_ profile: Profile) {
         if let index = profiles.firstIndex(where: { $0.id == profile.id }) {
             profiles[index] = profile

--- a/Claude Usage/Shared/Services/UsageHistoryService.swift
+++ b/Claude Usage/Shared/Services/UsageHistoryService.swift
@@ -249,6 +249,54 @@ class UsageHistoryService {
         LoggingService.shared.logInfo("Recorded periodic weekly snapshot: \(usage.weeklyPercentage)%")
     }
 
+    // MARK: - Multi-Provider Recording
+
+    /// Record OpenAI cost snapshot
+    func recordOpenAICost(for profileId: UUID, usage: OpenAIUsage) {
+        var history = loadHistory(for: profileId)
+        let snapshot = UsageSnapshot(
+            timestamp: usage.lastUpdated,
+            resetType: .billingCycle,
+            apiSpendCents: usage.currentSpendCents,
+            snapshotType: "openaiCost",
+            triggeringResetTime: usage.lastUpdated
+        )
+        history.snapshots.append(snapshot)
+        trimSnapshots(&history.snapshots, type: "openaiCost", max: 500)
+        saveHistory(history, for: profileId)
+    }
+
+    /// Record Codex rate-limit snapshot
+    func recordCodexRateLimit(for profileId: UUID, usage: CodexUsage) {
+        var history = loadHistory(for: profileId)
+        let snapshot = UsageSnapshot(
+            timestamp: usage.lastUpdated,
+            resetType: .sessionReset,
+            sessionPercentage: usage.requestPercentageUsed,
+            weeklyPercentage: usage.tokenPercentageUsed,
+            snapshotType: "codexRateLimit",
+            triggeringResetTime: usage.lastUpdated
+        )
+        history.snapshots.append(snapshot)
+        trimSnapshots(&history.snapshots, type: "codexRateLimit", max: 500)
+        saveHistory(history, for: profileId)
+    }
+
+    private func trimSnapshots(_ snapshots: inout [UsageSnapshot], type: String, max: Int) {
+        let typed = snapshots.filter { $0.snapshotType == type }
+        if typed.count > max {
+            let excess = typed.count - max
+            var removed = 0
+            snapshots.removeAll { snapshot in
+                if snapshot.snapshotType == type && removed < excess {
+                    removed += 1
+                    return true
+                }
+                return false
+            }
+        }
+    }
+
     // MARK: - Query Methods
 
     /// Gets session snapshots for a profile (sorted newest first)

--- a/Claude Usage/Shared/Services/UsageProviderFactory.swift
+++ b/Claude Usage/Shared/Services/UsageProviderFactory.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+enum UsageProviderFactory {
+    static func makeProvider(for profile: Profile) -> UsageProvider {
+        switch profile.providerType {
+        case .claudeMax:
+            return ClaudeMaxProvider(profile: profile)
+        case .claudeAPI:
+            return ClaudeAPIBillingProvider(profile: profile)
+        case .openaiAPI:
+            return OpenAIAPIProvider(profile: profile)
+        case .codex:
+            return CodexProvider(profile: profile)
+        }
+    }
+}

--- a/Claude Usage/Shared/Storage/ProfileStore.swift
+++ b/Claude Usage/Shared/Storage/ProfileStore.swift
@@ -15,7 +15,8 @@ class ProfileStore {
     private let keychainService = KeychainService.shared
 
     private enum Keys {
-        static let profiles = "profiles_v3"
+        static let profiles = "profiles_v4"
+        static let legacyProfiles = "profiles_v3"
         static let activeProfileId = "activeProfileId"
         static let displayMode = "profileDisplayMode"
         static let multiProfileConfig = "multiProfileDisplayConfig"
@@ -48,20 +49,29 @@ class ProfileStore {
     }
 
     func loadProfiles() -> [Profile] {
-        guard let data = defaults.data(forKey: Keys.profiles) else {
-            LoggingService.shared.log("ProfileStore: No profiles found in storage")
-            return []
+        // Try v4 first
+        if let data = defaults.data(forKey: Keys.profiles) {
+            do {
+                let profiles = try JSONDecoder().decode([Profile].self, from: data)
+                LoggingService.shared.log("ProfileStore: Loaded \(profiles.count) profiles from v4 storage")
+                return profiles
+            } catch {
+                LoggingService.shared.logStorageError("loadProfiles v4", error: error)
+            }
         }
-
-        do {
-            let profiles = try JSONDecoder().decode([Profile].self, from: data)
-            LoggingService.shared.log("ProfileStore: Loaded \(profiles.count) profiles from storage")
-            return profiles
-        } catch {
-            LoggingService.shared.logStorageError("loadProfiles", error: error)
-            LoggingService.shared.logError("ProfileStore: Failed to decode profiles, returning empty array")
-            return []
+        // Fall back to v3
+        if let data = defaults.data(forKey: Keys.legacyProfiles) {
+            do {
+                let profiles = try JSONDecoder().decode([Profile].self, from: data)
+                LoggingService.shared.log("ProfileStore: Migrated \(profiles.count) profiles from v3 to v4")
+                saveProfiles(profiles)
+                return profiles
+            } catch {
+                LoggingService.shared.logStorageError("loadProfiles v3 migration", error: error)
+            }
         }
+        LoggingService.shared.log("ProfileStore: No profiles found in storage")
+        return []
     }
 
     func saveActiveProfileId(_ id: UUID) {

--- a/Claude Usage/Views/Settings/AddProviderView.swift
+++ b/Claude Usage/Views/Settings/AddProviderView.swift
@@ -43,11 +43,11 @@ struct AddProviderView: View {
         .sheet(item: $selectedType) { type in
             switch type {
             case .claudeMax:
-                Text("Use the existing Claude setup wizard for Claude Max accounts")
-                    .padding()
+                SetupWizardView()
+                    .frame(minWidth: 500, minHeight: 400)
             case .claudeAPI:
-                Text("Use the existing API billing setup for Claude API")
-                    .padding()
+                APIBillingView()
+                    .frame(minWidth: 500, minHeight: 400)
             case .openaiAPI:
                 OpenAICredentialView(providerType: .openaiAPI)
             case .codex:

--- a/Claude Usage/Views/Settings/AddProviderView.swift
+++ b/Claude Usage/Views/Settings/AddProviderView.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+
+struct AddProviderView: View {
+    @Environment(\.dismiss) var dismiss
+    @State private var selectedType: ProfileProviderType?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Add Service")
+                .font(.headline)
+
+            Text("Choose what you want to track:")
+                .foregroundStyle(.secondary)
+
+            ForEach(ProfileProviderType.allCases, id: \.self) { type in
+                Button(action: { selectedType = type }) {
+                    HStack(spacing: 12) {
+                        Image(systemName: type.iconSystemName)
+                            .frame(width: 24)
+                        VStack(alignment: .leading) {
+                            Text(type.displayName)
+                                .fontWeight(.medium)
+                            Text(typeDescription(type))
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        Spacer()
+                    }
+                    .padding(10)
+                    .background(selectedType == type ? Color.accentColor.opacity(0.15) : Color.clear)
+                    .cornerRadius(8)
+                }
+                .buttonStyle(.plain)
+            }
+
+            HStack {
+                Button("Cancel") { dismiss() }
+                Spacer()
+            }
+        }
+        .padding(20)
+        .frame(width: 400)
+        .sheet(item: $selectedType) { type in
+            switch type {
+            case .claudeMax:
+                Text("Use the existing Claude setup wizard for Claude Max accounts")
+                    .padding()
+            case .claudeAPI:
+                Text("Use the existing API billing setup for Claude API")
+                    .padding()
+            case .openaiAPI:
+                OpenAICredentialView(providerType: .openaiAPI)
+            case .codex:
+                OpenAICredentialView(providerType: .codex)
+            }
+        }
+    }
+
+    private func typeDescription(_ type: ProfileProviderType) -> String {
+        switch type {
+        case .claudeMax: return "Track Claude subscription session and weekly limits"
+        case .claudeAPI: return "Track Anthropic API billing and spend"
+        case .openaiAPI: return "Track OpenAI API billing and spend (requires Admin key)"
+        case .codex: return "Track OpenAI API rate limits via probe requests"
+        }
+    }
+}
+
+extension ProfileProviderType: Identifiable {
+    var id: String { rawValue }
+}

--- a/Claude Usage/Views/Settings/Credentials/OpenAICredentialView.swift
+++ b/Claude Usage/Views/Settings/Credentials/OpenAICredentialView.swift
@@ -1,0 +1,100 @@
+import SwiftUI
+
+struct OpenAICredentialView: View {
+    @Environment(\.dismiss) var dismiss
+    @StateObject private var profileManager = ProfileManager.shared
+
+    let providerType: ProfileProviderType
+    @State private var name: String = ""
+    @State private var apiKey: String = ""
+    @State private var isValidating = false
+    @State private var validationError: String?
+    @State private var validationSuccess = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text(providerType == .openaiAPI ? "Add OpenAI API" : "Add Codex")
+                .font(.headline)
+
+            TextField("Display Name", text: $name)
+                .textFieldStyle(.roundedBorder)
+
+            SecureField(
+                providerType == .openaiAPI ? "Admin API Key (sk-admin-...)" : "API Key (sk-...)",
+                text: $apiKey
+            )
+            .textFieldStyle(.roundedBorder)
+
+            if providerType == .openaiAPI {
+                Text("Requires an Admin API key from platform.openai.com/settings")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } else {
+                Text("Tracks API rate limits via probe requests. This is NOT your Codex subscription quota.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            if let error = validationError {
+                Text(error)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+
+            if validationSuccess {
+                Text("Connected successfully!")
+                    .font(.caption)
+                    .foregroundStyle(.green)
+            }
+
+            HStack {
+                Button("Cancel") { dismiss() }
+                    .keyboardShortcut(.cancelAction)
+                Spacer()
+                Button("Validate & Save") {
+                    Task { await validateAndSave() }
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(apiKey.isEmpty || name.isEmpty || isValidating)
+            }
+        }
+        .padding(20)
+        .frame(width: 400)
+        .onAppear {
+            name = providerType == .openaiAPI ? "OpenAI API" : "Codex"
+        }
+    }
+
+    private func validateAndSave() async {
+        isValidating = true
+        validationError = nil
+        validationSuccess = false
+
+        let profile: Profile
+        if providerType == .openaiAPI {
+            profile = Profile(name: name, providerType: .openaiAPI, openaiAdminKey: apiKey)
+        } else {
+            profile = Profile(name: name, providerType: .codex, openaiApiKey: apiKey)
+        }
+
+        let provider = UsageProviderFactory.makeProvider(for: profile)
+        do {
+            let isValid = try await provider.validateCredentials(for: profile)
+            if isValid {
+                if providerType == .openaiAPI {
+                    _ = profileManager.createOpenAIAPIProfile(name: name, adminKey: apiKey)
+                } else {
+                    _ = profileManager.createCodexProfile(name: name, apiKey: apiKey)
+                }
+                validationSuccess = true
+                try? await Task.sleep(for: .seconds(1))
+                dismiss()
+            } else {
+                validationError = "Credentials are invalid. Check your API key."
+            }
+        } catch {
+            validationError = error.localizedDescription
+        }
+        isValidating = false
+    }
+}

--- a/Claude UsageTests/CodexProviderTests.swift
+++ b/Claude UsageTests/CodexProviderTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import Claude_Usage
+
+final class CodexProviderTests: XCTestCase {
+    func testBuildProbeRequest() {
+        let profile = Profile(name: "Test Codex", providerType: .codex, openaiApiKey: "sk-test123")
+        let provider = CodexProvider(profile: profile)
+        let request = provider.buildProbeRequest(apiKey: "sk-test123")
+
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(request.url?.absoluteString, "https://api.openai.com/v1/chat/completions")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer sk-test123")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+
+        let body = try! JSONSerialization.jsonObject(with: request.httpBody!) as! [String: Any]
+        XCTAssertEqual(body["max_tokens"] as? Int, 1)
+        XCTAssertNotNil(body["model"])
+        XCTAssertNotNil(body["messages"])
+    }
+}

--- a/Claude UsageTests/CodexUsageTests.swift
+++ b/Claude UsageTests/CodexUsageTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+@testable import Claude_Usage
+
+final class CodexUsageTests: XCTestCase {
+    func testRequestPercentageUsed() {
+        let usage = CodexUsage(
+            requestLimit: 100, requestsRemaining: 28,
+            tokenLimit: 100000, tokensRemaining: 55000,
+            requestResetTime: Date(), tokenResetTime: Date(),
+            lastUpdated: Date()
+        )
+        XCTAssertEqual(usage.requestPercentageUsed, 72.0, accuracy: 0.001)
+        XCTAssertEqual(usage.tokenPercentageUsed, 45.0, accuracy: 0.001)
+    }
+
+    func testZeroLimitReturnsZeroPercentage() {
+        let usage = CodexUsage(
+            requestLimit: 0, requestsRemaining: 0,
+            tokenLimit: 0, tokensRemaining: 0,
+            requestResetTime: Date(), tokenResetTime: Date(),
+            lastUpdated: Date()
+        )
+        XCTAssertEqual(usage.requestPercentageUsed, 0)
+        XCTAssertEqual(usage.tokenPercentageUsed, 0)
+    }
+
+    func testParseResetDurationMinutesSeconds() {
+        let duration = CodexUsage.parseResetDuration("6m32.345s")
+        XCTAssertNotNil(duration)
+        XCTAssertEqual(duration!, 392.345, accuracy: 0.001)
+    }
+
+    func testParseResetDurationMilliseconds() {
+        let duration = CodexUsage.parseResetDuration("432ms")
+        XCTAssertNotNil(duration)
+        XCTAssertEqual(duration!, 0.432, accuracy: 0.001)
+    }
+
+    func testParseResetDurationHoursMinutesSeconds() {
+        let duration = CodexUsage.parseResetDuration("1h2m3s")
+        XCTAssertNotNil(duration)
+        XCTAssertEqual(duration!, 3723, accuracy: 0.001)
+    }
+
+    func testParseResetDurationZero() {
+        let duration = CodexUsage.parseResetDuration("0s")
+        XCTAssertNotNil(duration)
+        XCTAssertEqual(duration!, 0, accuracy: 0.001)
+    }
+
+    func testFromHeaders() {
+        let now = Date()
+        let headers: [String: String] = [
+            "x-ratelimit-limit-requests": "100",
+            "x-ratelimit-remaining-requests": "72",
+            "x-ratelimit-limit-tokens": "50000",
+            "x-ratelimit-remaining-tokens": "35000",
+            "x-ratelimit-reset-requests": "2m30s",
+            "x-ratelimit-reset-tokens": "1m0s"
+        ]
+        let usage = CodexUsage.fromHeaders(headers, at: now)
+        XCTAssertNotNil(usage)
+        XCTAssertEqual(usage!.requestLimit, 100)
+        XCTAssertEqual(usage!.requestsRemaining, 72)
+        XCTAssertEqual(usage!.tokenLimit, 50000)
+        XCTAssertEqual(usage!.tokensRemaining, 35000)
+        XCTAssertEqual(usage!.requestResetTime.timeIntervalSince(now), 150, accuracy: 0.001)
+        XCTAssertEqual(usage!.tokenResetTime.timeIntervalSince(now), 60, accuracy: 0.001)
+    }
+
+    func testFromHeadersMissingFieldReturnsNil() {
+        let headers: [String: String] = [
+            "x-ratelimit-limit-requests": "100"
+        ]
+        XCTAssertNil(CodexUsage.fromHeaders(headers))
+    }
+
+    func testCodableRoundTrip() throws {
+        let usage = CodexUsage(
+            requestLimit: 100, requestsRemaining: 72,
+            tokenLimit: 50000, tokensRemaining: 35000,
+            requestResetTime: Date(), tokenResetTime: Date(),
+            lastUpdated: Date()
+        )
+        let data = try JSONEncoder().encode(usage)
+        let decoded = try JSONDecoder().decode(CodexUsage.self, from: data)
+        XCTAssertEqual(usage, decoded)
+    }
+}

--- a/Claude UsageTests/OpenAIAPIProviderTests.swift
+++ b/Claude UsageTests/OpenAIAPIProviderTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+@testable import Claude_Usage
+
+final class OpenAIAPIProviderTests: XCTestCase {
+    func testParseCostsResponse() throws {
+        let json = """
+        {
+            "object": "page",
+            "data": [
+                {
+                    "object": "bucket",
+                    "start_time": 1743638400,
+                    "end_time": 1743724800,
+                    "results": [
+                        {"object": "organization.costs.result", "amount": {"value": 350, "currency": "usd"}, "line_item": "Tokens"}
+                    ]
+                },
+                {
+                    "object": "bucket",
+                    "start_time": 1743724800,
+                    "end_time": 1743811200,
+                    "results": [
+                        {"object": "organization.costs.result", "amount": {"value": 480, "currency": "usd"}, "line_item": "Tokens"}
+                    ]
+                }
+            ],
+            "has_more": false
+        }
+        """.data(using: .utf8)!
+        let response = try JSONDecoder().decode(OpenAIAPIProvider.CostsPageResponse.self, from: json)
+        XCTAssertEqual(response.data.count, 2)
+        XCTAssertFalse(response.hasMore)
+        XCTAssertEqual(response.data[0].results[0].amount.value, 350)
+        XCTAssertEqual(response.data[0].results[0].amount.currency, "usd")
+    }
+
+    func testParseCompletionsUsageResponse() throws {
+        let json = """
+        {
+            "object": "page",
+            "data": [
+                {
+                    "object": "bucket",
+                    "start_time": 1743638400,
+                    "end_time": 1743724800,
+                    "results": [
+                        {
+                            "object": "organization.usage.completions.result",
+                            "input_tokens": 5000,
+                            "output_tokens": 2000,
+                            "input_cached_tokens": 1000,
+                            "model": "gpt-4o"
+                        }
+                    ]
+                }
+            ],
+            "has_more": false
+        }
+        """.data(using: .utf8)!
+        let response = try JSONDecoder().decode(OpenAIAPIProvider.CompletionsPageResponse.self, from: json)
+        XCTAssertEqual(response.data.count, 1)
+        XCTAssertEqual(response.data[0].results[0].model, "gpt-4o")
+        XCTAssertEqual(response.data[0].results[0].inputTokens, 5000)
+    }
+}

--- a/Claude UsageTests/OpenAIUsageTests.swift
+++ b/Claude UsageTests/OpenAIUsageTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+@testable import Claude_Usage
+
+final class OpenAIUsageTests: XCTestCase {
+    func testUsedAmountConversion() {
+        let usage = OpenAIUsage(
+            currentSpendCents: 1250,
+            currency: "usd",
+            resetsAt: Date().addingTimeInterval(86400 * 27),
+            dailyCostCents: ["2026-04-01": 500, "2026-04-02": 750],
+            tokensByModel: nil,
+            lastUpdated: Date()
+        )
+        XCTAssertEqual(usage.usedAmount, 12.50, accuracy: 0.001)
+    }
+
+    func testSortedDailyCosts() {
+        let usage = OpenAIUsage(
+            currentSpendCents: 1250,
+            currency: "usd",
+            resetsAt: Date(),
+            dailyCostCents: ["2026-04-03": 300, "2026-04-01": 500, "2026-04-02": 450],
+            tokensByModel: nil,
+            lastUpdated: Date()
+        )
+        let sorted = usage.sortedDailyCosts
+        XCTAssertEqual(sorted.count, 3)
+        XCTAssertEqual(sorted[0].cents, 500)
+        XCTAssertEqual(sorted[2].cents, 300)
+    }
+
+    func testCodableRoundTrip() throws {
+        let usage = OpenAIUsage(
+            currentSpendCents: 830,
+            currency: "usd",
+            resetsAt: Date(),
+            dailyCostCents: ["2026-04-03": 120],
+            tokensByModel: ["gpt-4o": OpenAIModelTokens(inputTokens: 5000, outputTokens: 2000, cachedTokens: 1000)],
+            lastUpdated: Date()
+        )
+        let data = try JSONEncoder().encode(usage)
+        let decoded = try JSONDecoder().decode(OpenAIUsage.self, from: data)
+        XCTAssertEqual(usage, decoded)
+    }
+
+    func testModelTokensTotalTokens() {
+        let tokens = OpenAIModelTokens(inputTokens: 5000, outputTokens: 2000, cachedTokens: 1000)
+        XCTAssertEqual(tokens.totalTokens, 7000)
+    }
+}

--- a/Claude UsageTests/ProfileMigrationTests.swift
+++ b/Claude UsageTests/ProfileMigrationTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+@testable import Claude_Usage
+
+final class ProfileMigrationTests: XCTestCase {
+    func testProfileProviderTypeCodable() throws {
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+        for providerType in ProfileProviderType.allCases {
+            let data = try encoder.encode(providerType)
+            let decoded = try decoder.decode(ProfileProviderType.self, from: data)
+            XCTAssertEqual(providerType, decoded)
+        }
+    }
+
+    func testProfileProviderTypeDefaultRefreshIntervals() {
+        XCTAssertEqual(ProfileProviderType.claudeMax.defaultRefreshInterval, 30)
+        XCTAssertEqual(ProfileProviderType.claudeAPI.defaultRefreshInterval, 300)
+        XCTAssertEqual(ProfileProviderType.openaiAPI.defaultRefreshInterval, 300)
+        XCTAssertEqual(ProfileProviderType.codex.defaultRefreshInterval, 60)
+    }
+}

--- a/Claude UsageTests/ProfileMigrationTests.swift
+++ b/Claude UsageTests/ProfileMigrationTests.swift
@@ -18,4 +18,68 @@ final class ProfileMigrationTests: XCTestCase {
         XCTAssertEqual(ProfileProviderType.openaiAPI.defaultRefreshInterval, 300)
         XCTAssertEqual(ProfileProviderType.codex.defaultRefreshInterval, 60)
     }
+
+    func testExistingProfileDecodesWithoutNewFields() throws {
+        let json = """
+        {
+            "id": "550E8400-E29B-41D4-A716-446655440000",
+            "name": "Test Profile",
+            "hasCliAccount": false,
+            "iconConfig": {
+                "colorMode": "multiColor",
+                "singleColorHex": "#FFFFFF",
+                "showIconNames": false,
+                "showRemainingPercentage": false,
+                "showTimeMarker": true,
+                "showPaceMarker": false,
+                "usePaceColoring": false,
+                "metrics": []
+            },
+            "refreshInterval": 30.0,
+            "autoStartSessionEnabled": false,
+            "checkOverageLimitEnabled": true,
+            "notificationSettings": {
+                "enabled": true,
+                "threshold75Enabled": true,
+                "threshold90Enabled": true,
+                "threshold95Enabled": true,
+                "soundName": "default",
+                "customThresholds": []
+            },
+            "isSelectedForDisplay": true,
+            "createdAt": 0,
+            "lastUsedAt": 0
+        }
+        """.data(using: .utf8)!
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .secondsSince1970
+        let profile = try decoder.decode(Profile.self, from: json)
+
+        XCTAssertEqual(profile.name, "Test Profile")
+        XCTAssertEqual(profile.providerType, .claudeMax)
+        XCTAssertNil(profile.primaryModel)
+        XCTAssertNil(profile.openaiAdminKey)
+        XCTAssertNil(profile.openaiApiKey)
+        XCTAssertNil(profile.openaiOrganizationId)
+        XCTAssertNil(profile.openaiUsage)
+        XCTAssertNil(profile.codexUsage)
+        XCTAssertNil(profile.spendBudgetCents)
+        XCTAssertNil(profile.spendBudgetCurrency)
+    }
+
+    func testNewProfileWithOpenAIFields() throws {
+        let profile = Profile(
+            name: "OpenAI Test",
+            providerType: .openaiAPI,
+            openaiAdminKey: "sk-admin-test123"
+        )
+        XCTAssertEqual(profile.providerType, .openaiAPI)
+        XCTAssertEqual(profile.openaiAdminKey, "sk-admin-test123")
+
+        let data = try JSONEncoder().encode(profile)
+        let decoded = try JSONDecoder().decode(Profile.self, from: data)
+        XCTAssertEqual(decoded.providerType, .openaiAPI)
+        XCTAssertEqual(decoded.openaiAdminKey, "sk-admin-test123")
+    }
 }

--- a/Claude UsageTests/SmartStatusBarRendererTests.swift
+++ b/Claude UsageTests/SmartStatusBarRendererTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+@testable import Claude_Usage
+
+final class SmartStatusBarRendererTests: XCTestCase {
+
+    func testNoProfilesAboveThresholdReturnsEmpty() {
+        let profiles = [
+            makeClaudeMaxProfile(name: "Low", percentage: 30),
+            makeClaudeMaxProfile(name: "Medium", percentage: 55)
+        ]
+        let result = SmartStatusBarRenderer.profilesForStatusBar(profiles, threshold: 60, maxItems: 4)
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testProfilesAboveThresholdReturned() {
+        let profiles = [
+            makeClaudeMaxProfile(name: "High", percentage: 85),
+            makeClaudeMaxProfile(name: "Low", percentage: 30),
+            makeClaudeMaxProfile(name: "Critical", percentage: 95)
+        ]
+        let result = SmartStatusBarRenderer.profilesForStatusBar(profiles, threshold: 60, maxItems: 4)
+        XCTAssertEqual(result.count, 2)
+        XCTAssertEqual(result[0].name, "Critical")
+        XCTAssertEqual(result[1].name, "High")
+    }
+
+    func testMaxItemsRespected() {
+        let profiles = (1...6).map { i in
+            makeClaudeMaxProfile(name: "P\(i)", percentage: Double(60 + i * 5))
+        }
+        let result = SmartStatusBarRenderer.profilesForStatusBar(profiles, threshold: 60, maxItems: 3)
+        XCTAssertEqual(result.count, 3)
+    }
+
+    func testColorForPercentage() {
+        XCTAssertEqual(SmartStatusBarRenderer.alertLevel(for: 50), .none)
+        XCTAssertEqual(SmartStatusBarRenderer.alertLevel(for: 72), .warning)
+        XCTAssertEqual(SmartStatusBarRenderer.alertLevel(for: 95), .critical)
+    }
+
+    func testAPIProfileWithNoBudgetExcluded() {
+        var profile = Profile(name: "API", providerType: .claudeAPI)
+        profile.apiUsage = APIUsage(
+            currentSpendCents: 5000,
+            resetsAt: Date(),
+            prepaidCreditsCents: 10000,
+            currency: "usd",
+            apiTokenCostCents: nil,
+            apiCostByModel: nil,
+            costBySource: nil,
+            dailyCostCents: nil
+        )
+        XCTAssertNil(profile.effectivePercentageForThreshold)
+    }
+
+    // MARK: - Helpers
+
+    private func makeClaudeMaxProfile(name: String, percentage: Double) -> Profile {
+        var profile = Profile(name: name, providerType: .claudeMax)
+        profile.claudeUsage = ClaudeUsage(
+            sessionTokensUsed: 0, sessionLimit: 0,
+            sessionPercentage: percentage,
+            sessionResetTime: Date().addingTimeInterval(3600),
+            weeklyTokensUsed: 0, weeklyLimit: 0,
+            weeklyPercentage: percentage,
+            weeklyResetTime: Date(),
+            opusWeeklyTokensUsed: 0,
+            opusWeeklyPercentage: percentage,
+            sonnetWeeklyTokensUsed: 0,
+            sonnetWeeklyPercentage: 0,
+            lastUpdated: Date(),
+            userTimezone: .current
+        )
+        return profile
+    }
+}

--- a/docs/superpowers/plans/2026-04-03-ai-usage-tracker.md
+++ b/docs/superpowers/plans/2026-04-03-ai-usage-tracker.md
@@ -1,0 +1,2398 @@
+# AI Usage Tracker Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend the Claude Usage Tracker macOS menu bar app to support OpenAI API billing and Codex rate-limit tracking, with a smart status bar that surfaces only what needs attention.
+
+**Architecture:** Evolve the existing Profile model with new optional fields for OpenAI credentials and usage data. Add two new provider implementations (OpenAI API, Codex) alongside the existing Claude providers. The status bar becomes threshold-aware, only showing profiles approaching limits.
+
+**Tech Stack:** Swift 5.0+, SwiftUI, macOS 14.0+ (Sonoma), XCTest, Xcode
+
+**Spec:** `docs/superpowers/specs/2026-04-03-ai-usage-tracker-design.md`
+
+---
+
+## File Structure
+
+### New Files
+
+| File | Responsibility |
+|---|---|
+| `Claude Usage/Shared/Models/ProfileProviderType.swift` | Enum for provider types |
+| `Claude Usage/Shared/Models/OpenAIUsage.swift` | OpenAI billing data model |
+| `Claude Usage/Shared/Models/CodexUsage.swift` | Codex rate-limit data model |
+| `Claude Usage/Shared/Protocols/UsageProviderProtocol.swift` | Protocol for all providers |
+| `Claude Usage/Shared/Services/OpenAIAPIProvider.swift` | OpenAI org-level API client |
+| `Claude Usage/Shared/Services/CodexProvider.swift` | Probe request + header parsing |
+| `Claude Usage/Shared/Services/ClaudeMaxProvider.swift` | Wraps existing ClaudeAPIService |
+| `Claude Usage/Shared/Services/ClaudeAPIBillingProvider.swift` | Wraps existing Console API |
+| `Claude Usage/Shared/Services/UsageProviderFactory.swift` | Creates provider for a profile |
+| `Claude Usage/MenuBar/SmartStatusBarRenderer.swift` | Threshold-based status bar logic |
+| `Claude Usage/Views/Credentials/OpenAICredentialView.swift` | Admin API key entry |
+| `Claude Usage/Views/Credentials/CodexCredentialView.swift` | Regular API key entry |
+| `Claude Usage/Views/Settings/AddProviderView.swift` | Provider type picker for new profiles |
+| `Claude UsageTests/OpenAIUsageTests.swift` | OpenAI model tests |
+| `Claude UsageTests/CodexUsageTests.swift` | Codex model tests |
+| `Claude UsageTests/OpenAIAPIProviderTests.swift` | OpenAI API provider tests |
+| `Claude UsageTests/CodexProviderTests.swift` | Codex provider tests |
+| `Claude UsageTests/SmartStatusBarRendererTests.swift` | Status bar threshold tests |
+| `Claude UsageTests/ProfileMigrationTests.swift` | Backward-compatible decoding tests |
+
+### Modified Files
+
+| File | Changes |
+|---|---|
+| `Claude Usage/Shared/Models/Profile.swift` | Add `providerType`, `primaryModel`, OpenAI fields |
+| `Claude Usage/Shared/Models/MenuBarIconConfig.swift` | Add `.openai` and `.codex` metric types |
+| `Claude Usage/Shared/Services/ProfileManager.swift` | Factory methods for new profile types |
+| `Claude Usage/Shared/Storage/ProfileStore.swift` | `profiles_v4` key with v3 fallback |
+| `Claude Usage/MenuBar/UsageRefreshCoordinator.swift` | Per-profile variable refresh intervals |
+| `Claude Usage/MenuBar/MenuBarManager.swift` | Smart status bar + OpenAI/Codex usage storage |
+| `Claude Usage/MenuBar/MenuBarIconRenderer.swift` | Render OpenAI/Codex metrics |
+| `Claude Usage/MenuBar/PopoverContentView.swift` | 3-section layout |
+| `Claude Usage/Shared/Services/UsageHistoryService.swift` | New snapshot types |
+| `Claude Usage/Shared/Services/NotificationManager.swift` | Provider-aware thresholds |
+| `Claude Usage/Views/SettingsView.swift` | Provider-aware profile creation |
+| `Claude Usage/App/ClaudeUsageTrackerApp.swift` | Rename to AIUsageTrackerApp |
+
+---
+
+## Phase 1: Data Models
+
+### Task 1: ProfileProviderType enum
+
+**Files:**
+- Create: `Claude Usage/Shared/Models/ProfileProviderType.swift`
+- Test: `Claude UsageTests/ProfileMigrationTests.swift`
+
+- [ ] **Step 1: Create the enum file**
+
+```swift
+// Claude Usage/Shared/Models/ProfileProviderType.swift
+
+import Foundation
+
+/// Identifies what kind of AI service a Profile tracks
+enum ProfileProviderType: String, Codable, CaseIterable {
+    case claudeMax      // Claude.ai subscription (session + weekly limits)
+    case claudeAPI      // Anthropic Console API billing
+    case openaiAPI      // OpenAI org-level API billing
+    case codex          // OpenAI API rate limits (via probe)
+
+    var displayName: String {
+        switch self {
+        case .claudeMax: return "Claude Max"
+        case .claudeAPI: return "Claude API"
+        case .openaiAPI: return "OpenAI API"
+        case .codex: return "Codex"
+        }
+    }
+
+    var iconSystemName: String {
+        switch self {
+        case .claudeMax: return "brain.head.profile"
+        case .claudeAPI: return "server.rack"
+        case .openaiAPI: return "cloud"
+        case .codex: return "terminal"
+        }
+    }
+
+    /// Default refresh interval in seconds
+    var defaultRefreshInterval: TimeInterval {
+        switch self {
+        case .claudeMax: return 30       // Real-time session tracking
+        case .claudeAPI: return 300      // 5 min — cost data updates slowly
+        case .openaiAPI: return 300      // 5 min — paginated, slow-changing
+        case .codex: return 60           // 1 min — each probe costs 1 request
+        }
+    }
+
+    /// Whether this provider uses percentage-based tracking (vs dollar-based)
+    var isPercentageBased: Bool {
+        switch self {
+        case .claudeMax, .codex: return true
+        case .claudeAPI, .openaiAPI: return false
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Write test for Codable round-trip**
+
+```swift
+// Claude UsageTests/ProfileMigrationTests.swift
+
+import XCTest
+@testable import Claude_Usage
+
+final class ProfileMigrationTests: XCTestCase {
+
+    func testProfileProviderTypeCodable() throws {
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+
+        for providerType in ProfileProviderType.allCases {
+            let data = try encoder.encode(providerType)
+            let decoded = try decoder.decode(ProfileProviderType.self, from: data)
+            XCTAssertEqual(providerType, decoded)
+        }
+    }
+
+    func testProfileProviderTypeDefaultRefreshIntervals() {
+        XCTAssertEqual(ProfileProviderType.claudeMax.defaultRefreshInterval, 30)
+        XCTAssertEqual(ProfileProviderType.claudeAPI.defaultRefreshInterval, 300)
+        XCTAssertEqual(ProfileProviderType.openaiAPI.defaultRefreshInterval, 300)
+        XCTAssertEqual(ProfileProviderType.codex.defaultRefreshInterval, 60)
+    }
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `xcodebuild test -project "Claude Usage.xcodeproj" -scheme "Claude Usage" -destination "platform=macOS" -only-testing:"Claude UsageTests/ProfileMigrationTests" 2>&1 | tail -20`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add "Claude Usage/Shared/Models/ProfileProviderType.swift" "Claude UsageTests/ProfileMigrationTests.swift"
+git commit -m "feat: add ProfileProviderType enum for multi-provider support"
+```
+
+---
+
+### Task 2: OpenAIUsage data model
+
+**Files:**
+- Create: `Claude Usage/Shared/Models/OpenAIUsage.swift`
+- Test: `Claude UsageTests/OpenAIUsageTests.swift`
+
+- [ ] **Step 1: Create the model**
+
+```swift
+// Claude Usage/Shared/Models/OpenAIUsage.swift
+
+import Foundation
+
+/// OpenAI API billing data — fetched from /v1/organization/costs and /v1/organization/usage/completions
+struct OpenAIUsage: Codable, Equatable {
+    let currentSpendCents: Int              // Summed from daily cost buckets
+    let currency: String                    // e.g. "usd"
+    let resetsAt: Date                      // Billing cycle end
+    let dailyCostCents: [String: Double]    // "2026-04-03" -> cents
+    let tokensByModel: [String: OpenAIModelTokens]?
+    let lastUpdated: Date
+
+    var usedAmount: Double {
+        Double(currentSpendCents) / 100.0
+    }
+
+    var formattedUsed: String {
+        formatCurrency(usedAmount)
+    }
+
+    var sortedDailyCosts: [(date: Date, cents: Double)] {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        return dailyCostCents.compactMap { key, value in
+            guard let date = formatter.date(from: key) else { return nil }
+            return (date: date, cents: value)
+        }.sorted { $0.date < $1.date }
+    }
+
+    var sortedModelTokens: [(model: String, tokens: OpenAIModelTokens)] {
+        guard let byModel = tokensByModel else { return [] }
+        return byModel.sorted { $0.value.totalTokens > $1.value.totalTokens }
+            .map { (model: $0.key, tokens: $0.value) }
+    }
+
+    private func formatCurrency(_ amount: Double) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.currencyCode = currency
+        formatter.minimumFractionDigits = 2
+        formatter.maximumFractionDigits = 2
+        return formatter.string(from: NSNumber(value: amount))
+            ?? "\(currency) \(String(format: "%.2f", amount))"
+    }
+}
+
+struct OpenAIModelTokens: Codable, Equatable {
+    let inputTokens: Int
+    let outputTokens: Int
+    let cachedTokens: Int
+
+    var totalTokens: Int {
+        inputTokens + outputTokens
+    }
+}
+```
+
+- [ ] **Step 2: Write tests**
+
+```swift
+// Claude UsageTests/OpenAIUsageTests.swift
+
+import XCTest
+@testable import Claude_Usage
+
+final class OpenAIUsageTests: XCTestCase {
+
+    func testUsedAmountConversion() {
+        let usage = OpenAIUsage(
+            currentSpendCents: 1250,
+            currency: "usd",
+            resetsAt: Date().addingTimeInterval(86400 * 27),
+            dailyCostCents: ["2026-04-01": 500, "2026-04-02": 750],
+            tokensByModel: nil,
+            lastUpdated: Date()
+        )
+        XCTAssertEqual(usage.usedAmount, 12.50, accuracy: 0.001)
+    }
+
+    func testSortedDailyCosts() {
+        let usage = OpenAIUsage(
+            currentSpendCents: 1250,
+            currency: "usd",
+            resetsAt: Date(),
+            dailyCostCents: ["2026-04-03": 300, "2026-04-01": 500, "2026-04-02": 450],
+            tokensByModel: nil,
+            lastUpdated: Date()
+        )
+        let sorted = usage.sortedDailyCosts
+        XCTAssertEqual(sorted.count, 3)
+        XCTAssertEqual(sorted[0].cents, 500)  // Apr 1 first
+        XCTAssertEqual(sorted[2].cents, 300)  // Apr 3 last
+    }
+
+    func testCodableRoundTrip() throws {
+        let usage = OpenAIUsage(
+            currentSpendCents: 830,
+            currency: "usd",
+            resetsAt: Date(),
+            dailyCostCents: ["2026-04-03": 120],
+            tokensByModel: ["gpt-4o": OpenAIModelTokens(inputTokens: 5000, outputTokens: 2000, cachedTokens: 1000)],
+            lastUpdated: Date()
+        )
+        let data = try JSONEncoder().encode(usage)
+        let decoded = try JSONDecoder().decode(OpenAIUsage.self, from: data)
+        XCTAssertEqual(usage, decoded)
+    }
+
+    func testModelTokensTotalTokens() {
+        let tokens = OpenAIModelTokens(inputTokens: 5000, outputTokens: 2000, cachedTokens: 1000)
+        XCTAssertEqual(tokens.totalTokens, 7000)
+    }
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `xcodebuild test -project "Claude Usage.xcodeproj" -scheme "Claude Usage" -destination "platform=macOS" -only-testing:"Claude UsageTests/OpenAIUsageTests" 2>&1 | tail -20`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add "Claude Usage/Shared/Models/OpenAIUsage.swift" "Claude UsageTests/OpenAIUsageTests.swift"
+git commit -m "feat: add OpenAIUsage data model"
+```
+
+---
+
+### Task 3: CodexUsage data model
+
+**Files:**
+- Create: `Claude Usage/Shared/Models/CodexUsage.swift`
+- Test: `Claude UsageTests/CodexUsageTests.swift`
+
+- [ ] **Step 1: Create the model**
+
+```swift
+// Claude Usage/Shared/Models/CodexUsage.swift
+
+import Foundation
+
+/// Codex rate-limit data parsed from OpenAI API response headers
+struct CodexUsage: Codable, Equatable {
+    let requestLimit: Int               // x-ratelimit-limit-requests
+    let requestsRemaining: Int          // x-ratelimit-remaining-requests
+    let tokenLimit: Int                 // x-ratelimit-limit-tokens
+    let tokensRemaining: Int            // x-ratelimit-remaining-tokens
+    let requestResetTime: Date          // x-ratelimit-reset-requests (parsed)
+    let tokenResetTime: Date            // x-ratelimit-reset-tokens (parsed)
+    let lastUpdated: Date
+
+    var requestPercentageUsed: Double {
+        guard requestLimit > 0 else { return 0 }
+        return Double(requestLimit - requestsRemaining) / Double(requestLimit) * 100.0
+    }
+
+    var tokenPercentageUsed: Double {
+        guard tokenLimit > 0 else { return 0 }
+        return Double(tokenLimit - tokensRemaining) / Double(tokenLimit) * 100.0
+    }
+
+    var requestsUsed: Int {
+        requestLimit - requestsRemaining
+    }
+
+    var tokensUsed: Int {
+        tokenLimit - tokensRemaining
+    }
+
+    /// Parse the OpenAI rate-limit reset header value.
+    /// Formats: "6m32.345s", "432ms", "1h2m3s", "0s"
+    static func parseResetDuration(_ value: String) -> TimeInterval? {
+        var total: TimeInterval = 0
+        let scanner = Scanner(string: value)
+        scanner.charactersToBeSkipped = nil
+
+        while !scanner.isAtEnd {
+            guard let number = scanner.scanDouble() else { return nil }
+            if scanner.scanString("h") != nil {
+                total += number * 3600
+            } else if scanner.scanString("ms") != nil {
+                total += number / 1000
+            } else if scanner.scanString("m") != nil {
+                total += number * 60
+            } else if scanner.scanString("s") != nil {
+                total += number
+            } else {
+                return nil
+            }
+        }
+        return total
+    }
+
+    /// Create from response headers dictionary
+    static func fromHeaders(_ headers: [String: String], at date: Date = Date()) -> CodexUsage? {
+        guard let limitReq = headers["x-ratelimit-limit-requests"].flatMap(Int.init),
+              let remainReq = headers["x-ratelimit-remaining-requests"].flatMap(Int.init),
+              let limitTok = headers["x-ratelimit-limit-tokens"].flatMap(Int.init),
+              let remainTok = headers["x-ratelimit-remaining-tokens"].flatMap(Int.init),
+              let resetReqStr = headers["x-ratelimit-reset-requests"],
+              let resetTokStr = headers["x-ratelimit-reset-tokens"],
+              let resetReqDuration = parseResetDuration(resetReqStr),
+              let resetTokDuration = parseResetDuration(resetTokStr)
+        else { return nil }
+
+        return CodexUsage(
+            requestLimit: limitReq,
+            requestsRemaining: remainReq,
+            tokenLimit: limitTok,
+            tokensRemaining: remainTok,
+            requestResetTime: date.addingTimeInterval(resetReqDuration),
+            tokenResetTime: date.addingTimeInterval(resetTokDuration),
+            lastUpdated: date
+        )
+    }
+}
+```
+
+- [ ] **Step 2: Write tests**
+
+```swift
+// Claude UsageTests/CodexUsageTests.swift
+
+import XCTest
+@testable import Claude_Usage
+
+final class CodexUsageTests: XCTestCase {
+
+    func testRequestPercentageUsed() {
+        let usage = CodexUsage(
+            requestLimit: 100, requestsRemaining: 28,
+            tokenLimit: 100000, tokensRemaining: 55000,
+            requestResetTime: Date(), tokenResetTime: Date(),
+            lastUpdated: Date()
+        )
+        XCTAssertEqual(usage.requestPercentageUsed, 72.0, accuracy: 0.001)
+        XCTAssertEqual(usage.tokenPercentageUsed, 45.0, accuracy: 0.001)
+    }
+
+    func testZeroLimitReturnsZeroPercentage() {
+        let usage = CodexUsage(
+            requestLimit: 0, requestsRemaining: 0,
+            tokenLimit: 0, tokensRemaining: 0,
+            requestResetTime: Date(), tokenResetTime: Date(),
+            lastUpdated: Date()
+        )
+        XCTAssertEqual(usage.requestPercentageUsed, 0)
+        XCTAssertEqual(usage.tokenPercentageUsed, 0)
+    }
+
+    func testParseResetDurationMinutesSeconds() {
+        let duration = CodexUsage.parseResetDuration("6m32.345s")
+        XCTAssertNotNil(duration)
+        XCTAssertEqual(duration!, 392.345, accuracy: 0.001)
+    }
+
+    func testParseResetDurationMilliseconds() {
+        let duration = CodexUsage.parseResetDuration("432ms")
+        XCTAssertNotNil(duration)
+        XCTAssertEqual(duration!, 0.432, accuracy: 0.001)
+    }
+
+    func testParseResetDurationHoursMinutesSeconds() {
+        let duration = CodexUsage.parseResetDuration("1h2m3s")
+        XCTAssertNotNil(duration)
+        XCTAssertEqual(duration!, 3723, accuracy: 0.001)
+    }
+
+    func testParseResetDurationZero() {
+        let duration = CodexUsage.parseResetDuration("0s")
+        XCTAssertNotNil(duration)
+        XCTAssertEqual(duration!, 0, accuracy: 0.001)
+    }
+
+    func testFromHeaders() {
+        let now = Date()
+        let headers: [String: String] = [
+            "x-ratelimit-limit-requests": "100",
+            "x-ratelimit-remaining-requests": "72",
+            "x-ratelimit-limit-tokens": "50000",
+            "x-ratelimit-remaining-tokens": "35000",
+            "x-ratelimit-reset-requests": "2m30s",
+            "x-ratelimit-reset-tokens": "1m0s"
+        ]
+        let usage = CodexUsage.fromHeaders(headers, at: now)
+        XCTAssertNotNil(usage)
+        XCTAssertEqual(usage!.requestLimit, 100)
+        XCTAssertEqual(usage!.requestsRemaining, 72)
+        XCTAssertEqual(usage!.tokenLimit, 50000)
+        XCTAssertEqual(usage!.tokensRemaining, 35000)
+        XCTAssertEqual(usage!.requestResetTime.timeIntervalSince(now), 150, accuracy: 0.001)
+        XCTAssertEqual(usage!.tokenResetTime.timeIntervalSince(now), 60, accuracy: 0.001)
+    }
+
+    func testFromHeadersMissingFieldReturnsNil() {
+        let headers: [String: String] = [
+            "x-ratelimit-limit-requests": "100"
+            // Missing other required fields
+        ]
+        XCTAssertNil(CodexUsage.fromHeaders(headers))
+    }
+
+    func testCodableRoundTrip() throws {
+        let usage = CodexUsage(
+            requestLimit: 100, requestsRemaining: 72,
+            tokenLimit: 50000, tokensRemaining: 35000,
+            requestResetTime: Date(), tokenResetTime: Date(),
+            lastUpdated: Date()
+        )
+        let data = try JSONEncoder().encode(usage)
+        let decoded = try JSONDecoder().decode(CodexUsage.self, from: data)
+        XCTAssertEqual(usage, decoded)
+    }
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `xcodebuild test -project "Claude Usage.xcodeproj" -scheme "Claude Usage" -destination "platform=macOS" -only-testing:"Claude UsageTests/CodexUsageTests" 2>&1 | tail -20`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add "Claude Usage/Shared/Models/CodexUsage.swift" "Claude UsageTests/CodexUsageTests.swift"
+git commit -m "feat: add CodexUsage data model with header parsing"
+```
+
+---
+
+### Task 4: Extend Profile with new fields
+
+**Files:**
+- Modify: `Claude Usage/Shared/Models/Profile.swift`
+- Test: `Claude UsageTests/ProfileMigrationTests.swift` (extend)
+
+- [ ] **Step 1: Write migration test — existing profiles decode without new fields**
+
+Add to `Claude UsageTests/ProfileMigrationTests.swift`:
+
+```swift
+func testExistingProfileDecodesWithoutNewFields() throws {
+    // Simulate a v3 profile JSON (no providerType, no OpenAI fields)
+    let json = """
+    {
+        "id": "550E8400-E29B-41D4-A716-446655440000",
+        "name": "Test Profile",
+        "hasCliAccount": false,
+        "iconConfig": {
+            "colorMode": "multiColor",
+            "singleColorHex": "#FFFFFF",
+            "showIconNames": false,
+            "showRemainingPercentage": false,
+            "showTimeMarker": true,
+            "showPaceMarker": false,
+            "usePaceColoring": false,
+            "metrics": []
+        },
+        "refreshInterval": 30.0,
+        "autoStartSessionEnabled": false,
+        "checkOverageLimitEnabled": true,
+        "notificationSettings": {
+            "enabled": true,
+            "threshold75Enabled": true,
+            "threshold90Enabled": true,
+            "threshold95Enabled": true,
+            "soundName": "default",
+            "customThresholds": []
+        },
+        "isSelectedForDisplay": true,
+        "createdAt": 0,
+        "lastUsedAt": 0
+    }
+    """.data(using: .utf8)!
+
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .secondsSince1970
+    let profile = try decoder.decode(Profile.self, from: json)
+
+    XCTAssertEqual(profile.name, "Test Profile")
+    // New fields should default gracefully
+    XCTAssertEqual(profile.providerType, .claudeMax)
+    XCTAssertNil(profile.primaryModel)
+    XCTAssertNil(profile.openaiAdminKey)
+    XCTAssertNil(profile.openaiApiKey)
+    XCTAssertNil(profile.openaiOrganizationId)
+    XCTAssertNil(profile.openaiUsage)
+    XCTAssertNil(profile.codexUsage)
+    XCTAssertNil(profile.spendBudgetCents)
+    XCTAssertNil(profile.spendBudgetCurrency)
+}
+
+func testNewProfileWithOpenAIFields() throws {
+    let profile = Profile(
+        name: "OpenAI Test",
+        providerType: .openaiAPI,
+        openaiAdminKey: "sk-admin-test123"
+    )
+    XCTAssertEqual(profile.providerType, .openaiAPI)
+    XCTAssertEqual(profile.openaiAdminKey, "sk-admin-test123")
+
+    // Codable round-trip
+    let data = try JSONEncoder().encode(profile)
+    let decoded = try JSONDecoder().decode(Profile.self, from: data)
+    XCTAssertEqual(decoded.providerType, .openaiAPI)
+    XCTAssertEqual(decoded.openaiAdminKey, "sk-admin-test123")
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `xcodebuild test -project "Claude Usage.xcodeproj" -scheme "Claude Usage" -destination "platform=macOS" -only-testing:"Claude UsageTests/ProfileMigrationTests" 2>&1 | tail -20`
+Expected: FAIL — `providerType`, `openaiAdminKey` etc. don't exist yet
+
+- [ ] **Step 3: Add new fields to Profile.swift**
+
+Add these properties after the existing `lastUsedAt` field (around line 48):
+
+```swift
+// MARK: - Provider Type (NEW — defaults to .claudeMax for existing profiles)
+var providerType: ProfileProviderType
+var primaryModel: String?               // "opus", "sonnet" — for Opus-first display
+
+// MARK: - OpenAI Credentials (NEW — only used when providerType is .openaiAPI or .codex)
+var openaiAdminKey: String?             // Admin API key for org-level endpoints
+var openaiApiKey: String?               // Regular API key for probe requests
+var openaiOrganizationId: String?
+
+// MARK: - OpenAI Usage Data (NEW)
+var openaiUsage: OpenAIUsage?
+var codexUsage: CodexUsage?
+
+// MARK: - Budget Settings (NEW — user-configured spend threshold for API billing alerts)
+var spendBudgetCents: Int?
+var spendBudgetCurrency: String?
+```
+
+Update the `init()` to include new parameters with defaults:
+
+```swift
+providerType: ProfileProviderType = .claudeMax,
+primaryModel: String? = nil,
+openaiAdminKey: String? = nil,
+openaiApiKey: String? = nil,
+openaiOrganizationId: String? = nil,
+openaiUsage: OpenAIUsage? = nil,
+codexUsage: CodexUsage? = nil,
+spendBudgetCents: Int? = nil,
+spendBudgetCurrency: String? = nil,
+```
+
+Add corresponding assignments in `init` body.
+
+Add a custom `init(from decoder:)` for backward compatibility:
+
+```swift
+init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+
+    // Existing fields
+    id = try container.decode(UUID.self, forKey: .id)
+    name = try container.decode(String.self, forKey: .name)
+    claudeSessionKey = try container.decodeIfPresent(String.self, forKey: .claudeSessionKey)
+    organizationId = try container.decodeIfPresent(String.self, forKey: .organizationId)
+    apiSessionKey = try container.decodeIfPresent(String.self, forKey: .apiSessionKey)
+    apiOrganizationId = try container.decodeIfPresent(String.self, forKey: .apiOrganizationId)
+    apiSessionKeyExpiry = try container.decodeIfPresent(Date.self, forKey: .apiSessionKeyExpiry)
+    cliCredentialsJSON = try container.decodeIfPresent(String.self, forKey: .cliCredentialsJSON)
+    hasCliAccount = try container.decodeIfPresent(Bool.self, forKey: .hasCliAccount) ?? false
+    cliAccountSyncedAt = try container.decodeIfPresent(Date.self, forKey: .cliAccountSyncedAt)
+    claudeUsage = try container.decodeIfPresent(ClaudeUsage.self, forKey: .claudeUsage)
+    apiUsage = try container.decodeIfPresent(APIUsage.self, forKey: .apiUsage)
+    iconConfig = try container.decodeIfPresent(MenuBarIconConfiguration.self, forKey: .iconConfig) ?? .default
+    refreshInterval = try container.decodeIfPresent(TimeInterval.self, forKey: .refreshInterval) ?? 30.0
+    autoStartSessionEnabled = try container.decodeIfPresent(Bool.self, forKey: .autoStartSessionEnabled) ?? false
+    checkOverageLimitEnabled = try container.decodeIfPresent(Bool.self, forKey: .checkOverageLimitEnabled) ?? true
+    notificationSettings = try container.decodeIfPresent(NotificationSettings.self, forKey: .notificationSettings) ?? NotificationSettings()
+    isSelectedForDisplay = try container.decodeIfPresent(Bool.self, forKey: .isSelectedForDisplay) ?? true
+    createdAt = try container.decodeIfPresent(Date.self, forKey: .createdAt) ?? Date()
+    lastUsedAt = try container.decodeIfPresent(Date.self, forKey: .lastUsedAt) ?? Date()
+
+    // New fields — all optional with defaults
+    providerType = try container.decodeIfPresent(ProfileProviderType.self, forKey: .providerType) ?? .claudeMax
+    primaryModel = try container.decodeIfPresent(String.self, forKey: .primaryModel)
+    openaiAdminKey = try container.decodeIfPresent(String.self, forKey: .openaiAdminKey)
+    openaiApiKey = try container.decodeIfPresent(String.self, forKey: .openaiApiKey)
+    openaiOrganizationId = try container.decodeIfPresent(String.self, forKey: .openaiOrganizationId)
+    openaiUsage = try container.decodeIfPresent(OpenAIUsage.self, forKey: .openaiUsage)
+    codexUsage = try container.decodeIfPresent(CodexUsage.self, forKey: .codexUsage)
+    spendBudgetCents = try container.decodeIfPresent(Int.self, forKey: .spendBudgetCents)
+    spendBudgetCurrency = try container.decodeIfPresent(String.self, forKey: .spendBudgetCurrency)
+}
+```
+
+Add computed properties:
+
+```swift
+var hasOpenAIAPI: Bool {
+    openaiAdminKey != nil
+}
+
+var hasCodexProbe: Bool {
+    openaiApiKey != nil
+}
+
+/// The percentage to use for status bar threshold comparisons
+var effectivePercentageForThreshold: Double? {
+    switch providerType {
+    case .claudeMax:
+        if primaryModel == "sonnet" {
+            return claudeUsage?.sonnetWeeklyPercentage
+        }
+        return claudeUsage?.opusWeeklyPercentage ?? claudeUsage?.effectiveSessionPercentage
+    case .codex:
+        return codexUsage?.requestPercentageUsed
+    case .claudeAPI:
+        guard let budget = spendBudgetCents, budget > 0, let usage = apiUsage else { return nil }
+        return Double(usage.currentSpendCents) / Double(budget) * 100.0
+    case .openaiAPI:
+        guard let budget = spendBudgetCents, budget > 0, let usage = openaiUsage else { return nil }
+        return Double(usage.currentSpendCents) / Double(budget) * 100.0
+    }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `xcodebuild test -project "Claude Usage.xcodeproj" -scheme "Claude Usage" -destination "platform=macOS" -only-testing:"Claude UsageTests/ProfileMigrationTests" 2>&1 | tail -20`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "Claude Usage/Shared/Models/Profile.swift" "Claude UsageTests/ProfileMigrationTests.swift"
+git commit -m "feat: extend Profile with providerType, OpenAI fields, and backward-compatible decoding"
+```
+
+---
+
+## Phase 2: Provider Implementations
+
+### Task 5: UsageProvider protocol and factory
+
+**Files:**
+- Create: `Claude Usage/Shared/Protocols/UsageProviderProtocol.swift`
+- Create: `Claude Usage/Shared/Services/UsageProviderFactory.swift`
+
+- [ ] **Step 1: Create the protocol**
+
+```swift
+// Claude Usage/Shared/Protocols/UsageProviderProtocol.swift
+
+import Foundation
+
+/// Type-safe container for provider-specific usage updates.
+/// Each provider sets only its relevant field; caller merges into Profile.
+struct ProfileUsageUpdate {
+    var claudeUsage: ClaudeUsage?
+    var apiUsage: APIUsage?
+    var openaiUsage: OpenAIUsage?
+    var codexUsage: CodexUsage?
+}
+
+/// Protocol for all usage data providers. Each Profile maps to one provider.
+protocol UsageProvider {
+    var providerType: ProfileProviderType { get }
+    var profileId: UUID { get }
+    var displayName: String { get }
+
+    /// Fetch fresh usage data for the given profile.
+    func fetchUsage(for profile: Profile) async throws -> ProfileUsageUpdate
+
+    /// Validate that the profile's credentials are working.
+    func validateCredentials(for profile: Profile) async throws -> Bool
+}
+```
+
+- [ ] **Step 2: Create the factory**
+
+```swift
+// Claude Usage/Shared/Services/UsageProviderFactory.swift
+
+import Foundation
+
+/// Creates the appropriate UsageProvider for a given Profile based on its providerType.
+enum UsageProviderFactory {
+    static func makeProvider(for profile: Profile) -> UsageProvider {
+        switch profile.providerType {
+        case .claudeMax:
+            return ClaudeMaxProvider(profile: profile)
+        case .claudeAPI:
+            return ClaudeAPIBillingProvider(profile: profile)
+        case .openaiAPI:
+            return OpenAIAPIProvider(profile: profile)
+        case .codex:
+            return CodexProvider(profile: profile)
+        }
+    }
+}
+```
+
+Note: The concrete provider classes (`ClaudeMaxProvider`, etc.) are created in subsequent tasks. This file will not compile until they exist. That's fine — it gets committed together with the first provider.
+
+- [ ] **Step 3: Commit protocol**
+
+```bash
+git add "Claude Usage/Shared/Protocols/UsageProviderProtocol.swift"
+git commit -m "feat: add UsageProvider protocol and ProfileUsageUpdate"
+```
+
+---
+
+### Task 6: ClaudeMaxProvider wrapper
+
+**Files:**
+- Create: `Claude Usage/Shared/Services/ClaudeMaxProvider.swift`
+
+- [ ] **Step 1: Create the wrapper**
+
+This wraps the existing `ClaudeAPIService` without modifying it. References `ClaudeAPIService` methods and `ProfileManager` to set active profile context.
+
+```swift
+// Claude Usage/Shared/Services/ClaudeMaxProvider.swift
+
+import Foundation
+
+/// Wraps existing ClaudeAPIService for Claude Max subscription tracking.
+/// Does NOT modify the original service — just delegates to it.
+struct ClaudeMaxProvider: UsageProvider {
+    let providerType: ProfileProviderType = .claudeMax
+    let profileId: UUID
+    let displayName: String
+
+    init(profile: Profile) {
+        self.profileId = profile.id
+        self.displayName = profile.name
+    }
+
+    func fetchUsage(for profile: Profile) async throws -> ProfileUsageUpdate {
+        // ClaudeAPIService reads credentials from ProfileManager.shared.activeProfile
+        // so this only works for the currently active profile.
+        let apiService = ClaudeAPIService()
+        let usage = try await apiService.fetchUsageData()
+        return ProfileUsageUpdate(claudeUsage: usage)
+    }
+
+    func validateCredentials(for profile: Profile) async throws -> Bool {
+        return profile.hasUsageCredentials
+    }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add "Claude Usage/Shared/Services/ClaudeMaxProvider.swift"
+git commit -m "feat: add ClaudeMaxProvider wrapping existing ClaudeAPIService"
+```
+
+---
+
+### Task 7: ClaudeAPIBillingProvider wrapper
+
+**Files:**
+- Create: `Claude Usage/Shared/Services/ClaudeAPIBillingProvider.swift`
+
+- [ ] **Step 1: Create the wrapper**
+
+```swift
+// Claude Usage/Shared/Services/ClaudeAPIBillingProvider.swift
+
+import Foundation
+
+/// Wraps existing Console API billing logic for Claude API spend tracking.
+struct ClaudeAPIBillingProvider: UsageProvider {
+    let providerType: ProfileProviderType = .claudeAPI
+    let profileId: UUID
+    let displayName: String
+
+    init(profile: Profile) {
+        self.profileId = profile.id
+        self.displayName = profile.name
+    }
+
+    func fetchUsage(for profile: Profile) async throws -> ProfileUsageUpdate {
+        let apiService = ClaudeAPIService()
+        guard let apiOrgId = profile.apiOrganizationId,
+              let apiKey = profile.apiSessionKey else {
+            throw ClaudeAPIService.APIError.noSessionKey
+        }
+        let apiUsage = try await apiService.fetchAPIUsageData(
+            organizationId: apiOrgId,
+            apiSessionKey: apiKey
+        )
+        return ProfileUsageUpdate(apiUsage: apiUsage)
+    }
+
+    func validateCredentials(for profile: Profile) async throws -> Bool {
+        return profile.hasAPIConsole
+    }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add "Claude Usage/Shared/Services/ClaudeAPIBillingProvider.swift"
+git commit -m "feat: add ClaudeAPIBillingProvider wrapping existing Console API"
+```
+
+---
+
+### Task 8: OpenAIAPIProvider
+
+**Files:**
+- Create: `Claude Usage/Shared/Services/OpenAIAPIProvider.swift`
+- Test: `Claude UsageTests/OpenAIAPIProviderTests.swift`
+
+- [ ] **Step 1: Write test for response parsing**
+
+```swift
+// Claude UsageTests/OpenAIAPIProviderTests.swift
+
+import XCTest
+@testable import Claude_Usage
+
+final class OpenAIAPIProviderTests: XCTestCase {
+
+    func testParseCostsResponse() throws {
+        let json = """
+        {
+            "object": "page",
+            "data": [
+                {
+                    "object": "bucket",
+                    "start_time": 1743638400,
+                    "end_time": 1743724800,
+                    "results": [
+                        {"object": "organization.costs.result", "amount": {"value": 350, "currency": "usd"}, "line_item": "Tokens"}
+                    ]
+                },
+                {
+                    "object": "bucket",
+                    "start_time": 1743724800,
+                    "end_time": 1743811200,
+                    "results": [
+                        {"object": "organization.costs.result", "amount": {"value": 480, "currency": "usd"}, "line_item": "Tokens"}
+                    ]
+                }
+            ],
+            "has_more": false
+        }
+        """.data(using: .utf8)!
+
+        let response = try JSONDecoder().decode(OpenAIAPIProvider.CostsPageResponse.self, from: json)
+        XCTAssertEqual(response.data.count, 2)
+        XCTAssertFalse(response.hasMore)
+        XCTAssertEqual(response.data[0].results[0].amount.value, 350)
+        XCTAssertEqual(response.data[0].results[0].amount.currency, "usd")
+    }
+
+    func testParseCompletionsUsageResponse() throws {
+        let json = """
+        {
+            "object": "page",
+            "data": [
+                {
+                    "object": "bucket",
+                    "start_time": 1743638400,
+                    "end_time": 1743724800,
+                    "results": [
+                        {
+                            "object": "organization.usage.completions.result",
+                            "input_tokens": 5000,
+                            "output_tokens": 2000,
+                            "input_cached_tokens": 1000,
+                            "model": "gpt-4o"
+                        }
+                    ]
+                }
+            ],
+            "has_more": false
+        }
+        """.data(using: .utf8)!
+
+        let response = try JSONDecoder().decode(OpenAIAPIProvider.CompletionsPageResponse.self, from: json)
+        XCTAssertEqual(response.data.count, 1)
+        XCTAssertEqual(response.data[0].results[0].model, "gpt-4o")
+        XCTAssertEqual(response.data[0].results[0].inputTokens, 5000)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `xcodebuild test -project "Claude Usage.xcodeproj" -scheme "Claude Usage" -destination "platform=macOS" -only-testing:"Claude UsageTests/OpenAIAPIProviderTests" 2>&1 | tail -20`
+Expected: FAIL — `OpenAIAPIProvider` doesn't exist
+
+- [ ] **Step 3: Implement OpenAIAPIProvider**
+
+```swift
+// Claude Usage/Shared/Services/OpenAIAPIProvider.swift
+
+import Foundation
+
+/// Fetches OpenAI API billing data from org-level admin endpoints.
+/// Requires an Admin API key (sk-admin-...).
+struct OpenAIAPIProvider: UsageProvider {
+    let providerType: ProfileProviderType = .openaiAPI
+    let profileId: UUID
+    let displayName: String
+
+    private static let baseURL = "https://api.openai.com/v1/organization"
+
+    init(profile: Profile) {
+        self.profileId = profile.id
+        self.displayName = profile.name
+    }
+
+    func fetchUsage(for profile: Profile) async throws -> ProfileUsageUpdate {
+        guard let adminKey = profile.openaiAdminKey else {
+            throw OpenAIError.noAdminKey
+        }
+
+        let now = Date()
+        let calendar = Calendar.current
+        let startOfMonth = calendar.date(from: calendar.dateComponents([.year, .month], from: now))!
+        let startOfNextMonth = calendar.date(byAdding: .month, value: 1, to: startOfMonth)!
+
+        let startTime = Int(startOfMonth.timeIntervalSince1970)
+        let endTime = Int(now.timeIntervalSince1970)
+
+        // Fetch costs (paginated)
+        let costs = try await fetchAllCosts(adminKey: adminKey, startTime: startTime, endTime: endTime)
+
+        // Fetch completions usage with model grouping (paginated)
+        let completions = try await fetchAllCompletions(adminKey: adminKey, startTime: startTime, endTime: endTime)
+
+        // Sum daily costs
+        var dailyCosts: [String: Double] = [:]
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+
+        var totalCents: Int = 0
+        var currency = "usd"
+
+        for bucket in costs {
+            let dateStr = dateFormatter.string(from: Date(timeIntervalSince1970: TimeInterval(bucket.startTime)))
+            let bucketTotal = bucket.results.reduce(0) { $0 + $1.amount.value }
+            dailyCosts[dateStr, default: 0] += Double(bucketTotal)
+            totalCents += bucketTotal
+            if let c = bucket.results.first?.amount.currency {
+                currency = c
+            }
+        }
+
+        // Aggregate tokens by model
+        var tokensByModel: [String: OpenAIModelTokens] = [:]
+        for bucket in completions {
+            for result in bucket.results {
+                let model = result.model ?? "unknown"
+                let existing = tokensByModel[model] ?? OpenAIModelTokens(inputTokens: 0, outputTokens: 0, cachedTokens: 0)
+                tokensByModel[model] = OpenAIModelTokens(
+                    inputTokens: existing.inputTokens + result.inputTokens,
+                    outputTokens: existing.outputTokens + result.outputTokens,
+                    cachedTokens: existing.cachedTokens + result.inputCachedTokens
+                )
+            }
+        }
+
+        let usage = OpenAIUsage(
+            currentSpendCents: totalCents,
+            currency: currency,
+            resetsAt: startOfNextMonth,
+            dailyCostCents: dailyCosts,
+            tokensByModel: tokensByModel.isEmpty ? nil : tokensByModel,
+            lastUpdated: now
+        )
+
+        return ProfileUsageUpdate(openaiUsage: usage)
+    }
+
+    func validateCredentials(for profile: Profile) async throws -> Bool {
+        guard let adminKey = profile.openaiAdminKey else { return false }
+        // Quick validation: fetch one day of costs
+        let now = Int(Date().timeIntervalSince1970)
+        let oneDayAgo = now - 86400
+        let url = URL(string: "\(Self.baseURL)/costs?start_time=\(oneDayAgo)&end_time=\(now)&bucket_width=1d&limit=1")!
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(adminKey)", forHTTPHeaderField: "Authorization")
+        let (_, response) = try await URLSession.shared.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else { return false }
+        return httpResponse.statusCode == 200
+    }
+
+    // MARK: - Pagination
+
+    private func fetchAllCosts(adminKey: String, startTime: Int, endTime: Int) async throws -> [CostBucket] {
+        var allBuckets: [CostBucket] = []
+        var nextPage: String? = nil
+
+        repeat {
+            var urlString = "\(Self.baseURL)/costs?start_time=\(startTime)&end_time=\(endTime)&bucket_width=1d&limit=7"
+            if let page = nextPage {
+                urlString += "&page=\(page)"
+            }
+            guard let url = URL(string: urlString) else { break }
+
+            var request = URLRequest(url: url)
+            request.setValue("Bearer \(adminKey)", forHTTPHeaderField: "Authorization")
+            let (data, _) = try await URLSession.shared.data(for: request)
+            let page = try JSONDecoder().decode(CostsPageResponse.self, from: data)
+            allBuckets.append(contentsOf: page.data)
+            nextPage = page.hasMore ? page.nextPage : nil
+        } while nextPage != nil
+
+        return allBuckets
+    }
+
+    private func fetchAllCompletions(adminKey: String, startTime: Int, endTime: Int) async throws -> [CompletionsBucket] {
+        var allBuckets: [CompletionsBucket] = []
+        var nextPage: String? = nil
+
+        repeat {
+            var urlString = "\(Self.baseURL)/usage/completions?start_time=\(startTime)&end_time=\(endTime)&bucket_width=1d&group_by[]=model&limit=7"
+            if let page = nextPage {
+                urlString += "&page=\(page)"
+            }
+            guard let url = URL(string: urlString) else { break }
+
+            var request = URLRequest(url: url)
+            request.setValue("Bearer \(adminKey)", forHTTPHeaderField: "Authorization")
+            let (data, _) = try await URLSession.shared.data(for: request)
+            let page = try JSONDecoder().decode(CompletionsPageResponse.self, from: data)
+            allBuckets.append(contentsOf: page.data)
+            nextPage = page.hasMore ? page.nextPage : nil
+        } while nextPage != nil
+
+        return allBuckets
+    }
+
+    // MARK: - Response Types
+
+    struct CostsPageResponse: Codable {
+        let data: [CostBucket]
+        let hasMore: Bool
+        let nextPage: String?
+
+        enum CodingKeys: String, CodingKey {
+            case data
+            case hasMore = "has_more"
+            case nextPage = "next_page"
+        }
+    }
+
+    struct CostBucket: Codable {
+        let startTime: Int
+        let endTime: Int
+        let results: [CostResult]
+
+        enum CodingKeys: String, CodingKey {
+            case startTime = "start_time"
+            case endTime = "end_time"
+            case results
+        }
+    }
+
+    struct CostResult: Codable {
+        let amount: CostAmount
+        let lineItem: String?
+
+        enum CodingKeys: String, CodingKey {
+            case amount
+            case lineItem = "line_item"
+        }
+    }
+
+    struct CostAmount: Codable {
+        let value: Int
+        let currency: String
+    }
+
+    struct CompletionsPageResponse: Codable {
+        let data: [CompletionsBucket]
+        let hasMore: Bool
+        let nextPage: String?
+
+        enum CodingKeys: String, CodingKey {
+            case data
+            case hasMore = "has_more"
+            case nextPage = "next_page"
+        }
+    }
+
+    struct CompletionsBucket: Codable {
+        let startTime: Int
+        let endTime: Int
+        let results: [CompletionsResult]
+
+        enum CodingKeys: String, CodingKey {
+            case startTime = "start_time"
+            case endTime = "end_time"
+            case results
+        }
+    }
+
+    struct CompletionsResult: Codable {
+        let inputTokens: Int
+        let outputTokens: Int
+        let inputCachedTokens: Int
+        let model: String?
+
+        enum CodingKeys: String, CodingKey {
+            case inputTokens = "input_tokens"
+            case outputTokens = "output_tokens"
+            case inputCachedTokens = "input_cached_tokens"
+            case model
+        }
+    }
+
+    // MARK: - Errors
+
+    enum OpenAIError: Error, LocalizedError {
+        case noAdminKey
+        case invalidResponse
+        case unauthorized
+
+        var errorDescription: String? {
+            switch self {
+            case .noAdminKey: return "No OpenAI Admin API key configured"
+            case .invalidResponse: return "Invalid response from OpenAI API"
+            case .unauthorized: return "OpenAI Admin API key is invalid or expired"
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `xcodebuild test -project "Claude Usage.xcodeproj" -scheme "Claude Usage" -destination "platform=macOS" -only-testing:"Claude UsageTests/OpenAIAPIProviderTests" 2>&1 | tail -20`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "Claude Usage/Shared/Services/OpenAIAPIProvider.swift" "Claude UsageTests/OpenAIAPIProviderTests.swift"
+git commit -m "feat: add OpenAIAPIProvider with paginated costs and completions endpoints"
+```
+
+---
+
+### Task 9: CodexProvider
+
+**Files:**
+- Create: `Claude Usage/Shared/Services/CodexProvider.swift`
+- Test: `Claude UsageTests/CodexProviderTests.swift`
+
+- [ ] **Step 1: Write test**
+
+```swift
+// Claude UsageTests/CodexProviderTests.swift
+
+import XCTest
+@testable import Claude_Usage
+
+final class CodexProviderTests: XCTestCase {
+
+    func testBuildProbeRequest() {
+        let provider = CodexProvider(profile: Profile(name: "Test Codex", providerType: .codex, openaiApiKey: "sk-test123"))
+        let request = provider.buildProbeRequest(apiKey: "sk-test123")
+
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(request.url?.absoluteString, "https://api.openai.com/v1/chat/completions")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer sk-test123")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+
+        // Verify body is minimal
+        let body = try! JSONSerialization.jsonObject(with: request.httpBody!) as! [String: Any]
+        XCTAssertEqual(body["max_tokens"] as? Int, 1)
+        XCTAssertNotNil(body["model"])
+        XCTAssertNotNil(body["messages"])
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `xcodebuild test -project "Claude Usage.xcodeproj" -scheme "Claude Usage" -destination "platform=macOS" -only-testing:"Claude UsageTests/CodexProviderTests" 2>&1 | tail -20`
+Expected: FAIL
+
+- [ ] **Step 3: Implement CodexProvider**
+
+```swift
+// Claude Usage/Shared/Services/CodexProvider.swift
+
+import Foundation
+
+/// Tracks OpenAI API rate limits by making a lightweight probe request
+/// and reading rate-limit headers from the response.
+struct CodexProvider: UsageProvider {
+    let providerType: ProfileProviderType = .codex
+    let profileId: UUID
+    let displayName: String
+
+    private static let completionsURL = URL(string: "https://api.openai.com/v1/chat/completions")!
+
+    init(profile: Profile) {
+        self.profileId = profile.id
+        self.displayName = profile.name
+    }
+
+    func fetchUsage(for profile: Profile) async throws -> ProfileUsageUpdate {
+        guard let apiKey = profile.openaiApiKey else {
+            throw CodexError.noApiKey
+        }
+
+        let request = buildProbeRequest(apiKey: apiKey)
+        let (_, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw CodexError.invalidResponse
+        }
+
+        guard httpResponse.statusCode == 200 || httpResponse.statusCode == 429 else {
+            if httpResponse.statusCode == 401 {
+                throw CodexError.unauthorized
+            }
+            throw CodexError.serverError(statusCode: httpResponse.statusCode)
+        }
+
+        // Extract rate-limit headers (available on both 200 and 429 responses)
+        let headers = Dictionary(
+            uniqueKeysWithValues: httpResponse.allHeaderFields.compactMap { key, value in
+                guard let k = key as? String, let v = value as? String else { return nil }
+                return (k.lowercased(), v)
+            }
+        )
+
+        guard let usage = CodexUsage.fromHeaders(headers) else {
+            throw CodexError.missingRateLimitHeaders
+        }
+
+        return ProfileUsageUpdate(codexUsage: usage)
+    }
+
+    func validateCredentials(for profile: Profile) async throws -> Bool {
+        guard let apiKey = profile.openaiApiKey else { return false }
+        let request = buildProbeRequest(apiKey: apiKey)
+        let (_, response) = try await URLSession.shared.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else { return false }
+        return httpResponse.statusCode == 200
+    }
+
+    /// Build a minimal probe request: 1 token, cheapest model
+    func buildProbeRequest(apiKey: String) -> URLRequest {
+        var request = URLRequest(url: Self.completionsURL)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try? JSONSerialization.data(withJSONObject: [
+            "model": "gpt-4o-mini",
+            "max_tokens": 1,
+            "messages": [["role": "user", "content": "hi"]]
+        ])
+        return request
+    }
+
+    // MARK: - Errors
+
+    enum CodexError: Error, LocalizedError {
+        case noApiKey
+        case invalidResponse
+        case unauthorized
+        case missingRateLimitHeaders
+        case serverError(statusCode: Int)
+
+        var errorDescription: String? {
+            switch self {
+            case .noApiKey: return "No OpenAI API key configured for Codex probe"
+            case .invalidResponse: return "Invalid response from OpenAI API"
+            case .unauthorized: return "OpenAI API key is invalid or expired"
+            case .missingRateLimitHeaders: return "Rate-limit headers missing from response"
+            case .serverError(let code): return "OpenAI API returned status \(code)"
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `xcodebuild test -project "Claude Usage.xcodeproj" -scheme "Claude Usage" -destination "platform=macOS" -only-testing:"Claude UsageTests/CodexProviderTests" 2>&1 | tail -20`
+Expected: PASS
+
+- [ ] **Step 5: Now commit the factory too (all providers exist)**
+
+```bash
+git add "Claude Usage/Shared/Services/CodexProvider.swift" "Claude UsageTests/CodexProviderTests.swift" "Claude Usage/Shared/Services/UsageProviderFactory.swift"
+git commit -m "feat: add CodexProvider with probe requests and UsageProviderFactory"
+```
+
+---
+
+## Phase 3: Infrastructure
+
+### Task 10: Smart status bar renderer
+
+**Files:**
+- Create: `Claude Usage/MenuBar/SmartStatusBarRenderer.swift`
+- Test: `Claude UsageTests/SmartStatusBarRendererTests.swift`
+
+- [ ] **Step 1: Write test**
+
+```swift
+// Claude UsageTests/SmartStatusBarRendererTests.swift
+
+import XCTest
+@testable import Claude_Usage
+
+final class SmartStatusBarRendererTests: XCTestCase {
+
+    func testNoProfilesAboveThresholdReturnsEmpty() {
+        let profiles = [
+            makeProfile(name: "Low", percentage: 30),
+            makeProfile(name: "Medium", percentage: 55)
+        ]
+        let result = SmartStatusBarRenderer.profilesForStatusBar(profiles, threshold: 60, maxItems: 4)
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testProfilesAboveThresholdReturned() {
+        let profiles = [
+            makeProfile(name: "High", percentage: 85),
+            makeProfile(name: "Low", percentage: 30),
+            makeProfile(name: "Critical", percentage: 95)
+        ]
+        let result = SmartStatusBarRenderer.profilesForStatusBar(profiles, threshold: 60, maxItems: 4)
+        XCTAssertEqual(result.count, 2)
+        XCTAssertEqual(result[0].name, "Critical")  // Highest first
+        XCTAssertEqual(result[1].name, "High")
+    }
+
+    func testMaxItemsRespected() {
+        let profiles = (1...6).map { i in
+            makeProfile(name: "P\(i)", percentage: Double(60 + i * 5))
+        }
+        let result = SmartStatusBarRenderer.profilesForStatusBar(profiles, threshold: 60, maxItems: 3)
+        XCTAssertEqual(result.count, 3)
+    }
+
+    func testColorForPercentage() {
+        XCTAssertEqual(SmartStatusBarRenderer.alertLevel(for: 50), .none)
+        XCTAssertEqual(SmartStatusBarRenderer.alertLevel(for: 72), .warning)
+        XCTAssertEqual(SmartStatusBarRenderer.alertLevel(for: 95), .critical)
+    }
+
+    func testAPIProfileWithNoBudgetExcluded() {
+        var profile = Profile(name: "API", providerType: .claudeAPI)
+        profile.apiUsage = APIUsage(
+            currentSpendCents: 5000,
+            resetsAt: Date(),
+            prepaidCreditsCents: 10000,
+            currency: "usd",
+            apiTokenCostCents: nil,
+            apiCostByModel: nil,
+            costBySource: nil,
+            dailyCostCents: nil
+        )
+        // No spendBudgetCents set → effectivePercentageForThreshold returns nil
+        XCTAssertNil(profile.effectivePercentageForThreshold)
+    }
+
+    // MARK: - Helpers
+
+    private func makeProfile(name: String, percentage: Double) -> Profile {
+        var profile = Profile(name: name, providerType: .claudeMax)
+        profile.claudeUsage = ClaudeUsage(
+            sessionTokensUsed: 0, sessionLimit: 0,
+            sessionPercentage: percentage,
+            sessionResetTime: Date().addingTimeInterval(3600),
+            weeklyTokensUsed: 0, weeklyLimit: 0,
+            weeklyPercentage: percentage,
+            weeklyResetTime: Date(),
+            opusWeeklyTokensUsed: 0,
+            opusWeeklyPercentage: percentage,
+            sonnetWeeklyTokensUsed: 0,
+            sonnetWeeklyPercentage: 0,
+            lastUpdated: Date(),
+            userTimezone: .current
+        )
+        return profile
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Expected: FAIL — `SmartStatusBarRenderer` doesn't exist
+
+- [ ] **Step 3: Implement SmartStatusBarRenderer**
+
+```swift
+// Claude Usage/MenuBar/SmartStatusBarRenderer.swift
+
+import Foundation
+
+/// Determines which profiles should appear in the status bar based on threshold logic.
+enum SmartStatusBarRenderer {
+
+    enum AlertLevel: Equatable {
+        case none       // Below threshold — hidden from status bar
+        case warning    // 60-89% — yellow
+        case critical   // 90%+ — red
+    }
+
+    /// Returns profiles that should appear in the status bar, sorted by urgency (highest % first).
+    /// Profiles below the threshold are excluded.
+    /// API billing profiles with no budget set are excluded.
+    static func profilesForStatusBar(
+        _ profiles: [Profile],
+        threshold: Double = 60,
+        maxItems: Int = 4
+    ) -> [Profile] {
+        profiles
+            .compactMap { profile -> (Profile, Double)? in
+                guard let pct = profile.effectivePercentageForThreshold,
+                      pct >= threshold else { return nil }
+                return (profile, pct)
+            }
+            .sorted { $0.1 > $1.1 }  // Highest percentage first
+            .prefix(maxItems)
+            .map(\.0)
+    }
+
+    /// Determine the alert level for a given percentage.
+    static func alertLevel(for percentage: Double) -> AlertLevel {
+        if percentage >= 90 { return .critical }
+        if percentage >= 60 { return .warning }
+        return .none
+    }
+
+    /// Format the status bar label for a profile.
+    static func statusBarLabel(for profile: Profile) -> String {
+        let pct = profile.effectivePercentageForThreshold ?? 0
+        let pctStr = String(format: "%.0f%%", pct)
+
+        switch profile.providerType {
+        case .claudeMax:
+            let model = profile.primaryModel ?? "opus"
+            return "\(profile.name) \(model) \(pctStr)"
+        case .codex:
+            return "Codex \(pctStr)"
+        case .claudeAPI, .openaiAPI:
+            if let usage = profile.providerType == .claudeAPI ? profile.apiUsage?.usedAmount : profile.openaiUsage?.usedAmount {
+                return "\(profile.name) $\(String(format: "%.0f", usage))"
+            }
+            return "\(profile.name) \(pctStr)"
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `xcodebuild test -project "Claude Usage.xcodeproj" -scheme "Claude Usage" -destination "platform=macOS" -only-testing:"Claude UsageTests/SmartStatusBarRendererTests" 2>&1 | tail -20`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "Claude Usage/MenuBar/SmartStatusBarRenderer.swift" "Claude UsageTests/SmartStatusBarRendererTests.swift"
+git commit -m "feat: add SmartStatusBarRenderer with threshold-based visibility"
+```
+
+---
+
+### Task 11: Extend UsageRefreshCoordinator for variable intervals
+
+**Files:**
+- Modify: `Claude Usage/MenuBar/UsageRefreshCoordinator.swift`
+
+- [ ] **Step 1: Add per-profile timer support**
+
+The current coordinator uses a single `refreshTimer`. Replace with per-profile timers keyed by `profileId`.
+
+In `UsageRefreshCoordinator.swift`, add:
+
+```swift
+// Add property for per-profile timers
+private var profileTimers: [UUID: Timer] = [:]
+
+/// Start refresh timers for all enabled profiles with variable intervals
+func startMultiProviderRefresh(profiles: [Profile]) {
+    stopAllTimers()
+
+    for profile in profiles where profile.isSelectedForDisplay {
+        let interval = profile.refreshInterval > 0
+            ? profile.refreshInterval
+            : profile.providerType.defaultRefreshInterval
+
+        let timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
+            Task { [weak self] in
+                await self?.refreshProfile(profile)
+            }
+        }
+        profileTimers[profile.id] = timer
+
+        // Immediate first refresh
+        Task { [weak self] in
+            await self?.refreshProfile(profile)
+        }
+    }
+}
+
+/// Refresh a single profile using its provider
+private func refreshProfile(_ profile: Profile) async {
+    let provider = UsageProviderFactory.makeProvider(for: profile)
+    do {
+        let update = try await provider.fetchUsage(for: profile)
+        await MainActor.run {
+            delegate?.profileUsageDidUpdate(profileId: profile.id, update: update)
+        }
+    } catch {
+        await MainActor.run {
+            delegate?.profileRefreshDidFail(profileId: profile.id, error: error)
+        }
+    }
+}
+
+func stopAllTimers() {
+    profileTimers.values.forEach { $0.invalidate() }
+    profileTimers.removeAll()
+}
+```
+
+Update the `UsageRefreshCoordinatorDelegate` protocol:
+
+```swift
+protocol UsageRefreshCoordinatorDelegate: AnyObject {
+    // Existing
+    func usageRefreshDidComplete(usage: ClaudeUsage)
+    func statusRefreshDidComplete(status: ClaudeStatus)
+    func apiUsageRefreshDidComplete(apiUsage: APIUsage)
+
+    // New
+    func profileUsageDidUpdate(profileId: UUID, update: ProfileUsageUpdate)
+    func profileRefreshDidFail(profileId: UUID, error: Error)
+}
+
+// Default implementations so existing code doesn't break
+extension UsageRefreshCoordinatorDelegate {
+    func profileUsageDidUpdate(profileId: UUID, update: ProfileUsageUpdate) {}
+    func profileRefreshDidFail(profileId: UUID, error: Error) {}
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add "Claude Usage/MenuBar/UsageRefreshCoordinator.swift"
+git commit -m "feat: add per-profile variable refresh intervals to UsageRefreshCoordinator"
+```
+
+---
+
+### Task 12: Extend ProfileStore with v4 storage migration
+
+**Files:**
+- Modify: `Claude Usage/Shared/Storage/ProfileStore.swift`
+
+- [ ] **Step 1: Add v4 key with v3 fallback**
+
+In `ProfileStore.swift`, update the `Keys` enum:
+
+```swift
+private enum Keys {
+    static let profiles = "profiles_v4"      // Updated from profiles_v3
+    static let legacyProfiles = "profiles_v3" // Fallback for migration
+    static let activeProfileId = "activeProfileId"
+    static let displayMode = "profileDisplayMode"
+    static let multiProfileConfig = "multiProfileDisplayConfig"
+}
+```
+
+Update `loadProfiles()` to try v4 first, fall back to v3:
+
+```swift
+func loadProfiles() -> [Profile] {
+    // Try v4 first
+    if let data = defaults.data(forKey: Keys.profiles) {
+        do {
+            let profiles = try JSONDecoder().decode([Profile].self, from: data)
+            LoggingService.shared.log("ProfileStore: Loaded \(profiles.count) profiles from v4 storage")
+            return profiles
+        } catch {
+            LoggingService.shared.logStorageError("loadProfiles v4", error: error)
+        }
+    }
+
+    // Fall back to v3 (existing profiles without new fields)
+    if let data = defaults.data(forKey: Keys.legacyProfiles) {
+        do {
+            let profiles = try JSONDecoder().decode([Profile].self, from: data)
+            LoggingService.shared.log("ProfileStore: Migrated \(profiles.count) profiles from v3 to v4")
+            // Save as v4 immediately
+            saveProfiles(profiles)
+            return profiles
+        } catch {
+            LoggingService.shared.logStorageError("loadProfiles v3 migration", error: error)
+        }
+    }
+
+    LoggingService.shared.log("ProfileStore: No profiles found in storage")
+    return []
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add "Claude Usage/Shared/Storage/ProfileStore.swift"
+git commit -m "feat: add profiles_v4 storage with v3 fallback migration"
+```
+
+---
+
+### Task 13: Extend ProfileManager with factory methods
+
+**Files:**
+- Modify: `Claude Usage/Shared/Services/ProfileManager.swift`
+
+- [ ] **Step 1: Add factory methods for new provider types**
+
+Add these methods to `ProfileManager`:
+
+```swift
+/// Create a new OpenAI API profile
+func createOpenAIAPIProfile(name: String, adminKey: String, organizationId: String? = nil) -> Profile {
+    let profile = Profile(
+        name: name,
+        providerType: .openaiAPI,
+        openaiAdminKey: adminKey,
+        openaiOrganizationId: organizationId
+    )
+    profiles.append(profile)
+    saveAndBroadcast()
+    return profile
+}
+
+/// Create a new Codex probe profile
+func createCodexProfile(name: String, apiKey: String) -> Profile {
+    let profile = Profile(
+        name: name,
+        providerType: .codex,
+        openaiApiKey: apiKey
+    )
+    profiles.append(profile)
+    saveAndBroadcast()
+    return profile
+}
+
+/// Create a new Claude API billing profile
+func createClaudeAPIProfile(name: String, apiSessionKey: String, apiOrganizationId: String) -> Profile {
+    let profile = Profile(
+        name: name,
+        providerType: .claudeAPI,
+        apiSessionKey: apiSessionKey,
+        apiOrganizationId: apiOrganizationId
+    )
+    profiles.append(profile)
+    saveAndBroadcast()
+    return profile
+}
+
+/// Helper to save and broadcast changes
+private func saveAndBroadcast() {
+    ProfileStore.shared.saveProfiles(profiles)
+    objectWillChange.send()
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add "Claude Usage/Shared/Services/ProfileManager.swift"
+git commit -m "feat: add ProfileManager factory methods for OpenAI, Codex, and Claude API profiles"
+```
+
+---
+
+## Phase 4: UI
+
+### Task 14: OpenAI credential entry view
+
+**Files:**
+- Create: `Claude Usage/Views/Credentials/OpenAICredentialView.swift`
+
+- [ ] **Step 1: Create the view**
+
+```swift
+// Claude Usage/Views/Credentials/OpenAICredentialView.swift
+
+import SwiftUI
+
+struct OpenAICredentialView: View {
+    @Environment(\.dismiss) var dismiss
+    @StateObject private var profileManager = ProfileManager.shared
+
+    let providerType: ProfileProviderType // .openaiAPI or .codex
+    @State private var name: String = ""
+    @State private var apiKey: String = ""
+    @State private var isValidating = false
+    @State private var validationError: String?
+    @State private var validationSuccess = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text(providerType == .openaiAPI ? "Add OpenAI API" : "Add Codex")
+                .font(.headline)
+
+            TextField("Display Name", text: $name)
+                .textFieldStyle(.roundedBorder)
+
+            SecureField(
+                providerType == .openaiAPI ? "Admin API Key (sk-admin-...)" : "API Key (sk-...)",
+                text: $apiKey
+            )
+            .textFieldStyle(.roundedBorder)
+
+            if providerType == .openaiAPI {
+                Text("Requires an Admin API key from platform.openai.com/settings")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } else {
+                Text("Tracks API rate limits via probe requests. This is NOT your Codex subscription quota.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            if let error = validationError {
+                Text(error)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+
+            if validationSuccess {
+                Text("Connected successfully!")
+                    .font(.caption)
+                    .foregroundStyle(.green)
+            }
+
+            HStack {
+                Button("Cancel") { dismiss() }
+                    .keyboardShortcut(.cancelAction)
+
+                Spacer()
+
+                Button("Validate & Save") {
+                    Task { await validateAndSave() }
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(apiKey.isEmpty || name.isEmpty || isValidating)
+            }
+        }
+        .padding(20)
+        .frame(width: 400)
+        .onAppear {
+            name = providerType == .openaiAPI ? "OpenAI API" : "Codex"
+        }
+    }
+
+    private func validateAndSave() async {
+        isValidating = true
+        validationError = nil
+        validationSuccess = false
+
+        let profile: Profile
+        if providerType == .openaiAPI {
+            profile = Profile(name: name, providerType: .openaiAPI, openaiAdminKey: apiKey)
+        } else {
+            profile = Profile(name: name, providerType: .codex, openaiApiKey: apiKey)
+        }
+
+        let provider = UsageProviderFactory.makeProvider(for: profile)
+        do {
+            let isValid = try await provider.validateCredentials(for: profile)
+            if isValid {
+                if providerType == .openaiAPI {
+                    _ = profileManager.createOpenAIAPIProfile(name: name, adminKey: apiKey)
+                } else {
+                    _ = profileManager.createCodexProfile(name: name, apiKey: apiKey)
+                }
+                validationSuccess = true
+                try? await Task.sleep(for: .seconds(1))
+                dismiss()
+            } else {
+                validationError = "Credentials are invalid. Check your API key."
+            }
+        } catch {
+            validationError = error.localizedDescription
+        }
+
+        isValidating = false
+    }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add "Claude Usage/Views/Credentials/OpenAICredentialView.swift"
+git commit -m "feat: add OpenAI and Codex credential entry views"
+```
+
+---
+
+### Task 15: Provider type picker for new profiles
+
+**Files:**
+- Create: `Claude Usage/Views/Settings/AddProviderView.swift`
+
+- [ ] **Step 1: Create the picker view**
+
+```swift
+// Claude Usage/Views/Settings/AddProviderView.swift
+
+import SwiftUI
+
+struct AddProviderView: View {
+    @Environment(\.dismiss) var dismiss
+    @State private var selectedType: ProfileProviderType?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Add Service")
+                .font(.headline)
+
+            Text("Choose what you want to track:")
+                .foregroundStyle(.secondary)
+
+            ForEach(ProfileProviderType.allCases, id: \.self) { type in
+                Button(action: { selectedType = type }) {
+                    HStack(spacing: 12) {
+                        Image(systemName: type.iconSystemName)
+                            .frame(width: 24)
+                        VStack(alignment: .leading) {
+                            Text(type.displayName)
+                                .fontWeight(.medium)
+                            Text(typeDescription(type))
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        Spacer()
+                    }
+                    .padding(10)
+                    .background(selectedType == type ? Color.accentColor.opacity(0.15) : Color.clear)
+                    .cornerRadius(8)
+                }
+                .buttonStyle(.plain)
+            }
+
+            HStack {
+                Button("Cancel") { dismiss() }
+                Spacer()
+            }
+        }
+        .padding(20)
+        .frame(width: 400)
+        .sheet(item: $selectedType) { type in
+            switch type {
+            case .claudeMax:
+                // Reuse existing credential setup flow
+                Text("Use the existing Claude setup wizard for Claude Max accounts")
+                    .padding()
+            case .claudeAPI:
+                Text("Use the existing API billing setup for Claude API")
+                    .padding()
+            case .openaiAPI:
+                OpenAICredentialView(providerType: .openaiAPI)
+            case .codex:
+                OpenAICredentialView(providerType: .codex)
+            }
+        }
+    }
+
+    private func typeDescription(_ type: ProfileProviderType) -> String {
+        switch type {
+        case .claudeMax: return "Track Claude subscription session and weekly limits"
+        case .claudeAPI: return "Track Anthropic API billing and spend"
+        case .openaiAPI: return "Track OpenAI API billing and spend (requires Admin key)"
+        case .codex: return "Track OpenAI API rate limits via probe requests"
+        }
+    }
+}
+
+extension ProfileProviderType: Identifiable {
+    var id: String { rawValue }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add "Claude Usage/Views/Settings/AddProviderView.swift"
+git commit -m "feat: add provider type picker for new profile creation"
+```
+
+---
+
+### Task 16: Extend PopoverContentView with 3-section layout
+
+**Files:**
+- Modify: `Claude Usage/MenuBar/PopoverContentView.swift`
+
+- [ ] **Step 1: Add section views for the new providers**
+
+Add these views to `PopoverContentView.swift` (or a new file `PopoverSections.swift` if the file is already large):
+
+```swift
+// Add to PopoverContentView.swift or create Claude Usage/MenuBar/PopoverSections.swift
+
+import SwiftUI
+
+/// Section showing OpenAI API billing in the popover
+struct OpenAIBillingSection: View {
+    let profile: Profile
+
+    var body: some View {
+        if let usage = profile.openaiUsage {
+            VStack(alignment: .leading, spacing: 6) {
+                HStack {
+                    Text(profile.name)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(.blue)
+                    Spacer()
+                    Text("Resets \(usage.resetsAt, style: .relative)")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+
+                HStack {
+                    Text("This month")
+                    Spacer()
+                    Text(usage.formattedUsed)
+                        .foregroundStyle(.blue)
+                }
+                .font(.caption)
+
+                if let budget = profile.spendBudgetCents, budget > 0 {
+                    let remaining = Double(budget - usage.currentSpendCents) / 100.0
+                    HStack {
+                        Text("Budget remaining")
+                        Spacer()
+                        Text("$\(String(format: "%.2f", remaining))")
+                    }
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 8)
+        }
+    }
+}
+
+/// Section showing Codex rate limits in the popover
+struct CodexSection: View {
+    let profile: Profile
+
+    var body: some View {
+        if let usage = profile.codexUsage {
+            VStack(alignment: .leading, spacing: 6) {
+                HStack {
+                    Text(profile.name)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(.purple)
+                    Spacer()
+                    Text("Resets \(usage.requestResetTime, style: .relative)")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+
+                // Requests bar (primary)
+                VStack(alignment: .leading, spacing: 2) {
+                    HStack {
+                        Text("Requests")
+                            .font(.caption2)
+                            .foregroundStyle(.purple)
+                        Spacer()
+                        Text("\(String(format: "%.0f", usage.requestPercentageUsed))%")
+                            .font(.caption2)
+                    }
+                    ProgressView(value: usage.requestPercentageUsed, total: 100)
+                        .tint(.purple)
+                }
+
+                // Tokens bar (secondary)
+                VStack(alignment: .leading, spacing: 2) {
+                    HStack {
+                        Text("Tokens")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        Text("\(String(format: "%.0f", usage.tokenPercentageUsed))%")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                    ProgressView(value: usage.tokenPercentageUsed, total: 100)
+                        .tint(.secondary)
+                }
+
+                Text("OpenAI API Rate Limits")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 8)
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add "Claude Usage/MenuBar/PopoverContentView.swift"
+git commit -m "feat: add OpenAI billing and Codex rate-limit popover sections"
+```
+
+---
+
+### Task 17: Rebrand app entry point
+
+**Files:**
+- Modify: `Claude Usage/App/ClaudeUsageTrackerApp.swift`
+
+- [ ] **Step 1: Rename the app struct**
+
+```swift
+// Claude Usage/App/ClaudeUsageTrackerApp.swift
+
+import SwiftUI
+
+@main
+struct AIUsageTrackerApp: App {
+    @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+
+    var body: some Scene {
+        Settings {
+            SettingsView()
+        }
+    }
+}
+```
+
+Note: The bundle identifier change (`HamedElfayome.Claude-Usage` → new identifier) is done in the Xcode project settings, not in Swift code. That can be configured in Xcode's target settings.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add "Claude Usage/App/ClaudeUsageTrackerApp.swift"
+git commit -m "refactor: rebrand app entry point to AIUsageTrackerApp"
+```
+
+---
+
+## Phase 5: Integration
+
+### Task 18: Wire up MenuBarManager for multi-provider display
+
+**Files:**
+- Modify: `Claude Usage/MenuBar/MenuBarManager.swift`
+
+- [ ] **Step 1: Add OpenAI/Codex usage properties and smart status bar integration**
+
+Add to `MenuBarManager` published properties:
+
+```swift
+// After existing @Published properties (around line 18)
+@Published private(set) var allProfileUsages: [UUID: ProfileUsageUpdate] = [:]
+```
+
+Implement the new delegate methods:
+
+```swift
+// MARK: - Multi-Provider Support
+
+func profileUsageDidUpdate(profileId: UUID, update: ProfileUsageUpdate) {
+    allProfileUsages[profileId] = update
+
+    // Update the profile's stored usage data
+    if var profile = profileManager.profiles.first(where: { $0.id == profileId }) {
+        if let claudeUsage = update.claudeUsage {
+            profile.claudeUsage = claudeUsage
+        }
+        if let apiUsage = update.apiUsage {
+            profile.apiUsage = apiUsage
+        }
+        if let openaiUsage = update.openaiUsage {
+            profile.openaiUsage = openaiUsage
+        }
+        if let codexUsage = update.codexUsage {
+            profile.codexUsage = codexUsage
+        }
+        profileManager.updateProfile(profile)
+    }
+
+    // Re-evaluate smart status bar
+    updateSmartStatusBar()
+}
+
+func profileRefreshDidFail(profileId: UUID, error: Error) {
+    LoggingService.shared.logError("Refresh failed for profile \(profileId): \(error.localizedDescription)")
+}
+
+private func updateSmartStatusBar() {
+    let profilesForBar = SmartStatusBarRenderer.profilesForStatusBar(
+        profileManager.profiles,
+        threshold: UserDefaults.standard.double(forKey: "statusBarThreshold").nonZeroOr(60),
+        maxItems: UserDefaults.standard.integer(forKey: "statusBarMaxItems").nonZeroOr(4)
+    )
+
+    // Update status bar items based on profilesForBar
+    // This integrates with the existing icon rendering system
+    objectWillChange.send()
+}
+```
+
+Add this small extension for safe defaults:
+
+```swift
+private extension Double {
+    func nonZeroOr(_ fallback: Double) -> Double {
+        self > 0 ? self : fallback
+    }
+}
+
+private extension Int {
+    func nonZeroOr(_ fallback: Int) -> Int {
+        self > 0 ? self : fallback
+    }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add "Claude Usage/MenuBar/MenuBarManager.swift"
+git commit -m "feat: wire up MenuBarManager for multi-provider usage and smart status bar"
+```
+
+---
+
+### Task 19: Extend UsageHistoryService with new snapshot types
+
+**Files:**
+- Modify: `Claude Usage/Shared/Services/UsageHistoryService.swift`
+
+- [ ] **Step 1: Add OpenAI and Codex recording methods**
+
+Add to `UsageHistoryService`:
+
+```swift
+/// Record OpenAI cost snapshot (called on each OpenAI API refresh)
+func recordOpenAICost(for profileId: UUID, usage: OpenAIUsage) {
+    var history = loadHistory(for: profileId)
+    let snapshot = UsageSnapshot(
+        timestamp: usage.lastUpdated,
+        sessionPercentage: nil,
+        weeklyPercentage: nil,
+        opusPercentage: nil,
+        sonnetPercentage: nil,
+        apiSpendCents: usage.currentSpendCents,
+        snapshotType: "openaiCost"
+    )
+    history.snapshots.append(snapshot)
+    // Keep last 500 OpenAI snapshots
+    let openaiSnapshots = history.snapshots.filter { $0.snapshotType == "openaiCost" }
+    if openaiSnapshots.count > 500 {
+        let excess = openaiSnapshots.count - 500
+        history.snapshots.removeAll { $0.snapshotType == "openaiCost" }
+        history.snapshots.append(contentsOf: Array(openaiSnapshots.dropFirst(excess)))
+    }
+    saveHistory(history, for: profileId)
+}
+
+/// Record Codex rate-limit snapshot
+func recordCodexRateLimit(for profileId: UUID, usage: CodexUsage) {
+    var history = loadHistory(for: profileId)
+    let snapshot = UsageSnapshot(
+        timestamp: usage.lastUpdated,
+        sessionPercentage: usage.requestPercentageUsed,
+        weeklyPercentage: usage.tokenPercentageUsed,
+        opusPercentage: nil,
+        sonnetPercentage: nil,
+        apiSpendCents: nil,
+        snapshotType: "codexRateLimit"
+    )
+    history.snapshots.append(snapshot)
+    let codexSnapshots = history.snapshots.filter { $0.snapshotType == "codexRateLimit" }
+    if codexSnapshots.count > 500 {
+        let excess = codexSnapshots.count - 500
+        history.snapshots.removeAll { $0.snapshotType == "codexRateLimit" }
+        history.snapshots.append(contentsOf: Array(codexSnapshots.dropFirst(excess)))
+    }
+    saveHistory(history, for: profileId)
+}
+```
+
+Note: This extends `UsageSnapshot` to include a `snapshotType` field and `apiSpendCents` field. Check if the existing model needs these additions — if `UsageSnapshot` doesn't have a `snapshotType` field, add it as an optional `String?` with backward-compatible decoding.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add "Claude Usage/Shared/Services/UsageHistoryService.swift"
+git commit -m "feat: add OpenAI and Codex history snapshot recording"
+```
+
+---
+
+### Task 20: Extend NotificationManager for provider-aware thresholds
+
+**Files:**
+- Modify: `Claude Usage/Shared/Services/NotificationManager.swift`
+
+- [ ] **Step 1: Add provider-aware notification checking**
+
+Add to `NotificationManager`:
+
+```swift
+/// Check and notify for any provider type based on profile settings
+func checkAndNotifyForProfile(_ profile: Profile) {
+    guard profile.notificationSettings.enabled else { return }
+
+    guard let percentage = profile.effectivePercentageForThreshold else { return }
+
+    let thresholds = profile.notificationSettings.sortedThresholds
+
+    for threshold in thresholds {
+        if percentage >= Double(threshold) {
+            let title: String
+            switch profile.providerType {
+            case .claudeMax:
+                let model = profile.primaryModel ?? "opus"
+                title = "\(profile.name) — \(model.capitalized) at \(Int(percentage))%"
+            case .claudeAPI:
+                title = "\(profile.name) — Claude API spend alert"
+            case .openaiAPI:
+                title = "\(profile.name) — OpenAI API spend alert"
+            case .codex:
+                title = "\(profile.name) — Codex rate limit at \(Int(percentage))%"
+            }
+
+            sendNotificationIfNeeded(
+                identifier: "\(profile.id.uuidString)-\(threshold)",
+                title: title,
+                body: "Usage has reached \(threshold)%",
+                sound: profile.notificationSettings.notificationSound
+            )
+        }
+    }
+}
+
+private func sendNotificationIfNeeded(identifier: String, title: String, body: String, sound: UNNotificationSound?) {
+    let content = UNMutableNotificationContent()
+    content.title = title
+    content.body = body
+    content.sound = sound
+
+    let request = UNNotificationRequest(identifier: identifier, content: content, trigger: nil)
+    UNUserNotificationCenter.current().add(request)
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add "Claude Usage/Shared/Services/NotificationManager.swift"
+git commit -m "feat: add provider-aware notification thresholds"
+```
+
+---
+
+## Verification
+
+### Task 21: Build verification
+
+- [ ] **Step 1: Build the project**
+
+Run: `xcodebuild build -project "Claude Usage.xcodeproj" -scheme "Claude Usage" -destination "platform=macOS" 2>&1 | tail -30`
+Expected: BUILD SUCCEEDED
+
+- [ ] **Step 2: Run all tests**
+
+Run: `xcodebuild test -project "Claude Usage.xcodeproj" -scheme "Claude Usage" -destination "platform=macOS" 2>&1 | tail -30`
+Expected: All tests pass
+
+- [ ] **Step 3: Fix any build errors or test failures**
+
+If there are Xcode project file issues (new files not added to target), add them via:
+- Open the `.xcodeproj/project.pbxproj` and add file references, OR
+- Open in Xcode and add files to the appropriate target
+
+- [ ] **Step 4: Final commit**
+
+```bash
+git add -A
+git commit -m "fix: resolve any build issues from multi-provider integration"
+```
+
+---
+
+## Summary
+
+| Phase | Tasks | What it delivers |
+|---|---|---|
+| **Phase 1: Models** | Tasks 1-4 | `ProfileProviderType`, `OpenAIUsage`, `CodexUsage`, extended `Profile` |
+| **Phase 2: Providers** | Tasks 5-9 | `UsageProvider` protocol, all 4 provider implementations |
+| **Phase 3: Infrastructure** | Tasks 10-13 | Smart status bar, variable refresh, storage migration, profile factory |
+| **Phase 4: UI** | Tasks 14-16 | Credential views, provider picker, popover sections |
+| **Phase 5: Integration** | Tasks 17-21 | Rebrand, wiring, history, notifications, build verification |

--- a/docs/superpowers/specs/2026-04-03-ai-usage-tracker-design.md
+++ b/docs/superpowers/specs/2026-04-03-ai-usage-tracker-design.md
@@ -1,0 +1,288 @@
+# AI Usage Tracker — Design Spec
+
+> Forked from [hamed-elfayome/Claude-Usage-Tracker](https://github.com/hamed-elfayome/Claude-Usage-Tracker). Rebranded and extended to track usage across Claude, OpenAI API, and Codex.
+
+## Overview
+
+A native macOS menu bar app that tracks AI usage across multiple providers and accounts. The status bar acts as a quiet alert system — only surfacing services approaching their limits. The dropdown popover shows the full dashboard with per-account, per-model breakdowns.
+
+## Goals
+
+1. Track Claude Max subscription usage per account with Opus-first model breakdown
+2. Track Claude API and OpenAI API billing/spend separately
+3. Track Codex CLI usage via probe requests and rate-limit headers
+4. Smart status bar that only shows what needs attention
+5. Rebrand to provider-neutral "AI Usage Tracker"
+
+## Service Types
+
+The app tracks 4 independent service types. Each instance is a "service" with its own credentials, display name, and usage data.
+
+### Claude Max
+
+- **Auth:** Session key, CLI OAuth (`~/.claude/` credentials), or browser sign-in (WKWebView)
+- **Data source:** `https://claude.ai/api/organizations/{orgId}/usage`
+- **Metrics:** Session %, weekly %, per-model breakdown (Opus, Sonnet)
+- **Display:** Opus % is the primary metric shown in status bar and dropdown. Sonnet shown as secondary bar in dropdown. Session/weekly shown as fine print.
+- **Multiple accounts supported:** Each org (Private, Creed Media, Creed Media Team, etc.) is a separate service instance.
+
+### Claude API
+
+- **Auth:** Console session key
+- **Data source:** `https://console.anthropic.com/api/organizations/{orgId}/current_spend`, `/prepaid/credits`, `/usage_cost`
+- **Metrics:** Monthly spend ($), credits remaining, per-model cost breakdown, daily breakdown
+- **Display:** Dollar amount in dropdown. Appears in status bar when spend exceeds configurable % of budget.
+
+### OpenAI API
+
+- **Auth:** Admin API key (stored in Keychain)
+- **Data source:**
+  - `GET /v1/organization/costs` — daily spend buckets (summed for monthly total)
+  - `GET /v1/organization/usage/completions` — token counts per model
+- **Metrics:** Monthly spend ($), daily spend, per-model token usage
+- **Display:** Dollar amount in dropdown. Same budget-% threshold logic as Claude API.
+
+### Codex
+
+- **Auth:** Reads `~/.codex/auth.json` for credentials, or manual API key entry
+- **Data source:** Lightweight probe request (`POST /v1/chat/completions` with `max_tokens: 1` to minimize cost) to OpenAI API; usage extracted from response headers:
+  - `x-ratelimit-limit-requests` / `x-ratelimit-remaining-requests`
+  - `x-ratelimit-limit-tokens` / `x-ratelimit-remaining-tokens`
+  - `x-ratelimit-reset-requests` / `x-ratelimit-reset-tokens`
+- **Metrics:** Request % remaining, token % remaining
+- **Display:** Request % as primary metric (like Opus-first for Claude). Token % as secondary.
+- **Limitation:** OpenAI does not expose Codex subscription quota via API. Probe-based tracking reflects API-level rate limits, not exact ChatGPT subscription quota. This is the best available approach until OpenAI ships a dedicated endpoint.
+
+## Architecture
+
+### Core Model: Service
+
+Replaces the existing `Profile` model. Each service is an independent tracked account.
+
+```
+struct Service: Codable, Identifiable {
+    let id: UUID
+    var type: ServiceType          // .claudeMax, .claudeAPI, .openaiAPI, .codex
+    var displayName: String        // "Private", "Creed Media", "Codex CLI"
+    var isEnabled: Bool
+    
+    // Credentials (type-specific, stored in Keychain)
+    var credentialRef: String      // Keychain reference
+    
+    // Usage data
+    var lastUsage: ServiceUsage?
+    var lastUpdated: Date?
+    
+    // Display settings
+    var primaryModel: String?      // "opus" for Claude Max, nil for others
+    var notificationThresholds: [Double]  // [0.75, 0.90, 0.95]
+    var refreshInterval: TimeInterval?    // Override global, nil = use default
+}
+```
+
+### Protocol: UsageProvider
+
+All 4 service types implement this. The refresh coordinator is provider-agnostic.
+
+```
+protocol UsageProvider {
+    var serviceType: ServiceType { get }
+    var displayName: String { get }
+    func fetchUsage() async throws -> ServiceUsage
+    func validateCredentials() async throws -> Bool
+}
+```
+
+Implementations:
+- `ClaudeMaxProvider` — wraps existing `ClaudeAPIService` logic
+- `ClaudeAPIProvider` — wraps existing Console API logic
+- `OpenAIAPIProvider` — new, calls OpenAI Usage/Costs endpoints
+- `CodexProvider` — new, probe request + header parsing
+
+### Unified Usage Model
+
+```
+struct ServiceUsage: Codable {
+    // Percentage-based metrics (Claude Max, Codex)
+    var primaryPercentage: Double?      // Opus % or request %
+    var secondaryPercentage: Double?    // Sonnet % or token %
+    var overallPercentage: Double?      // Combined/session
+    
+    // Dollar-based metrics (API billing)
+    var currentSpend: Double?
+    var spendLimit: Double?             // Budget or credits
+    var dailySpend: Double?
+    
+    // Time
+    var resetTime: Date?
+    var periodLabel: String?            // "5h window", "Apr 30", etc.
+    
+    // Model breakdown (optional detail)
+    var modelBreakdown: [ModelUsage]?   // e.g. [{model: "opus", percentage: 0.92}, {model: "sonnet", percentage: 0.35}]
+    
+    // Raw data for history
+    var rawData: [String: Double]?
+}
+```
+
+### Refresh Cycle
+
+- `UsageRefreshCoordinator` holds an array of `UsageProvider` instances
+- All services polled in parallel every 30s (configurable per-service)
+- Each service refreshes independently — if one fails, others continue
+- After each refresh, status bar thresholds re-evaluated
+- Wake-from-sleep triggers immediate refresh (preserved from original)
+- Retry logic: 3 attempts with exponential backoff (preserved from original)
+
+## UI Design
+
+### Smart Status Bar
+
+The status bar adapts based on service states:
+
+**State 1 — All clear (nothing above threshold):**
+```
+◉ AI
+```
+Calm green icon. Everything is fine.
+
+**State 2 — Warning (services between 60-89%):**
+```
+Private opus 78%  |  Team opus 91%
+```
+Only services above threshold appear. Yellow for warning range.
+
+**State 3 — Critical (services above 90%):**
+```
+Team opus 98%  |  Codex 72%
+```
+Red for critical. Most urgent items shown first.
+
+**Threshold logic:**
+- Below 60% → hidden from status bar
+- 60-89% → yellow
+- 90%+ → red
+- Nothing above 60% → calm "◉ AI" icon
+- API billing: uses % of budget (configurable spend limit) instead of usage %
+- Thresholds configurable in settings
+- Max items in status bar configurable to prevent overcrowding (default: 4)
+
+### Dropdown Popover
+
+Always shows all services, organized in 3 sections:
+
+**Claude Max section:**
+- Each account listed by display name
+- Opus bar: prominent, colored by threshold (green/yellow/red)
+- Sonnet bar: secondary, smaller, dimmed
+- Fine print: Session % · Weekly %
+- Reset time per account
+
+**API Billing section:**
+- Claude API: monthly spend, credits remaining, reset date
+- OpenAI API: monthly spend, daily spend, reset date
+
+**Codex section:**
+- Requests bar: primary, colored by threshold
+- Tokens bar: secondary, dimmed
+- Rolling window indicator
+
+**Footer:** Settings, History, Quit
+
+### Settings
+
+**Add Service flow:**
+1. Pick service type (Claude Max / Claude API / OpenAI API / Codex)
+2. Enter credentials (type-specific auth UI)
+3. Name it (auto-suggested from org name when possible)
+4. Validate connection
+5. Save
+
+**Per-service settings:**
+- Custom display name
+- Primary model selection (Claude Max only, defaults to Opus)
+- Show/hide in dropdown
+- Individual refresh interval override
+- Notification thresholds
+
+**Global settings:**
+- Status bar appearance threshold (default 60%)
+- Color mode (multi-color / monochrome / single color)
+- Icon style for "all clear" state
+- Max status bar items
+- Launch at login
+- Global keyboard shortcut
+- Language (9 languages preserved)
+
+### Preserved Features
+
+- Usage history charts (extended to all service types)
+- Notifications at configurable thresholds
+- Terminal statusline integration
+- Network debug view
+- Sparkle auto-updates
+- Keychain credential storage
+- Wake-from-sleep refresh
+- Headless mode for Remote Desktop
+
+### Removed/Replaced
+
+- Multi-profile system → replaced by flat service list
+- Profile switching → not needed, all services always active
+- Auto-switch profile → replaced by smart status bar
+- Profile display mode (single/multi) → always show all enabled services
+
+## Migration
+
+Existing Claude Usage Tracker users who update:
+- Each existing profile auto-converts to a Claude Max service
+- Credentials transferred from profile Keychain entries to service Keychain entries
+- Display names preserved (profile name → service display name)
+- Settings mapped: icon config → service display settings
+- API billing profiles → separate Claude API service instances
+- One-time migration on first launch of new version
+
+## File Changes Summary
+
+### New Files
+
+| File | Purpose |
+|---|---|
+| `Service.swift` | Service model replacing Profile |
+| `ServiceUsage.swift` | Unified usage data model |
+| `ServiceType.swift` | Enum for 4 service types |
+| `UsageProviderProtocol.swift` | Protocol all providers implement |
+| `OpenAIAPIProvider.swift` | OpenAI API usage fetching |
+| `CodexProvider.swift` | Codex probe + header parsing |
+| `ClaudeMaxProvider.swift` | Wraps existing Claude API logic |
+| `ClaudeAPIBillingProvider.swift` | Wraps existing Console API logic |
+| `ServiceManager.swift` | Manages service list (replaces ProfileManager) |
+| `SmartStatusBarRenderer.swift` | Threshold-based status bar logic |
+| `AddServiceView.swift` | Settings UI for adding services |
+| `ServiceSettingsView.swift` | Per-service settings |
+| `OpenAICredentialView.swift` | OpenAI API key entry UI |
+| `CodexCredentialView.swift` | Codex auth UI |
+| `MigrationService.swift` | Profile → Service migration |
+
+### Modified Files
+
+| File | Changes |
+|---|---|
+| `ClaudeUsageTrackerApp.swift` | Rename to AIUsageTrackerApp, init ServiceManager |
+| `MenuBarManager.swift` | Use ServiceManager + SmartStatusBarRenderer |
+| `MenuBarIconRenderer.swift` | Support threshold-based visibility |
+| `PopoverContentView.swift` | 3-section layout (Claude Max / API / Codex) |
+| `UsageRefreshCoordinator.swift` | Poll array of UsageProviders |
+| `DataStore.swift` | Save/load per-service usage |
+| `SettingsView.swift` | Service management UI |
+| `NotificationManager.swift` | Per-service threshold notifications |
+| `UsageHistoryService.swift` | History for all service types |
+
+### Unchanged
+
+- `APIServiceProtocol.swift` (still used internally by Claude providers)
+- `StorageProvider.swift`
+- Core refresh/notification infrastructure
+- Localization framework
+- Sparkle update system
+- Terminal statusline (extended, not replaced)

--- a/docs/superpowers/specs/2026-04-03-ai-usage-tracker-design.md
+++ b/docs/superpowers/specs/2026-04-03-ai-usage-tracker-design.md
@@ -1,6 +1,8 @@
-# AI Usage Tracker — Design Spec
+# AI Usage Tracker — Design Spec (v2)
 
 > Forked from [hamed-elfayome/Claude-Usage-Tracker](https://github.com/hamed-elfayome/Claude-Usage-Tracker). Rebranded and extended to track usage across Claude, OpenAI API, and Codex.
+>
+> **v2 note:** Revised after Codex code review that identified 10 issues with v1's architecture, data models, and migration plan. Key change: evolve Profile rather than replace it.
 
 ## Overview
 
@@ -10,135 +12,232 @@ A native macOS menu bar app that tracks AI usage across multiple providers and a
 
 1. Track Claude Max subscription usage per account with Opus-first model breakdown
 2. Track Claude API and OpenAI API billing/spend separately
-3. Track Codex CLI usage via probe requests and rate-limit headers
+3. Track Codex CLI usage via API key probe requests and rate-limit headers
 4. Smart status bar that only shows what needs attention
 5. Rebrand to provider-neutral "AI Usage Tracker"
 
-## Service Types
+## Provider Types
 
-The app tracks 4 independent service types. Each instance is a "service" with its own credentials, display name, and usage data.
+The app tracks 4 provider types. Each is backed by an extended Profile.
 
 ### Claude Max
 
-- **Auth:** Session key, CLI OAuth (`~/.claude/` credentials), or browser sign-in (WKWebView)
+- **Auth:** Session key, CLI OAuth (`~/.claude/` credentials), or browser sign-in (WKWebView) — all 3 methods preserved as-is
 - **Data source:** `https://claude.ai/api/organizations/{orgId}/usage`
 - **Metrics:** Session %, weekly %, per-model breakdown (Opus, Sonnet)
 - **Display:** Opus % is the primary metric shown in status bar and dropdown. Sonnet shown as secondary bar in dropdown. Session/weekly shown as fine print.
-- **Multiple accounts supported:** Each org (Private, Creed Media, Creed Media Team, etc.) is a separate service instance.
+- **Multiple accounts supported:** Each org (Private, Creed Media, Creed Media Team) is a separate Profile.
+- **Refresh interval:** 30s (preserved from original)
 
 ### Claude API
 
-- **Auth:** Console session key
+- **Auth:** Console session key — preserved as-is
 - **Data source:** `https://console.anthropic.com/api/organizations/{orgId}/current_spend`, `/prepaid/credits`, `/usage_cost`
-- **Metrics:** Monthly spend ($), credits remaining, per-model cost breakdown, daily breakdown
-- **Display:** Dollar amount in dropdown. Appears in status bar when spend exceeds configurable % of budget.
+- **Metrics:** Monthly spend (cents, with currency), credits remaining, per-model cost breakdown, daily breakdown, per-key source breakdown
+- **Display:** Dollar amount in dropdown. Appears in status bar when spend exceeds configurable % of a user-set budget (budget lives in Profile settings, NOT fetched from API).
+- **Refresh interval:** 5 minutes (cost data doesn't change fast)
 
 ### OpenAI API
 
-- **Auth:** Admin API key (stored in Keychain)
+- **Auth:** OpenAI Admin API key (NOT a regular project key — only admin keys can access org-level usage/cost endpoints). Stored in Profile credentials alongside existing Claude credentials.
 - **Data source:**
-  - `GET /v1/organization/costs` — daily spend buckets (summed for monthly total)
-  - `GET /v1/organization/usage/completions` — token counts per model
-- **Metrics:** Monthly spend ($), daily spend, per-model token usage
-- **Display:** Dollar amount in dropdown. Same budget-% threshold logic as Claude API.
+  - `GET /v1/organization/costs?bucket_width=1d&start_time=...&end_time=...` — daily spend buckets. Must sum buckets client-side for monthly total. Groups by `project_id` and `line_item`, NOT by model. Paginated (follow `next_page` cursor).
+  - `GET /v1/organization/usage/completions?bucket_width=1d&start_time=...&end_time=...&group_by[]=model` — token counts per model. Must pass `group_by[]=model` explicitly or model field can be null. Paginated.
+- **Metrics:** Monthly spend (cents, with currency), daily spend, per-model token usage
+- **Display:** Dollar amount in dropdown. Same user-set budget threshold logic as Claude API.
+- **Refresh interval:** 5 minutes (cost data doesn't change fast, endpoints are paginated)
 
 ### Codex
 
-- **Auth:** Reads `~/.codex/auth.json` for credentials, or manual API key entry
-- **Data source:** Lightweight probe request (`POST /v1/chat/completions` with `max_tokens: 1` to minimize cost) to OpenAI API; usage extracted from response headers:
+- **Auth:** Requires a separate OpenAI API key (NOT the ChatGPT session tokens from `~/.codex/auth.json`). ChatGPT sign-in and API-key sign-in are completely separate auth paths in OpenAI's system. ChatGPT access tokens cannot be used to call `/v1/chat/completions`.
+- **Data source:** Lightweight probe request (`POST /v1/chat/completions` with `max_tokens: 1`, cheapest model) using the user's OpenAI API key. Usage extracted from response headers:
   - `x-ratelimit-limit-requests` / `x-ratelimit-remaining-requests`
   - `x-ratelimit-limit-tokens` / `x-ratelimit-remaining-tokens`
   - `x-ratelimit-reset-requests` / `x-ratelimit-reset-tokens`
 - **Metrics:** Request % remaining, token % remaining
-- **Display:** Request % as primary metric (like Opus-first for Claude). Token % as secondary.
-- **Limitation:** OpenAI does not expose Codex subscription quota via API. Probe-based tracking reflects API-level rate limits, not exact ChatGPT subscription quota. This is the best available approach until OpenAI ships a dedicated endpoint.
+- **Display:** Request % as primary metric. Token % as secondary.
+- **Limitation:** This tracks API key rate limits, NOT ChatGPT subscription Codex quota. OpenAI does not expose Codex subscription quota via any public API. The UI must clearly label this as "OpenAI API rate limits" to avoid confusion. If/when OpenAI ships a Codex quota endpoint, this can be updated.
+- **Refresh interval:** 60s (each probe consumes 1 request + minimal tokens from the monitored budget — balance visibility vs overhead)
+- **Cost consideration:** Each probe costs ~1 token of input/output. At 60s intervals that's ~1440 probes/day. Negligible cost but it does consume rate limit quota.
 
 ## Architecture
 
-### Core Model: Service
+### Strategy: Evolve Profile, Don't Replace It
 
-Replaces the existing `Profile` model. Each service is an independent tracked account.
+Codex review finding #1 was clear: Profile is not just a data model. It's the account boundary, runtime switch point, usage container, notification container, refresh config, and UI config. `ClaudeAPIService`, `ProfileManager`, `MenuBarManager`, and `UsageRefreshCoordinator` all assume active-profile semantics. Replacing it with a flat service list would be a full app-state rewrite.
 
-```
-struct Service: Codable, Identifiable {
+**Instead:** Extend Profile with a `providerType` field and optional OpenAI credential/usage containers. This preserves ALL existing behavior while adding new providers.
+
+### Extended Profile Model
+
+```swift
+// New enum
+enum ProfileProviderType: String, Codable {
+    case claudeMax      // Existing behavior
+    case claudeAPI      // Existing behavior (API Console)
+    case openaiAPI      // New
+    case codex          // New
+}
+
+// Profile.swift — additions only (all existing fields preserved)
+struct Profile: Codable, Identifiable, Equatable {
+    // === ALL EXISTING FIELDS PRESERVED AS-IS ===
     let id: UUID
-    var type: ServiceType          // .claudeMax, .claudeAPI, .openaiAPI, .codex
-    var displayName: String        // "Private", "Creed Media", "Codex CLI"
-    var isEnabled: Bool
-    
-    // Credentials (type-specific, stored in Keychain)
-    var credentialRef: String      // Keychain reference
-    
-    // Usage data
-    var lastUsage: ServiceUsage?
-    var lastUpdated: Date?
-    
-    // Display settings
-    var primaryModel: String?      // "opus" for Claude Max, nil for others
-    var notificationThresholds: [Double]  // [0.75, 0.90, 0.95]
-    var refreshInterval: TimeInterval?    // Override global, nil = use default
+    var name: String
+
+    // Existing Claude credentials (unchanged)
+    var claudeSessionKey: String?
+    var organizationId: String?
+    var apiSessionKey: String?
+    var apiOrganizationId: String?
+    var apiSessionKeyExpiry: Date?
+    var cliCredentialsJSON: String?
+
+    // Existing CLI metadata (unchanged)
+    var hasCliAccount: Bool
+    var cliAccountSyncedAt: Date?
+
+    // Existing usage data (unchanged)
+    var claudeUsage: ClaudeUsage?
+    var apiUsage: APIUsage?
+
+    // Existing settings (ALL unchanged)
+    var iconConfig: MenuBarIconConfiguration
+    var refreshInterval: TimeInterval
+    var autoStartSessionEnabled: Bool
+    var checkOverageLimitEnabled: Bool
+    var notificationSettings: NotificationSettings  // Full struct preserved
+    var isSelectedForDisplay: Bool
+    var createdAt: Date
+    var lastUsedAt: Date
+
+    // === NEW FIELDS ===
+    var providerType: ProfileProviderType   // Defaults to .claudeMax for migration
+    var primaryModel: String?               // "opus", "sonnet", nil — for Opus-first display
+
+    // OpenAI credentials (only used when providerType is .openaiAPI or .codex)
+    var openaiAdminKey: String?             // Admin API key for org-level endpoints
+    var openaiApiKey: String?               // Regular API key for probe requests
+    var openaiOrganizationId: String?
+
+    // OpenAI usage data
+    var openaiUsage: OpenAIUsage?           // New strongly-typed model
+    var codexUsage: CodexUsage?             // New strongly-typed model
+
+    // Budget settings (user-configured, not fetched)
+    var spendBudgetCents: Int?              // Monthly budget for API billing threshold alerts
+    var spendBudgetCurrency: String?
 }
 ```
 
-### Protocol: UsageProvider
+**Migration safety:** New fields use optionals with `decodeIfPresent` so existing `profiles_v3` UserDefaults data decodes without errors. `providerType` defaults to `.claudeMax` when absent.
 
-All 4 service types implement this. The refresh coordinator is provider-agnostic.
+### New Strongly-Typed Usage Models
 
+**Codex review findings #5 was right:** a generic `ServiceUsage` loses the rich typing that already exists. Keep `ClaudeUsage` and `APIUsage` as-is. Add new models alongside:
+
+```swift
+/// OpenAI API billing data — mirrors APIUsage structure but for OpenAI
+struct OpenAIUsage: Codable, Equatable {
+    let currentSpendCents: Int              // Summed from daily cost buckets
+    let currency: String                    // "usd"
+    let resetsAt: Date                      // Billing cycle end
+    let dailyCostCents: [String: Double]    // "2026-04-03" -> cents
+    let tokensByModel: [String: OpenAIModelTokens]?  // Per-model breakdown
+    let lastUpdated: Date
+
+    var usedAmount: Double { Double(currentSpendCents) / 100.0 }
+
+    struct OpenAIModelTokens: Codable, Equatable {
+        let inputTokens: Int
+        let outputTokens: Int
+        let cachedTokens: Int
+    }
+}
+
+/// Codex rate-limit data from probe response headers
+struct CodexUsage: Codable, Equatable {
+    let requestLimit: Int                   // x-ratelimit-limit-requests
+    let requestsRemaining: Int              // x-ratelimit-remaining-requests
+    let tokenLimit: Int                     // x-ratelimit-limit-tokens
+    let tokensRemaining: Int                // x-ratelimit-remaining-tokens
+    let requestResetTime: Date              // x-ratelimit-reset-requests (parsed)
+    let tokenResetTime: Date                // x-ratelimit-reset-tokens (parsed)
+    let lastUpdated: Date
+
+    var requestPercentageUsed: Double {
+        guard requestLimit > 0 else { return 0 }
+        return Double(requestLimit - requestsRemaining) / Double(requestLimit) * 100.0
+    }
+
+    var tokenPercentageUsed: Double {
+        guard tokenLimit > 0 else { return 0 }
+        return Double(tokenLimit - tokensRemaining) / Double(tokenLimit) * 100.0
+    }
+}
 ```
+
+### Provider Protocol
+
+```swift
 protocol UsageProvider {
-    var serviceType: ServiceType { get }
+    var providerType: ProfileProviderType { get }
+    var profileId: UUID { get }             // Stable identity for persistence/history/notifications
     var displayName: String { get }
-    func fetchUsage() async throws -> ServiceUsage
-    func validateCredentials() async throws -> Bool
+
+    /// Fetch fresh usage data. Returns updated Profile fields (caller merges into Profile).
+    func fetchUsage(for profile: Profile) async throws -> ProfileUsageUpdate
+
+    /// Validate that credentials work before saving.
+    func validateCredentials(for profile: Profile) async throws -> Bool
+}
+
+/// Type-safe update container — each provider sets only its relevant fields
+struct ProfileUsageUpdate {
+    var claudeUsage: ClaudeUsage?
+    var apiUsage: APIUsage?
+    var openaiUsage: OpenAIUsage?
+    var codexUsage: CodexUsage?
 }
 ```
 
-Implementations:
-- `ClaudeMaxProvider` — wraps existing `ClaudeAPIService` logic
-- `ClaudeAPIProvider` — wraps existing Console API logic
-- `OpenAIAPIProvider` — new, calls OpenAI Usage/Costs endpoints
-- `CodexProvider` — new, probe request + header parsing
-
-### Unified Usage Model
-
-```
-struct ServiceUsage: Codable {
-    // Percentage-based metrics (Claude Max, Codex)
-    var primaryPercentage: Double?      // Opus % or request %
-    var secondaryPercentage: Double?    // Sonnet % or token %
-    var overallPercentage: Double?      // Combined/session
-    
-    // Dollar-based metrics (API billing)
-    var currentSpend: Double?
-    var spendLimit: Double?             // Budget or credits
-    var dailySpend: Double?
-    
-    // Time
-    var resetTime: Date?
-    var periodLabel: String?            // "5h window", "Apr 30", etc.
-    
-    // Model breakdown (optional detail)
-    var modelBreakdown: [ModelUsage]?   // e.g. [{model: "opus", percentage: 0.92}, {model: "sonnet", percentage: 0.35}]
-    
-    // Raw data for history
-    var rawData: [String: Double]?
-}
-```
+**Implementations:**
+- `ClaudeMaxProvider` — wraps existing `ClaudeAPIService` logic unchanged
+- `ClaudeAPIBillingProvider` — wraps existing Console API logic unchanged
+- `OpenAIAPIProvider` — new, calls OpenAI org Usage/Costs endpoints with Admin key, handles pagination and `group_by`
+- `CodexProvider` — new, probe request + header parsing using regular API key
 
 ### Refresh Cycle
 
-- `UsageRefreshCoordinator` holds an array of `UsageProvider` instances
-- All services polled in parallel every 30s (configurable per-service)
-- Each service refreshes independently — if one fails, others continue
+**Codex finding #9:** 30s for everything is wasteful. Variable rates per provider type:
+
+| Provider | Default Interval | Reason |
+|----------|-----------------|--------|
+| Claude Max | 30s | Real-time session tracking (preserved from original) |
+| Claude API | 5 min | Cost data updates slowly |
+| OpenAI API | 5 min | Cost data updates slowly, endpoints are paginated |
+| Codex | 60s | Each probe costs 1 request from monitored budget |
+
+- `UsageRefreshCoordinator` tracks per-profile timers (not one global timer)
+- Each profile refreshes independently — if one fails, others continue
 - After each refresh, status bar thresholds re-evaluated
-- Wake-from-sleep triggers immediate refresh (preserved from original)
-- Retry logic: 3 attempts with exponential backoff (preserved from original)
+- Wake-from-sleep triggers immediate refresh for all profiles (preserved)
+- Retry logic: 3 attempts with exponential backoff (preserved)
+- Per-profile override still available in settings
+
+### Credential Storage
+
+**Codex finding #2:** Current credentials are stored in UserDefaults as part of the `profiles_v3` JSON blob via `ProfileStore.saveProfiles()`, NOT in Keychain. Session keys, API keys, and CLI OAuth tokens are all serialized directly into the encoded Profile.
+
+**For OpenAI credentials:** Follow the same pattern for now (add `openaiAdminKey` and `openaiApiKey` as Profile fields, serialized into `profiles_v3`). This is consistent with existing behavior.
+
+**Future consideration:** Moving secrets to Keychain is a good idea but is a separate initiative that should apply to ALL credentials (Claude + OpenAI) at once. Not in scope for this feature.
 
 ## UI Design
 
 ### Smart Status Bar
 
-The status bar adapts based on service states:
+The status bar adapts based on profile states:
 
 **State 1 — All clear (nothing above threshold):**
 ```
@@ -146,13 +245,13 @@ The status bar adapts based on service states:
 ```
 Calm green icon. Everything is fine.
 
-**State 2 — Warning (services between 60-89%):**
+**State 2 — Warning (profiles between 60-89%):**
 ```
 Private opus 78%  |  Team opus 91%
 ```
-Only services above threshold appear. Yellow for warning range.
+Only profiles above threshold appear. Yellow for warning range.
 
-**State 3 — Critical (services above 90%):**
+**State 3 — Critical (profiles above 90%):**
 ```
 Team opus 98%  |  Codex 72%
 ```
@@ -163,84 +262,124 @@ Red for critical. Most urgent items shown first.
 - 60-89% → yellow
 - 90%+ → red
 - Nothing above 60% → calm "◉ AI" icon
-- API billing: uses % of budget (configurable spend limit) instead of usage %
+- API billing profiles: uses % of user-configured spend budget. If no budget set, never appears in status bar (only in dropdown).
 - Thresholds configurable in settings
-- Max items in status bar configurable to prevent overcrowding (default: 4)
+- Max items in status bar: configurable, default 4
+- Priority order: highest percentage first, then by provider type (Claude Max > Codex > APIs)
+
+**Which percentage drives the status bar for Claude Max profiles:**
+- Uses `primaryModel` setting to determine which model % to show
+- Default: Opus % (since user primarily uses Opus)
+- If Opus is at 92% but overall is 70%, status bar shows 92%
 
 ### Dropdown Popover
 
-Always shows all services, organized in 3 sections:
+Always shows all enabled profiles, organized in 3 sections:
 
 **Claude Max section:**
-- Each account listed by display name
+- Each account listed by profile display name
 - Opus bar: prominent, colored by threshold (green/yellow/red)
 - Sonnet bar: secondary, smaller, dimmed
 - Fine print: Session % · Weekly %
 - Reset time per account
 
 **API Billing section:**
-- Claude API: monthly spend, credits remaining, reset date
+- Claude API: monthly spend, credits remaining, reset date, per-key source breakdown (preserved)
 - OpenAI API: monthly spend, daily spend, reset date
 
 **Codex section:**
 - Requests bar: primary, colored by threshold
 - Tokens bar: secondary, dimmed
-- Rolling window indicator
+- Reset time indicators
+- Label: "OpenAI API Rate Limits" (NOT "Codex quota" — to be honest about what we're tracking)
 
 **Footer:** Settings, History, Quit
 
 ### Settings
 
-**Add Service flow:**
-1. Pick service type (Claude Max / Claude API / OpenAI API / Codex)
-2. Enter credentials (type-specific auth UI)
+**Add Profile flow (extended):**
+1. Pick provider type (Claude Max / Claude API / OpenAI API / Codex)
+2. Enter credentials (provider-specific auth UI):
+   - Claude Max: existing 3 auth methods (session key, browser, CLI)
+   - Claude API: existing Console session key flow
+   - OpenAI API: Admin API key input with format validation (`sk-admin-...`)
+   - Codex: Regular OpenAI API key input (`sk-...`)
 3. Name it (auto-suggested from org name when possible)
-4. Validate connection
+4. Validate connection (test the credentials against real endpoints)
 5. Save
 
-**Per-service settings:**
+**Per-profile settings (ALL existing settings preserved + new ones):**
 - Custom display name
-- Primary model selection (Claude Max only, defaults to Opus)
-- Show/hide in dropdown
-- Individual refresh interval override
-- Notification thresholds
+- Primary model selection (Claude Max only, defaults to Opus) — NEW
+- Spend budget for alerts (API profiles only) — NEW
+- Show/hide in dropdown (maps to existing `isSelectedForDisplay`)
+- Refresh interval override (maps to existing `refreshInterval`)
+- Notification settings: full `NotificationSettings` struct preserved (enabled flags, per-threshold toggles, sound config, custom thresholds)
+- Auto-start session (Claude Max only, preserved)
+- Check overage limit (Claude Max only, preserved)
 
-**Global settings:**
-- Status bar appearance threshold (default 60%)
+**Global settings (unchanged):**
 - Color mode (multi-color / monochrome / single color)
-- Icon style for "all clear" state
-- Max status bar items
+- Status bar appearance threshold (default 60%) — NEW
+- Max status bar items (default 4) — NEW
 - Launch at login
 - Global keyboard shortcut
 - Language (9 languages preserved)
 
-### Preserved Features
+### Preserved Features (ALL of these work exactly as before)
 
-- Usage history charts (extended to all service types)
-- Notifications at configurable thresholds
+- Usage history charts (extended with new provider-specific history)
+- Notifications with full `NotificationSettings` (enabled, per-threshold, sound, custom)
 - Terminal statusline integration
 - Network debug view
 - Sparkle auto-updates
-- Keychain credential storage
-- Wake-from-sleep refresh
+- Wake-from-sleep refresh with smart debouncing
 - Headless mode for Remote Desktop
-
-### Removed/Replaced
-
-- Multi-profile system → replaced by flat service list
-- Profile switching → not needed, all services always active
-- Auto-switch profile → replaced by smart status bar
-- Profile display mode (single/multi) → always show all enabled services
+- Multi-profile menu bar display
+- CLI account sync metadata (`hasCliAccount`, `cliAccountSyncedAt`)
+- `createdAt` and `lastUsedAt` tracking
+- `autoStartSessionEnabled` and `checkOverageLimitEnabled`
+- Profile icon configuration (`MenuBarIconConfiguration`)
 
 ## Migration
 
-Existing Claude Usage Tracker users who update:
-- Each existing profile auto-converts to a Claude Max service
-- Credentials transferred from profile Keychain entries to service Keychain entries
-- Display names preserved (profile name → service display name)
-- Settings mapped: icon config → service display settings
-- API billing profiles → separate Claude API service instances
-- One-time migration on first launch of new version
+### Existing Users (Profile → Extended Profile)
+
+**Codex finding #2:** Credentials live in `profiles_v3` UserDefaults blob, not Keychain.
+
+Migration is additive — we only add new optional fields to Profile. Existing data decodes unchanged:
+
+1. **On first launch of new version:** `ProfileStore.loadProfiles()` runs as usual
+2. **New fields decode as nil:** `providerType`, `primaryModel`, `openaiAdminKey`, `openaiApiKey`, `openaiUsage`, `codexUsage`, `spendBudgetCents` all decode as `nil` via `decodeIfPresent`
+3. **Default provider type:** If `providerType` is nil, treat as `.claudeMax` (existing behavior)
+4. **Default primary model:** If `primaryModel` is nil, default to `"opus"`
+5. **No credential transfer needed:** Existing credentials stay exactly where they are
+6. **No key schema change:** UserDefaults key remains `profiles_v3`
+7. **Bump storage version:** Change key to `profiles_v4` on first migration to prevent downgrade data loss. Old `profiles_v3` preserved as backup.
+
+**This is the safest possible migration: existing data is structurally preserved, new fields are additive optionals.**
+
+### Usage History
+
+**Codex finding #7:** History is keyed by `profileId` with Claude-specific snapshot types.
+
+- Existing Claude Max history: **unchanged**. Same profileId, same snapshot types.
+- New OpenAI/Codex profiles get new UUIDs → new history keys → no collision.
+- History snapshots extended with new types:
+  - `openaiCostSnapshot` — daily cost recording for OpenAI
+  - `codexRateLimitSnapshot` — periodic rate-limit state capture
+- These are stored alongside existing `sessionSnapshot`, `weeklySnapshot`, `apiCostSnapshot` without affecting them.
+
+### Notifications
+
+**Codex finding #8:** Current notification logic dedupes by `profileName` and uses full `NotificationSettings`.
+
+- `NotificationSettings` struct: **preserved exactly** (enabled, threshold75/90/95, soundName, customThresholds)
+- `NotificationManager` dedup logic: continues using `profile.name` — works because new OpenAI/Codex profiles have distinct names
+- New provider types trigger notifications using the same threshold system:
+  - Claude Max: Opus % or session % (based on `primaryModel` setting)
+  - Claude API / OpenAI API: spend % of budget (requires `spendBudgetCents` to be set)
+  - Codex: request % used
 
 ## File Changes Summary
 
@@ -248,41 +387,63 @@ Existing Claude Usage Tracker users who update:
 
 | File | Purpose |
 |---|---|
-| `Service.swift` | Service model replacing Profile |
-| `ServiceUsage.swift` | Unified usage data model |
-| `ServiceType.swift` | Enum for 4 service types |
-| `UsageProviderProtocol.swift` | Protocol all providers implement |
-| `OpenAIAPIProvider.swift` | OpenAI API usage fetching |
-| `CodexProvider.swift` | Codex probe + header parsing |
-| `ClaudeMaxProvider.swift` | Wraps existing Claude API logic |
-| `ClaudeAPIBillingProvider.swift` | Wraps existing Console API logic |
-| `ServiceManager.swift` | Manages service list (replaces ProfileManager) |
-| `SmartStatusBarRenderer.swift` | Threshold-based status bar logic |
-| `AddServiceView.swift` | Settings UI for adding services |
-| `ServiceSettingsView.swift` | Per-service settings |
-| `OpenAICredentialView.swift` | OpenAI API key entry UI |
-| `CodexCredentialView.swift` | Codex auth UI |
-| `MigrationService.swift` | Profile → Service migration |
+| `ProfileProviderType.swift` | Enum: `.claudeMax`, `.claudeAPI`, `.openaiAPI`, `.codex` |
+| `OpenAIUsage.swift` | Strongly-typed OpenAI billing data model |
+| `CodexUsage.swift` | Strongly-typed rate-limit data model |
+| `OpenAIAPIProvider.swift` | Fetches from OpenAI org Usage/Costs endpoints (Admin key, pagination, group_by) |
+| `CodexProvider.swift` | Probe request + response header parsing |
+| `SmartStatusBarRenderer.swift` | Threshold-based status bar visibility logic |
+| `AddProfileProviderView.swift` | Provider type selection in Add Profile flow |
+| `OpenAICredentialView.swift` | Admin API key + regular API key entry UI |
+| `CodexCredentialView.swift` | OpenAI API key entry for Codex probe |
 
 ### Modified Files
 
 | File | Changes |
 |---|---|
-| `ClaudeUsageTrackerApp.swift` | Rename to AIUsageTrackerApp, init ServiceManager |
-| `MenuBarManager.swift` | Use ServiceManager + SmartStatusBarRenderer |
-| `MenuBarIconRenderer.swift` | Support threshold-based visibility |
-| `PopoverContentView.swift` | 3-section layout (Claude Max / API / Codex) |
-| `UsageRefreshCoordinator.swift` | Poll array of UsageProviders |
-| `DataStore.swift` | Save/load per-service usage |
-| `SettingsView.swift` | Service management UI |
-| `NotificationManager.swift` | Per-service threshold notifications |
-| `UsageHistoryService.swift` | History for all service types |
+| `Profile.swift` | Add `providerType`, `primaryModel`, OpenAI credential/usage fields, `spendBudgetCents` |
+| `ClaudeUsageTrackerApp.swift` | Rename to `AIUsageTrackerApp`, update bundle identifiers |
+| `MenuBarManager.swift` | Smart status bar threshold logic, multi-provider display |
+| `MenuBarIconRenderer.swift` | Render OpenAI/Codex metrics alongside Claude |
+| `PopoverContentView.swift` | 3-section layout (Claude Max / API Billing / Codex) |
+| `UsageRefreshCoordinator.swift` | Per-profile variable refresh intervals based on `providerType` |
+| `DataStore.swift` | Save/load `OpenAIUsage` and `CodexUsage` per profile |
+| `ProfileStore.swift` | Storage version bump `profiles_v3` → `profiles_v4` with backward-compatible decoding |
+| `ProfileManager.swift` | Factory methods for creating OpenAI/Codex profiles |
+| `SettingsView.swift` | Provider-aware profile creation and per-profile settings |
+| `NotificationManager.swift` | Provider-aware threshold calculations |
+| `UsageHistoryService.swift` | New snapshot types for OpenAI cost and Codex rate limits |
 
 ### Unchanged
 
-- `APIServiceProtocol.swift` (still used internally by Claude providers)
-- `StorageProvider.swift`
-- Core refresh/notification infrastructure
-- Localization framework
-- Sparkle update system
-- Terminal statusline (extended, not replaced)
+- `ClaudeAPIService.swift` — still used by ClaudeMax and ClaudeAPI providers internally
+- `ClaudeAPIService+ConsoleAPI.swift` — Console API logic untouched
+- `ClaudeAPIService+Types.swift` — response types untouched
+- `APIServiceProtocol.swift` — still used internally by Claude providers
+- `StorageProvider.swift` — no changes needed
+- `ClaudeUsage.swift` — model preserved exactly
+- `APIUsage.swift` — model preserved exactly
+- `NotificationSettings.swift` — struct preserved exactly
+- `MenuBarIconConfiguration.swift` — preserved
+- `ProfileCredentials.swift` — preserved
+- Localization framework — preserved (add new strings for OpenAI/Codex UI)
+- Sparkle update system — preserved
+- Terminal statusline — preserved (extended with new provider info)
+- Keychain infrastructure — preserved
+
+## Codex Review Status
+
+v2 of this spec addresses all 10 findings from the Codex review:
+
+| # | Finding | Resolution |
+|---|---------|------------|
+| 1 | Service is wrong top-level replacement | Evolve Profile instead, preserve all runtime semantics |
+| 2 | Migration credentials not in Keychain | Corrected: credentials are in UserDefaults `profiles_v3` blob. Migration is additive optionals only. |
+| 3 | Codex probe doesn't track subscription quota | Corrected: requires separate API key, clearly labeled as "API rate limits" not "Codex quota" |
+| 4 | UsageProvider underspecified | Added `profileId` for stable identity, `ProfileUsageUpdate` for type-safe updates |
+| 5 | ServiceUsage badly typed | Dropped generic model. Keep `ClaudeUsage`/`APIUsage`, add `OpenAIUsage`/`CodexUsage` alongside |
+| 6 | OpenAI endpoints need Admin keys | Specified Admin API key requirement, `group_by` params, pagination handling |
+| 7 | History migration not specified | Detailed: existing history untouched, new profiles get new UUIDs + new snapshot types |
+| 8 | Notification migration underspecified | Full `NotificationSettings` preserved, provider-aware threshold logic added |
+| 9 | Refresh plan naive | Variable intervals: 30s Claude Max, 60s Codex, 5min APIs |
+| 10 | Service drops critical Profile fields | ALL Profile fields preserved. Extension only, no deletions. |


### PR DESCRIPTION
## Summary
- Rebranded from Claude Usage Tracker to AI Usage Tracker with multi-provider support
- Added OpenAI API billing tracking (org-level costs + completions usage via Admin API key)
- Added Codex rate-limit tracking via lightweight probe requests with header parsing
- Smart status bar that only surfaces services approaching limits (configurable threshold)
- Extended Profile model with backward-compatible decoding (existing users migrate seamlessly)
- Unified "Add Service" picker for all 4 provider types: Claude Max, Claude API, OpenAI API, Codex
- Opus-first model display for Claude Max accounts
- Variable refresh intervals per provider type (30s Claude, 60s Codex, 5min APIs)
- Storage migration from profiles_v3 to profiles_v4 with automatic fallback

## New files (19)
- Data models: `ProfileProviderType`, `OpenAIUsage`, `CodexUsage`
- Providers: `UsageProvider` protocol, `ClaudeMaxProvider`, `ClaudeAPIBillingProvider`, `OpenAIAPIProvider`, `CodexProvider`, `UsageProviderFactory`
- UI: `SmartStatusBarRenderer`, `OpenAICredentialView`, `AddProviderView`, `PopoverSections`
- Tests: 6 new test files covering models, providers, and status bar logic

## Test plan
- [x] All 40 unit tests pass
- [x] Build succeeds (Xcode, macOS 14+)
- [x] Existing Claude profiles decode without data loss (backward-compatible)
- [ ] Manual: Add OpenAI API profile with Admin key, verify billing data shows
- [ ] Manual: Add Codex profile with API key, verify rate-limit bars appear
- [ ] Manual: Verify smart status bar hides services below 60% threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)