### PR TITLE
Add nix as installation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,23 @@ Or use the built-in automatic update feature (Settings → Updates).
 brew uninstall --cask claude-usage-tracker
 ```
 
-#### Option 2: Direct Download
+#### Option 2: Nix
+
+Test the app:
+
+```bash
+nix-shell -p claude-usage-tracker
+```
+
+Install it using home-manager:
+
+```nix
+home.packages = with pkgs; [
+  claude-usage-tracker
+];
+```
+
+#### Option 3: Direct Download
 
 **[Download Claude-Usage.zip](https://github.com/hamed-elfayome/Claude-Usage-Tracker/releases/latest/download/Claude-Usage.zip)**
 
@@ -143,7 +159,7 @@ brew uninstall --cask claude-usage-tracker
 
 **Automatic Updates**: Once installed, the app will automatically check for updates and notify you when new versions are available (Settings → Updates).
 
-#### Option 3: Build from Source
+#### Option 4: Build from Source
 
 ```bash
 # Clone the repository


### PR DESCRIPTION
## Description

I added claude-usage-tracker to the official nixpkgs repo (https://github.com/NixOS/nixpkgs/pull/507019#event-24209757849). The nix people can now use this package easily :)

## Changes

-

## Screenshots / Screen Recordings

<!-- REQUIRED for any visual/UI changes. Please attach screenshots or screen recordings of the running app showing your changes. PRs with visual changes that don't include screenshots will not be reviewed. -->

<!-- If your change is not visual (e.g., logic-only, refactoring), write "N/A - no visual changes" -->

## Important Guidelines

- **Do NOT use App Groups Keychain with app group identifiers.** This app is distributed outside the App Store via a Developer ID certificate. App Group entitlements require Keychain access prompts on every launch, which breaks the user experience. Use standard `UserDefaults` and standard Keychain access (without group identifiers) instead.
- Follow existing code patterns and architecture (MVVM, protocol-oriented)
- Add localization keys for any new user-facing strings (9 languages supported)
- Test on macOS 14.0+ (Sonoma)

## Checklist

- [ ] I have tested these changes on a running build
- [ ] I have attached screenshots/recordings for any visual changes
- [ ] I have not introduced App Group or grouped Keychain usage
- [ ] I have added localization keys for any new user-facing strings
