### PR TITLE
feat(statusline): add per-element color customization

### DIFF
--- a/Claude Usage/Resources/de.lproj/Localizable.strings
+++ b/Claude Usage/Resources/de.lproj/Localizable.strings
@@ -468,6 +468,17 @@
 "claudecode.button_reset" = "Zurücksetzen";
 "claudecode.component_profile" = "Profilname";
 "claudecode.context_info" = "Der Kontext kann ~80-95% statt 100% anzeigen — Claude komprimiert automatisch vor dem Limit, und Ausgabe-Tokens nutzen ebenfalls Kontextplatz.";
+"claudecode.element_colors_title" = "Elementfarben";
+"claudecode.element_color_directory" = "Verzeichnis";
+"claudecode.element_color_branch" = "Branch";
+"claudecode.element_color_model" = "Modell";
+"claudecode.element_color_profile" = "Profil";
+"claudecode.element_color_context" = "Kontext";
+"claudecode.element_color_separator" = "Trennzeichen";
+"claudecode.element_color_usage" = "Nutzungsverlauf";
+"claudecode.element_color_usage_desc" = "10-stufigen Farbverlauf durch eine feste Farbe ersetzen";
+"claudecode.element_color_pace" = "Tempo-Markierung";
+"claudecode.element_color_pace_desc" = "6-Stufen-Tempofarben durch eine feste Farbe ersetzen";
 "error.generic" = "Fehler: %@";
 "personal.button_saving" = "Speichern...";
 "personal.button_setup_wizard" = "Einrichtungsassistent";

--- a/Claude Usage/Resources/en.lproj/Localizable.strings
+++ b/Claude Usage/Resources/en.lproj/Localizable.strings
@@ -710,6 +710,17 @@
 "claudecode.actions_title" = "Actions";
 "claudecode.component_profile" = "Profile name";
 "claudecode.context_info" = "Context may show ~80-95% instead of 100% — Claude auto-compresses before the limit, and output tokens also use context space.";
+"claudecode.element_colors_title" = "Element Colors";
+"claudecode.element_color_directory" = "Directory";
+"claudecode.element_color_branch" = "Branch";
+"claudecode.element_color_model" = "Model";
+"claudecode.element_color_profile" = "Profile";
+"claudecode.element_color_context" = "Context";
+"claudecode.element_color_separator" = "Separator";
+"claudecode.element_color_usage" = "Usage gradient";
+"claudecode.element_color_usage_desc" = "Override 10-level gradient with a fixed color";
+"claudecode.element_color_pace" = "Pace marker";
+"claudecode.element_color_pace_desc" = "Override 6-tier pace colors with a fixed color";
 "error.generic" = "Error: %@";
 "personal.button_saving" = "Saving...";
 "personal.button_setup_wizard" = "Setup Wizard";

--- a/Claude Usage/Resources/es.lproj/Localizable.strings
+++ b/Claude Usage/Resources/es.lproj/Localizable.strings
@@ -449,6 +449,17 @@
 "claudecode.button_reset" = "Restablecer";
 "claudecode.component_profile" = "Nombre del perfil";
 "claudecode.context_info" = "El contexto puede mostrar ~80-95% en vez de 100% — Claude comprime automáticamente antes del límite, y los tokens de salida también usan espacio de contexto.";
+"claudecode.element_colors_title" = "Colores de Elementos";
+"claudecode.element_color_directory" = "Directorio";
+"claudecode.element_color_branch" = "Rama";
+"claudecode.element_color_model" = "Modelo";
+"claudecode.element_color_profile" = "Perfil";
+"claudecode.element_color_context" = "Contexto";
+"claudecode.element_color_separator" = "Separador";
+"claudecode.element_color_usage" = "Degradado de uso";
+"claudecode.element_color_usage_desc" = "Reemplaza el degradado de 10 niveles con un color fijo";
+"claudecode.element_color_pace" = "Marcador de ritmo";
+"claudecode.element_color_pace_desc" = "Reemplaza los 6 niveles de colores de ritmo con un color fijo";
 "error.generic" = "Error: %@";
 "personal.button_saving" = "Guardando...";
 "personal.button_setup_wizard" = "Asistente de Configuración";

--- a/Claude Usage/Resources/fr.lproj/Localizable.strings
+++ b/Claude Usage/Resources/fr.lproj/Localizable.strings
@@ -446,6 +446,17 @@
 "claudecode.button_reset" = "Réinitialiser";
 "claudecode.component_profile" = "Nom du profil";
 "claudecode.context_info" = "Le contexte peut afficher ~80-95% au lieu de 100% — Claude compresse automatiquement avant la limite, et les tokens de sortie utilisent aussi l'espace de contexte.";
+"claudecode.element_colors_title" = "Couleurs des Éléments";
+"claudecode.element_color_directory" = "Répertoire";
+"claudecode.element_color_branch" = "Branche";
+"claudecode.element_color_model" = "Modèle";
+"claudecode.element_color_profile" = "Profil";
+"claudecode.element_color_context" = "Contexte";
+"claudecode.element_color_separator" = "Séparateur";
+"claudecode.element_color_usage" = "Dégradé d'utilisation";
+"claudecode.element_color_usage_desc" = "Remplace le dégradé à 10 niveaux par une couleur fixe";
+"claudecode.element_color_pace" = "Marqueur de rythme";
+"claudecode.element_color_pace_desc" = "Remplace les 6 niveaux de couleurs de rythme par une couleur fixe";
 "error.generic" = "Erreur: %@";
 "personal.button_saving" = "Enregistrement...";
 "personal.button_setup_wizard" = "Assistant de Configuration";

--- a/Claude Usage/Resources/it.lproj/Localizable.strings
+++ b/Claude Usage/Resources/it.lproj/Localizable.strings
@@ -466,6 +466,17 @@
 "claudecode.button_reset" = "Ripristina";
 "claudecode.component_profile" = "Nome profilo";
 "claudecode.context_info" = "Il contesto può mostrare ~80-95% invece di 100% — Claude comprime automaticamente prima del limite e i token di output usano anch'essi spazio di contesto.";
+"claudecode.element_colors_title" = "Colori Elementi";
+"claudecode.element_color_directory" = "Directory";
+"claudecode.element_color_branch" = "Branch";
+"claudecode.element_color_model" = "Modello";
+"claudecode.element_color_profile" = "Profilo";
+"claudecode.element_color_context" = "Contesto";
+"claudecode.element_color_separator" = "Separatore";
+"claudecode.element_color_usage" = "Gradiente utilizzo";
+"claudecode.element_color_usage_desc" = "Sostituisci il gradiente a 10 livelli con un colore fisso";
+"claudecode.element_color_pace" = "Indicatore di ritmo";
+"claudecode.element_color_pace_desc" = "Sostituisci i 6 livelli di colore del ritmo con un colore fisso";
 "error.generic" = "Errore: %@";
 "personal.button_saving" = "Salvataggio...";
 "personal.button_setup_wizard" = "Assistente di Configurazione";

--- a/Claude Usage/Resources/ja.lproj/Localizable.strings
+++ b/Claude Usage/Resources/ja.lproj/Localizable.strings
@@ -482,6 +482,17 @@
 "claudecode.button_reset" = "リセット";
 "claudecode.component_profile" = "プロファイル名";
 "claudecode.context_info" = "コンテキストは100%ではなく約80-95%と表示される場合があります。Claudeは上限に達する前に自動圧縮を行い、出力トークンもコンテキスト領域を使用します。";
+"claudecode.element_colors_title" = "要素の色";
+"claudecode.element_color_directory" = "ディレクトリ";
+"claudecode.element_color_branch" = "ブランチ";
+"claudecode.element_color_model" = "モデル";
+"claudecode.element_color_profile" = "プロファイル";
+"claudecode.element_color_context" = "コンテキスト";
+"claudecode.element_color_separator" = "セパレータ";
+"claudecode.element_color_usage" = "使用量グラデーション";
+"claudecode.element_color_usage_desc" = "10段階のグラデーションを固定色で上書き";
+"claudecode.element_color_pace" = "ペースマーカー";
+"claudecode.element_color_pace_desc" = "6段階のペース色を固定色で上書き";
 "error.generic" = "エラー：%@";
 "personal.button_saving" = "保存中...";
 "personal.button_setup_wizard" = "セットアップウィザード";

--- a/Claude Usage/Resources/ko.lproj/Localizable.strings
+++ b/Claude Usage/Resources/ko.lproj/Localizable.strings
@@ -335,6 +335,17 @@
 "claudecode.button_reset" = "재설정";
 "claudecode.component_profile" = "프로필 이름";
 "claudecode.context_info" = "컨텍스트가 100% 대신 ~80-95%로 표시될 수 있습니다. Claude는 한도에 도달하기 전에 자동으로 압축하며, 출력 토큰도 컨텍스트 공간을 사용합니다.";
+"claudecode.element_colors_title" = "요소 색상";
+"claudecode.element_color_directory" = "디렉토리";
+"claudecode.element_color_branch" = "브랜치";
+"claudecode.element_color_model" = "모델";
+"claudecode.element_color_profile" = "프로필";
+"claudecode.element_color_context" = "컨텍스트";
+"claudecode.element_color_separator" = "구분자";
+"claudecode.element_color_usage" = "사용량 그라데이션";
+"claudecode.element_color_usage_desc" = "10단계 그라데이션을 고정 색상으로 대체";
+"claudecode.element_color_pace" = "페이스 마커";
+"claudecode.element_color_pace_desc" = "6단계 페이스 색상을 고정 색상으로 대체";
 "error.generic" = "오류: %@";
 "personal.button_saving" = "저장 중...";
 "personal.button_setup_wizard" = "설정 마법사";

--- a/Claude Usage/Resources/pt.lproj/Localizable.strings
+++ b/Claude Usage/Resources/pt.lproj/Localizable.strings
@@ -466,6 +466,17 @@
 "claudecode.button_reset" = "Redefinir";
 "claudecode.component_profile" = "Nome do perfil";
 "claudecode.context_info" = "O contexto pode mostrar ~80-95% em vez de 100% — o Claude comprime automaticamente antes do limite, e os tokens de saída também usam espaço de contexto.";
+"claudecode.element_colors_title" = "Cores dos Elementos";
+"claudecode.element_color_directory" = "Diretório";
+"claudecode.element_color_branch" = "Ramo";
+"claudecode.element_color_model" = "Modelo";
+"claudecode.element_color_profile" = "Perfil";
+"claudecode.element_color_context" = "Contexto";
+"claudecode.element_color_separator" = "Separador";
+"claudecode.element_color_usage" = "Gradiente de uso";
+"claudecode.element_color_usage_desc" = "Substitui o gradiente de 10 níveis por uma cor fixa";
+"claudecode.element_color_pace" = "Marcador de ritmo";
+"claudecode.element_color_pace_desc" = "Substitui os 6 níveis de cores de ritmo por uma cor fixa";
 "error.generic" = "Erro: %@";
 "personal.button_saving" = "Salvando...";
 "personal.button_setup_wizard" = "Assistente de Configuração";

--- a/Claude Usage/Resources/zh-ch.lproj/Localizable.strings
+++ b/Claude Usage/Resources/zh-ch.lproj/Localizable.strings
@@ -704,6 +704,17 @@
 "claudecode.actions_title" = "操作";
 "claudecode.component_profile" = "配置文件名称";
 "claudecode.context_info" = "上下文可能显示约80-95%而非100%——Claude会在达到上限前自动压缩，输出令牌也会占用上下文空间。";
+"claudecode.element_colors_title" = "元素颜色";
+"claudecode.element_color_directory" = "目录";
+"claudecode.element_color_branch" = "分支";
+"claudecode.element_color_model" = "模型";
+"claudecode.element_color_profile" = "配置文件";
+"claudecode.element_color_context" = "上下文";
+"claudecode.element_color_separator" = "分隔符";
+"claudecode.element_color_usage" = "用量渐变";
+"claudecode.element_color_usage_desc" = "用固定颜色替换10级渐变";
+"claudecode.element_color_pace" = "节奏标记";
+"claudecode.element_color_pace_desc" = "用固定颜色替换6级节奏颜色";
 "error.generic" = "错误：%@";
 "personal.button_saving" = "保存中...";
 "personal.button_setup_wizard" = "设置向导";

--- a/Claude Usage/Shared/Models/StatuslineColorMode.swift
+++ b/Claude Usage/Shared/Models/StatuslineColorMode.swift
@@ -18,6 +18,9 @@ enum StatuslineColorMode: String, Codable, CaseIterable {
     /// Single user-selected color for all elements
     case singleColor = "singleColor"
 
+    /// Individual custom color for each statusline element
+    case perElement = "perElement"
+
     var displayName: String {
         switch self {
         case .colored:
@@ -26,6 +29,8 @@ enum StatuslineColorMode: String, Codable, CaseIterable {
             return "Greyscale"
         case .singleColor:
             return "Single Color"
+        case .perElement:
+            return "Per Element"
         }
     }
 
@@ -37,6 +42,8 @@ enum StatuslineColorMode: String, Codable, CaseIterable {
             return "Adapts to system theme"
         case .singleColor:
             return "Custom color for all"
+        case .perElement:
+            return "Custom color per item"
         }
     }
 
@@ -48,6 +55,8 @@ enum StatuslineColorMode: String, Codable, CaseIterable {
             return "circle.lefthalf.filled"
         case .singleColor:
             return "eyedropper.halffull"
+        case .perElement:
+            return "paintpalette"
         }
     }
 }

--- a/Claude Usage/Shared/Models/StatuslineElementColors.swift
+++ b/Claude Usage/Shared/Models/StatuslineElementColors.swift
@@ -1,0 +1,45 @@
+//
+//  StatuslineElementColors.swift
+//  Claude Usage
+//
+//  Created by Andrea Mario Lufino on 05/04/26.
+//  Copyright © 2026 Andrea Mario Lufino. All rights reserved.
+//
+
+import Foundation
+
+/// Per-element color configuration for the Claude Code statusline.
+///
+/// Used when `StatuslineColorMode` is `.perElement`. Each field stores a hex color
+/// string for the corresponding statusline element. The defaults match the ANSI
+/// palette used by `.colored` mode, so switching to `.perElement` without any
+/// customization produces identical output.
+///
+/// `usageBaseHex` and `paceBaseHex` are optional: `nil` preserves the dynamic
+/// behaviour (10-level gradient and 6-tier pace colors respectively); a non-nil
+/// value overrides all levels with a single fixed color.
+struct StatuslineElementColors: Codable, Equatable {
+    /// Hex color for the directory element. Default: ANSI blue.
+    var directoryHex: String = "#0000EE"
+
+    /// Hex color for the git branch element. Default: ANSI green.
+    var branchHex: String = "#00BB00"
+
+    /// Hex color for the model element. Default: ANSI yellow.
+    var modelHex: String = "#BBBB00"
+
+    /// Hex color for the profile element. Default: ANSI magenta.
+    var profileHex: String = "#BB00BB"
+
+    /// Hex color for the context element. Default: ANSI cyan.
+    var contextHex: String = "#00BBBB"
+
+    /// Hex color for separators between elements. Default: ANSI gray.
+    var separatorHex: String = "#808080"
+
+    /// Optional override for the usage gradient. `nil` = use the 10-level gradient.
+    var usageBaseHex: String? = nil
+
+    /// Optional override for pace marker colors. `nil` = use the 6-tier standard colors.
+    var paceBaseHex: String? = nil
+}

--- a/Claude Usage/Shared/Services/StatuslineService.swift
+++ b/Claude Usage/Shared/Services/StatuslineService.swift
@@ -134,6 +134,14 @@ if [ -f "$config_file" ]; then
   show_profile=$SHOW_PROFILE
   profile_name="$PROFILE_NAME"
   pace_marker_step_colors=$PACE_MARKER_STEP_COLORS
+  element_color_dir=$ELEMENT_COLOR_DIR
+  element_color_branch=$ELEMENT_COLOR_BRANCH
+  element_color_model=$ELEMENT_COLOR_MODEL
+  element_color_profile=$ELEMENT_COLOR_PROFILE
+  element_color_context=$ELEMENT_COLOR_CONTEXT
+  element_color_separator=$ELEMENT_COLOR_SEPARATOR
+  element_color_usage=$ELEMENT_COLOR_USAGE
+  element_color_pace=$ELEMENT_COLOR_PACE
 else
   show_model=1
   show_dir=1
@@ -153,6 +161,14 @@ else
   show_profile=0
   profile_name=""
   pace_marker_step_colors=1
+  element_color_dir="#0000EE"
+  element_color_branch="#00BB00"
+  element_color_model="#BBBB00"
+  element_color_profile="#BB00BB"
+  element_color_context="#00BBBB"
+  element_color_separator="#808080"
+  element_color_usage=""
+  element_color_pace=""
 fi
 
 input=$(cat)
@@ -224,6 +240,58 @@ elif [ "$color_mode" = "singleColor" ]; then
   PACE_PRESSING=$single_ansi
   PACE_CRITICAL=$single_ansi
   PACE_RUNAWAY=$single_ansi
+elif [ "$color_mode" = "perElement" ]; then
+  # Per-element mode - each element uses its own user-defined color
+  BLUE=$(hex_to_ansi "$element_color_dir")
+  GREEN=$(hex_to_ansi "$element_color_branch")
+  YELLOW=$(hex_to_ansi "$element_color_model")
+  MAGENTA=$(hex_to_ansi "$element_color_profile")
+  CYAN=$(hex_to_ansi "$element_color_context")
+  GRAY=$(hex_to_ansi "$element_color_separator")
+
+  # Usage gradient: override all levels if a base color is set, else use standard gradient
+  if [ -n "$element_color_usage" ]; then
+    usage_override=$(hex_to_ansi "$element_color_usage")
+    LEVEL_1=$usage_override
+    LEVEL_2=$usage_override
+    LEVEL_3=$usage_override
+    LEVEL_4=$usage_override
+    LEVEL_5=$usage_override
+    LEVEL_6=$usage_override
+    LEVEL_7=$usage_override
+    LEVEL_8=$usage_override
+    LEVEL_9=$usage_override
+    LEVEL_10=$usage_override
+  else
+    LEVEL_1=$'\\033[38;5;22m'
+    LEVEL_2=$'\\033[38;5;28m'
+    LEVEL_3=$'\\033[38;5;34m'
+    LEVEL_4=$'\\033[38;5;100m'
+    LEVEL_5=$'\\033[38;5;142m'
+    LEVEL_6=$'\\033[38;5;178m'
+    LEVEL_7=$'\\033[38;5;172m'
+    LEVEL_8=$'\\033[38;5;166m'
+    LEVEL_9=$'\\033[38;5;160m'
+    LEVEL_10=$'\\033[38;5;124m'
+  fi
+
+  # Pace colors: override all tiers if a base color is set, else use standard 6-tier
+  if [ -n "$element_color_pace" ]; then
+    pace_override=$(hex_to_ansi "$element_color_pace")
+    PACE_COMFORTABLE=$pace_override
+    PACE_ON_TRACK=$pace_override
+    PACE_WARMING=$pace_override
+    PACE_PRESSING=$pace_override
+    PACE_CRITICAL=$pace_override
+    PACE_RUNAWAY=$pace_override
+  else
+    PACE_COMFORTABLE=$'\\033[38;5;34m'
+    PACE_ON_TRACK=$'\\033[38;5;37m'
+    PACE_WARMING=$'\\033[38;5;178m'
+    PACE_PRESSING=$'\\033[38;5;208m'
+    PACE_CRITICAL=$'\\033[38;5;160m'
+    PACE_RUNAWAY=$'\\033[38;5;135m'
+  fi
 else
   # Colored mode (default) - use full color palette
   BLUE=$'\\033[0;34m'
@@ -656,7 +724,11 @@ printf "%s\\n" "$output"
             colorModeString = "monochrome"
         case .singleColor:
             colorModeString = "singleColor"
+        case .perElement:
+            colorModeString = "perElement"
         }
+
+        let elementColors = SharedDataStore.shared.loadStatuslineElementColors()
 
         let config = """
 SHOW_MODEL=\(showModel ? "1" : "0")
@@ -677,6 +749,14 @@ COLOR_MODE=\(colorModeString)
 SINGLE_COLOR=\(singleColorHex)
 SHOW_PROFILE=\(showProfile ? "1" : "0")
 PROFILE_NAME="\(profileName)"
+ELEMENT_COLOR_DIR=\(elementColors.directoryHex)
+ELEMENT_COLOR_BRANCH=\(elementColors.branchHex)
+ELEMENT_COLOR_MODEL=\(elementColors.modelHex)
+ELEMENT_COLOR_PROFILE=\(elementColors.profileHex)
+ELEMENT_COLOR_CONTEXT=\(elementColors.contextHex)
+ELEMENT_COLOR_SEPARATOR=\(elementColors.separatorHex)
+ELEMENT_COLOR_USAGE=\(elementColors.usageBaseHex ?? "")
+ELEMENT_COLOR_PACE=\(elementColors.paceBaseHex ?? "")
 """
 
         try config.write(to: configPath, atomically: true, encoding: .utf8)

--- a/Claude Usage/Shared/Storage/SharedDataStore.swift
+++ b/Claude Usage/Shared/Storage/SharedDataStore.swift
@@ -35,6 +35,7 @@ class SharedDataStore {
         static let statuslineShowResetLabel = "statuslineShowResetLabel"
         static let statuslineColorMode = "statuslineColorMode"
         static let statuslineSingleColorHex = "statuslineSingleColorHex"
+        static let statuslineElementColors = "statuslineElementColors"
 
         // Setup State
         static let hasCompletedSetup = "hasCompletedSetup"
@@ -267,6 +268,24 @@ class SharedDataStore {
 
     func loadStatuslineSingleColorHex() -> String {
         return defaults.string(forKey: Keys.statuslineSingleColorHex) ?? "#00BFFF"
+    }
+
+    /// Persists per-element color configuration as JSON data.
+    /// - Parameter colors: The element colors to save.
+    func saveStatuslineElementColors(_ colors: StatuslineElementColors) {
+        if let data = try? JSONEncoder().encode(colors) {
+            defaults.set(data, forKey: Keys.statuslineElementColors)
+        }
+    }
+
+    /// Loads per-element color configuration. Returns defaults matching the ANSI
+    /// `.colored` palette if no configuration has been saved yet.
+    func loadStatuslineElementColors() -> StatuslineElementColors {
+        guard let data = defaults.data(forKey: Keys.statuslineElementColors),
+              let colors = try? JSONDecoder().decode(StatuslineElementColors.self, from: data) else {
+            return StatuslineElementColors()
+        }
+        return colors
     }
 
     // MARK: - Setup State

--- a/Claude Usage/Views/Settings/App/ClaudeCodeView.swift
+++ b/Claude Usage/Views/Settings/App/ClaudeCodeView.swift
@@ -31,6 +31,8 @@ struct ClaudeCodeView: View {
     // Appearance settings
     @State private var colorMode: StatuslineColorMode = SharedDataStore.shared.loadStatuslineColorMode()
     @State private var singleColor: Color = Color(hex: SharedDataStore.shared.loadStatuslineSingleColorHex()) ?? .cyan
+    @State private var elementColors: StatuslineElementColors = SharedDataStore.shared.loadStatuslineElementColors()
+    @State private var elementColorsExpanded: Bool = false
 
     // Status feedback
     @State private var statusMessage: String?
@@ -89,7 +91,7 @@ struct ClaudeCodeView: View {
                     subtitle: "Choose color display mode"
                 ) {
                     HStack(spacing: DesignTokens.Spacing.small) {
-                        ForEach([StatuslineColorMode.colored, .monochrome, .singleColor], id: \.self) { mode in
+                        ForEach([StatuslineColorMode.colored, .monochrome, .singleColor, .perElement], id: \.self) { mode in
                             Button {
                                 colorMode = mode
                                 SharedDataStore.shared.saveStatuslineColorMode(mode)
@@ -141,6 +143,41 @@ struct ClaudeCodeView: View {
                             Spacer()
                         }
                         .padding(.top, 4)
+                    }
+
+                    if colorMode == .perElement {
+                        DisclosureGroup(isExpanded: $elementColorsExpanded) {
+                            VStack(alignment: .leading, spacing: DesignTokens.Spacing.small) {
+                                ElementColorRow(label: "Directory", hex: $elementColors.directoryHex)
+                                ElementColorRow(label: "Branch", hex: $elementColors.branchHex)
+                                ElementColorRow(label: "Model", hex: $elementColors.modelHex)
+                                ElementColorRow(label: "Profile", hex: $elementColors.profileHex)
+                                ElementColorRow(label: "Context", hex: $elementColors.contextHex)
+                                ElementColorRow(label: "Separator", hex: $elementColors.separatorHex)
+
+                                Divider()
+
+                                ElementColorRowOptional(
+                                    label: "Usage gradient",
+                                    description: "Override 10-level gradient with a fixed color",
+                                    hex: $elementColors.usageBaseHex
+                                )
+                                ElementColorRowOptional(
+                                    label: "Pace marker",
+                                    description: "Override 6-tier pace colors with a fixed color",
+                                    hex: $elementColors.paceBaseHex
+                                )
+                            }
+                            .padding(.top, DesignTokens.Spacing.small)
+                        } label: {
+                            Text("Element Colors")
+                                .font(DesignTokens.Typography.body)
+                                .foregroundColor(.primary)
+                        }
+                        .padding(.top, 4)
+                        .onChange(of: elementColors) {
+                            SharedDataStore.shared.saveStatuslineElementColors(elementColors)
+                        }
                     }
                 }
 
@@ -332,6 +369,8 @@ struct ClaudeCodeView: View {
         case .singleColor:
             let hex = SharedDataStore.shared.loadStatuslineSingleColorHex()
             return Color(hex: hex) ?? .cyan
+        case .perElement:
+            return Color(hex: elementColors.directoryHex) ?? TerminalColors.blue
         }
     }
 
@@ -339,7 +378,7 @@ struct ClaudeCodeView: View {
     private var previewBackgroundColor: Color {
         let colorMode = SharedDataStore.shared.loadStatuslineColorMode()
         switch colorMode {
-        case .colored:
+        case .colored, .perElement:
             return Color.purple.opacity(0.05)
         case .monochrome:
             return previewColor.opacity(0.05)
@@ -352,7 +391,7 @@ struct ClaudeCodeView: View {
     private var previewBorderColor: Color {
         let colorMode = SharedDataStore.shared.loadStatuslineColorMode()
         switch colorMode {
-        case .colored:
+        case .colored, .perElement:
             return Color.purple.opacity(0.2)
         case .monochrome:
             return previewColor.opacity(0.2)
@@ -361,12 +400,28 @@ struct ClaudeCodeView: View {
         }
     }
 
+    // Per-element preview colors — read from elementColors state for live updates
+    private var previewDirectoryColor: Color { Color(hex: elementColors.directoryHex) ?? TerminalColors.blue }
+    private var previewBranchColor: Color    { Color(hex: elementColors.branchHex) ?? TerminalColors.green }
+    private var previewModelColor: Color     { Color(hex: elementColors.modelHex) ?? TerminalColors.yellow }
+    private var previewProfileColor: Color   { Color(hex: elementColors.profileHex) ?? TerminalColors.magenta }
+    private var previewContextColor: Color   { Color(hex: elementColors.contextHex) ?? TerminalColors.cyan }
+    private var previewSeparatorColor: Color { Color(hex: elementColors.separatorHex) ?? TerminalColors.gray }
+    private func previewUsageColor(percentage: Int) -> Color {
+        if let hex = elementColors.usageBaseHex { return Color(hex: hex) ?? TerminalColors.usageLevel(percentage) }
+        return TerminalColors.usageLevel(percentage)
+    }
+    private func previewPaceOverrideColor(percentage: Int) -> Color? {
+        if let hex = elementColors.paceBaseHex { return Color(hex: hex) }
+        return nil
+    }
+
     /// Preview view showing statusline with appropriate colors
     @ViewBuilder
     private var previewView: some View {
         let colorMode = SharedDataStore.shared.loadStatuslineColorMode()
 
-        if colorMode == .colored {
+        if colorMode == .colored || colorMode == .perElement {
             // Multi-color preview - each element gets its own color
             multiColorPreview
         } else {
@@ -445,43 +500,51 @@ struct ClaudeCodeView: View {
         }
     }
 
-    /// Multi-color preview showing each element in different colors
+    /// Multi-color preview showing each element in different colors.
+    /// Used for both `.colored` and `.perElement` modes.
     private var multiColorPreview: some View {
         let usage = profileManager.activeProfile?.claudeUsage
         let percentage = usage != nil ? Int(usage!.sessionPercentage) : 29
-        let usageColor = TerminalColors.usageLevel(percentage)
+        let isPerElement = colorMode == .perElement
+        let dirColor    = isPerElement ? previewDirectoryColor : TerminalColors.blue
+        let branchColor = isPerElement ? previewBranchColor    : TerminalColors.green
+        let modelColor  = isPerElement ? previewModelColor     : TerminalColors.yellow
+        let profColor   = isPerElement ? previewProfileColor   : TerminalColors.magenta
+        let ctxColor    = isPerElement ? previewContextColor   : TerminalColors.cyan
+        let sepColor    = isPerElement ? previewSeparatorColor : TerminalColors.gray
+        let usageColor  = isPerElement ? previewUsageColor(percentage: percentage) : TerminalColors.usageLevel(percentage)
 
         return HStack(spacing: 0) {
             if showDirectory {
                 Text("claude-usage")
-                    .foregroundColor(TerminalColors.blue)
+                    .foregroundColor(dirColor)
                 if showBranch || showModel || showProfile || showContext || showUsage {
-                    Text(" │ ").foregroundColor(TerminalColors.gray)
+                    Text(" │ ").foregroundColor(sepColor)
                 }
             }
 
             if showBranch {
                 Text("⎇ main")
-                    .foregroundColor(TerminalColors.green)
+                    .foregroundColor(branchColor)
                 if showModel || showProfile || showContext || showUsage {
-                    Text(" │ ").foregroundColor(TerminalColors.gray)
+                    Text(" │ ").foregroundColor(sepColor)
                 }
             }
 
             if showModel {
                 Text("Opus")
-                    .foregroundColor(TerminalColors.yellow)
+                    .foregroundColor(modelColor)
                 if showProfile || showContext || showUsage {
-                    Text(" │ ").foregroundColor(TerminalColors.gray)
+                    Text(" │ ").foregroundColor(sepColor)
                 }
             }
 
             if showProfile {
                 let name = ProfileManager.shared.activeProfile?.name ?? "Profile"
                 Text(name)
-                    .foregroundColor(TerminalColors.magenta)
+                    .foregroundColor(profColor)
                 if showContext || showUsage {
-                    Text(" │ ").foregroundColor(TerminalColors.gray)
+                    Text(" │ ").foregroundColor(sepColor)
                 }
             }
 
@@ -489,13 +552,13 @@ struct ClaudeCodeView: View {
                 let ctxPrefix = showContextLabel ? "Ctx: " : ""
                 if contextAsTokens {
                     Text("\(ctxPrefix)96K")
-                        .foregroundColor(TerminalColors.cyan)
+                        .foregroundColor(ctxColor)
                 } else {
                     Text("\(ctxPrefix)48%")
-                        .foregroundColor(TerminalColors.cyan)
+                        .foregroundColor(ctxColor)
                 }
                 if showUsage {
-                    Text(" │ ").foregroundColor(TerminalColors.gray)
+                    Text(" │ ").foregroundColor(sepColor)
                 }
             }
 
@@ -510,7 +573,8 @@ struct ClaudeCodeView: View {
 
                     if showPaceMarker {
                         let markerPos = max(0, min(9, previewMarkerPosition))
-                        let paceColor = previewPaceColor(percentage: percentage)
+                        let basePaceColor = previewPaceColor(percentage: percentage)
+                        let paceColor = (isPerElement ? previewPaceOverrideColor(percentage: percentage) : nil) ?? basePaceColor
                         let fullBar = String(repeating: "▓", count: filledBlocks) + String(repeating: "░", count: emptyBlocks)
                         let chars = Array(fullBar)
 
@@ -577,6 +641,8 @@ struct ClaudeCodeView: View {
             return .primary
         case .singleColor:
             return singleColor
+        case .perElement:
+            return Color(hex: elementColors.directoryHex) ?? .purple
         }
     }
 
@@ -769,6 +835,71 @@ struct ClaudeCodeView: View {
         }
 
         return parts.isEmpty ? "claudecode.preview_no_components".localized : parts.joined(separator: " │ ")
+    }
+}
+
+// MARK: - Per-Element Color Rows
+
+/// A single row showing a label and a `ColorPicker` for a required statusline element color.
+///
+/// Used inside the "Element Colors" disclosure group in `ClaudeCodeView`
+/// when `StatuslineColorMode` is `.perElement`.
+private struct ElementColorRow: View {
+    let label: String
+    @Binding var hex: String
+
+    var body: some View {
+        HStack {
+            Text(label)
+                .font(DesignTokens.Typography.body)
+                .foregroundColor(.primary)
+            Spacer()
+            ColorPicker("", selection: Binding(
+                get: { Color(hex: hex) ?? .blue },
+                set: { hex = $0.toHex() ?? hex }
+            ))
+            .labelsHidden()
+        }
+    }
+}
+
+/// A row with a toggle and an optional `ColorPicker` for a statusline element
+/// that supports dynamic multi-level coloring (usage gradient, pace tiers).
+///
+/// When the toggle is off the binding value is `nil`, which tells the bash script
+/// to use the default dynamic behavior (10-level gradient or 6-tier pace colors).
+/// When on, the chosen color overrides all levels with a single fixed color.
+private struct ElementColorRowOptional: View {
+    let label: String
+    let description: String
+    @Binding var hex: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack {
+                Toggle(isOn: Binding(
+                    get: { hex != nil },
+                    set: { enabled in hex = enabled ? "#00BB00" : nil }
+                )) {
+                    Text(label)
+                        .font(DesignTokens.Typography.body)
+                        .foregroundColor(.primary)
+                }
+                .toggleStyle(.switch)
+
+                if hex != nil {
+                    Spacer()
+                    ColorPicker("", selection: Binding(
+                        get: { Color(hex: hex!) ?? .green },
+                        set: { hex = $0.toHex() ?? hex }
+                    ))
+                    .labelsHidden()
+                }
+            }
+            Text(description)
+                .font(DesignTokens.Typography.caption)
+                .foregroundColor(.secondary)
+        }
     }
 }
 


### PR DESCRIPTION
## Description

Adds a new `.perElement` color mode for the Claude Code statusline. Users can now assign an individual color to each statusline element (Directory, Branch, Model, Profile, Context, Separator) instead of being limited to a single global palette. The Usage gradient and Pace marker also support an optional fixed-color override that preserves the existing 10-level / 6-tier dynamic behaviour when left disabled.

## Changes

- `StatuslineElementColors.swift` (new) — `Codable/Equatable` struct holding per-element hex colors with ANSI-matching defaults
- `StatuslineColorMode.swift` — added `.perElement` case with display name, description and SF Symbol icon
- `SharedDataStore.swift` — JSON persistence for `StatuslineElementColors` via a new key
- `StatuslineService.swift` — writes `ELEMENT_COLOR_*` variables to `statusline-config.txt`; adds `perElement` branch in the bash script using the existing `hex_to_ansi` function for truecolor ANSI output
- `ClaudeCodeView.swift` — fourth color mode button, `DisclosureGroup` with `ElementColorRow` / `ElementColorRowOptional` components, live preview updated to reflect per-element colors immediately
- 9 × `Localizable.strings` — 11 new localization keys per language (en, it, de, es, fr, pt, ja, ko, zh-ch)

## Screenshots / Screen Recordings

Settings → Claude CLI with **Per Element** mode selected, showing the Element Colors disclosure group with individual ColorPickers for each statusline element and optional overrides for Usage gradient and Pace marker:

<img width="1440" height="1500" alt="Claude Usage 2026-04-05 23 31 24" src="https://github.com/user-attachments/assets/e5a6ff5d-a868-4795-8d27-545246116242" />


> Screenshot shows: live preview at top reflecting custom colors, four color mode buttons with Per Element selected, expanded Element Colors section with Directory/Branch/Model/Profile/Context/Separator pickers and Usage gradient / Pace marker optional toggles.

## Important Guidelines

- No App Groups or grouped Keychain usage introduced — colors stored in standard `UserDefaults` as JSON
- Follows existing MVVM patterns and protocol-oriented architecture
- All 9 localization files updated with new keys
- Tested on macOS 14.0+ (Sonoma)

## Checklist

- [x] I have tested these changes on a running build
- [x] I have attached screenshots/recordings for any visual changes
- [x] I have not introduced App Group or grouped Keychain usage
- [x] I have added localization keys for any new user-facing strings