### PR TITLE
Fix menu bar item persistence across configuration changes

### DIFF
--- a/Claude Usage/MenuBar/MenuBarManager.swift
+++ b/Claude Usage/MenuBar/MenuBarManager.swift
@@ -991,7 +991,9 @@ class MenuBarManager: NSObject, ObservableObject {
             action: #selector(togglePopover)
         )
 
-        // Defer icon update to next run loop iteration to let NSStatusBar finalize layout
+        // WORKAROUND: Defer icon update to next run loop iteration to avoid race condition
+        // where NSStatusBar layout hasn't finalized yet after status item creation.
+        // This prevents potential flicker or layout issues during incremental updates.
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
             self.statusBarUIManager?.updateMultiProfileButtons(profiles: self.profileManager.profiles, config: config, activeProfileId: self.profileManager.activeProfile?.id)

--- a/Claude Usage/MenuBar/MenuBarManager.swift
+++ b/Claude Usage/MenuBar/MenuBarManager.swift
@@ -290,6 +290,10 @@ class MenuBarManager: NSObject, ObservableObject {
             NotificationCenter.default.removeObserver(multiProfileConfigObserver)
             self.multiProfileConfigObserver = nil
         }
+        if let peakHoursObserver = peakHoursObserver {
+            NotificationCenter.default.removeObserver(peakHoursObserver)
+            self.peakHoursObserver = nil
+        }
         if let monitor = eventMonitor {
             NSEvent.removeMonitor(monitor)
             eventMonitor = nil

--- a/Claude Usage/MenuBar/MenuBarManager.swift
+++ b/Claude Usage/MenuBar/MenuBarManager.swift
@@ -98,6 +98,8 @@ class MenuBarManager: NSObject, ObservableObject {
     // Observer for peak hours setting changes
     private var peakHoursObserver: NSObjectProtocol?
 
+    private var multiProfileConfigObserver: NSObjectProtocol?
+
     // MARK: - Image Caching (CPU Optimization)
     private var cachedImage: NSImage?
     private var cachedImageKey: String = ""
@@ -214,6 +216,7 @@ class MenuBarManager: NSObject, ObservableObject {
 
         // Observe display mode changes (single/multi profile)
         observeDisplayModeChanges()
+        observeMultiProfileConfigChanges()
 
         // Setup headless mode observer if enabled (for Remote Desktop support)
         setupHeadlessModeObserver()
@@ -282,6 +285,10 @@ class MenuBarManager: NSObject, ObservableObject {
         if let wakeObserver = wakeObserver {
             NSWorkspace.shared.notificationCenter.removeObserver(wakeObserver)
             self.wakeObserver = nil
+        }
+        if let multiProfileConfigObserver = multiProfileConfigObserver {
+            NotificationCenter.default.removeObserver(multiProfileConfigObserver)
+            self.multiProfileConfigObserver = nil
         }
         if let monitor = eventMonitor {
             NSEvent.removeMonitor(monitor)
@@ -373,8 +380,8 @@ class MenuBarManager: NSObject, ObservableObject {
         // 3. Update menu bar based on current display mode
         // IMPORTANT: In multi-profile mode, we update all icons, not just switch config
         if profileManager.displayMode == .multi {
-            // Multi-profile mode - refresh all profile icons
-            setupMultiProfileMode()
+            // Multi-profile mode - update icons without recreating status items
+            updateMultiProfileDisplay()
         } else {
             // Single profile mode - update menu bar configuration
             updateMenuBarDisplay(with: profile.iconConfig)
@@ -815,8 +822,8 @@ class MenuBarManager: NSObject, ObservableObject {
             Task { @MainActor in
                 // Handle differently based on display mode
                 if self.profileManager.displayMode == .multi {
-                    // Multi-profile mode - refresh all profile icons
-                    self.setupMultiProfileMode()
+                    // Multi-profile mode - update icons without recreating status items
+                    self.updateMultiProfileDisplay()
                 } else {
                     // Single profile mode
                     let newConfig = self.profileManager.activeProfile?.iconConfig ?? .default
@@ -837,6 +844,22 @@ class MenuBarManager: NSObject, ObservableObject {
 
             Task { @MainActor in
                 self.handleDisplayModeChange()
+            }
+        }
+    }
+
+    private func observeMultiProfileConfigChanges() {
+        // Observe multi-profile visual config changes (icon style, toggles, profile selection)
+        // Uses incremental update — does NOT destroy/recreate status items
+        multiProfileConfigObserver = NotificationCenter.default.addObserver(
+            forName: .multiProfileConfigChanged,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self = self else { return }
+
+            Task { @MainActor in
+                self.updateMultiProfileDisplay()
             }
         }
     }
@@ -950,6 +973,27 @@ class MenuBarManager: NSObject, ObservableObject {
 
         // Refresh data for all selected profiles that have credentials
         refreshAllSelectedProfiles()
+    }
+
+    /// Incrementally updates multi-profile status items (without destroying/recreating them)
+    /// Use this when only icon config changed but the set of profiles may or may not have changed.
+    private func updateMultiProfileDisplay() {
+        let selectedProfiles = profileManager.getSelectedProfiles()
+        let config = profileManager.multiProfileConfig
+
+        statusBarUIManager?.updateMultiProfileConfiguration(
+            profiles: selectedProfiles,
+            target: self,
+            action: #selector(togglePopover)
+        )
+
+        // Defer icon update to next run loop iteration to let NSStatusBar finalize layout
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            self.statusBarUIManager?.updateMultiProfileButtons(profiles: self.profileManager.profiles, config: config, activeProfileId: self.profileManager.activeProfile?.id)
+        }
+
+        LoggingService.shared.log("MenuBarManager: Multi-profile display updated incrementally with \(selectedProfiles.count) profiles")
     }
 
     /// Refreshes usage data for all profiles selected for multi-profile display

--- a/Claude Usage/MenuBar/StatusBarUIManager.swift
+++ b/Claude Usage/MenuBar/StatusBarUIManager.swift
@@ -36,6 +36,28 @@ final class StatusBarUIManager {
 
     weak var delegate: StatusBarUIManagerDelegate?
 
+    // MARK: - Stable autosaveName helpers
+
+    /// Base prefix for all status item autosave names.
+    /// Ice (icemenubar.app) and macOS use autosaveName to persist item positions.
+    private static let autosavePrefix = "claudeUsageTracker"
+
+    /// Returns a stable autosaveName for a single-profile metric item
+    private static func autosaveName(for metricType: MenuBarMetricType) -> NSStatusItem.AutosaveName {
+        return "\(autosavePrefix).metric.\(metricType.rawValue)"
+    }
+
+    /// Returns a stable autosaveName for a multi-profile item by profile ID
+    private static func autosaveName(forProfileId id: UUID) -> NSStatusItem.AutosaveName {
+        return "\(autosavePrefix).multiProfile.\(id.uuidString)"
+    }
+
+    /// Returns a stable autosaveName for the peak hours indicator
+    private static let peakHoursAutosaveName: NSStatusItem.AutosaveName = "\(autosavePrefix).peakHours"
+
+    /// Returns a stable autosaveName for the default logo (no credentials)
+    private static let defaultLogoAutosaveName: NSStatusItem.AutosaveName = "\(autosavePrefix).defaultLogo"
+
     // MARK: - Multi-profile identity helpers
 
     /// Well-known placeholder UUID used for the default logo in multi-profile mode
@@ -56,6 +78,7 @@ final class StatusBarUIManager {
         if config.enabledMetrics.isEmpty {
             // No credentials/metrics - show default app logo
             let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+            statusItem.autosaveName = Self.defaultLogoAutosaveName
 
             if let button = statusItem.button {
                 button.action = action
@@ -74,6 +97,7 @@ final class StatusBarUIManager {
             // Create status items for enabled metrics
             for metricConfig in config.enabledMetrics {
                 let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+                statusItem.autosaveName = Self.autosaveName(for: metricConfig.metricType)
 
                 if let button = statusItem.button {
                     button.action = action
@@ -124,6 +148,10 @@ final class StatusBarUIManager {
         let itemsToAdd = newMetricTypes.subtracting(currentMetricTypes)
         for metricType in itemsToAdd {
             let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+            // When enabledMetrics is empty, only .session is in newMetricTypes, so this is safe
+            statusItem.autosaveName = config.enabledMetrics.isEmpty
+                ? Self.defaultLogoAutosaveName
+                : Self.autosaveName(for: metricType)
 
             if let button = statusItem.button {
                 button.action = action
@@ -215,6 +243,7 @@ final class StatusBarUIManager {
             // Create the status item if not already showing
             if peakHoursStatusItem == nil, let target = peakHoursTarget, let action = peakHoursAction {
                 let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+                statusItem.autosaveName = Self.peakHoursAutosaveName
                 if let button = statusItem.button {
                     button.action = action
                     button.target = target
@@ -261,6 +290,7 @@ final class StatusBarUIManager {
         if selectedProfiles.isEmpty {
             // No profiles selected - show default logo
             let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+            statusItem.autosaveName = Self.defaultLogoAutosaveName
             if let button = statusItem.button {
                 button.action = action
                 button.target = target
@@ -276,6 +306,7 @@ final class StatusBarUIManager {
             // Create one status item per selected profile
             for profile in selectedProfiles {
                 let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+                statusItem.autosaveName = Self.autosaveName(forProfileId: profile.id)
 
                 if let button = statusItem.button {
                     button.action = action
@@ -330,6 +361,7 @@ final class StatusBarUIManager {
         if selectedProfiles.isEmpty && idsToAdd.contains(Self.defaultLogoPlaceholderUUID) {
             // Need to add default logo
             let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+            statusItem.autosaveName = Self.defaultLogoAutosaveName
             if let button = statusItem.button {
                 button.action = action
                 button.target = target
@@ -341,6 +373,7 @@ final class StatusBarUIManager {
         } else {
             for profile in selectedProfiles where idsToAdd.contains(profile.id) {
                 let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+                statusItem.autosaveName = Self.autosaveName(forProfileId: profile.id)
                 if let button = statusItem.button {
                     button.action = action
                     button.target = target

--- a/Claude Usage/MenuBar/StatusBarUIManager.swift
+++ b/Claude Usage/MenuBar/StatusBarUIManager.swift
@@ -36,6 +36,11 @@ final class StatusBarUIManager {
 
     weak var delegate: StatusBarUIManagerDelegate?
 
+    // MARK: - Multi-profile identity helpers
+
+    /// Well-known placeholder UUID used for the default logo in multi-profile mode
+    private static let defaultLogoPlaceholderUUID = UUID(uuidString: "00000000-0000-0000-0000-000000000000")!
+
     // MARK: - Initialization
 
     init() {}
@@ -264,8 +269,8 @@ final class StatusBarUIManager {
             } else {
                 LoggingService.shared.logWarning("Multi-profile status bar button is nil - screens: \(NSScreen.screens.count)")
             }
-            // Use a placeholder UUID for default logo
-            multiProfileStatusItems[UUID()] = statusItem
+            // Use a well-known placeholder UUID for default logo (stable across calls)
+            multiProfileStatusItems[Self.defaultLogoPlaceholderUUID] = statusItem
             LoggingService.shared.logUIEvent("Multi-profile: No profiles selected, showing default logo")
         } else {
             // Create one status item per selected profile
@@ -287,6 +292,66 @@ final class StatusBarUIManager {
         }
 
         observeAppearanceChanges()
+    }
+
+    /// Incrementally updates multi-profile status items without destroying existing ones.
+    /// Only adds/removes items when the set of selected profiles changes.
+    func updateMultiProfileConfiguration(profiles: [Profile], target: AnyObject, action: Selector) {
+        guard isMultiProfileMode else {
+            // Not in multi-profile mode yet - do a full setup
+            setupMultiProfile(profiles: profiles, target: target, action: action)
+            return
+        }
+
+        let selectedProfiles = profiles.filter { $0.isSelectedForDisplay }
+        let newProfileIds: Set<UUID> = selectedProfiles.isEmpty
+            ? [Self.defaultLogoPlaceholderUUID]
+            : Set(selectedProfiles.map { $0.id })
+        let currentProfileIds = Set(multiProfileStatusItems.keys)
+
+        // Step 1: Remove items that are no longer needed
+        let idsToRemove = currentProfileIds.subtracting(newProfileIds)
+        for profileId in idsToRemove {
+            if let statusItem = multiProfileStatusItems[profileId] {
+                if let button = statusItem.button {
+                    button.image = nil
+                    button.action = nil
+                    button.target = nil
+                }
+                NSStatusBar.system.removeStatusItem(statusItem)
+                LoggingService.shared.logUIEvent("Multi-profile: Removed status item for profile \(profileId)")
+            }
+            multiProfileStatusItems.removeValue(forKey: profileId)
+        }
+
+        // Step 2: Add items that are new
+        let idsToAdd = newProfileIds.subtracting(currentProfileIds)
+
+        if selectedProfiles.isEmpty && idsToAdd.contains(Self.defaultLogoPlaceholderUUID) {
+            // Need to add default logo
+            let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+            if let button = statusItem.button {
+                button.action = action
+                button.target = target
+                button.sendAction(on: [.leftMouseUp, .rightMouseUp])
+                button.title = ""
+            }
+            multiProfileStatusItems[Self.defaultLogoPlaceholderUUID] = statusItem
+            LoggingService.shared.logUIEvent("Multi-profile: Added default logo")
+        } else {
+            for profile in selectedProfiles where idsToAdd.contains(profile.id) {
+                let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+                if let button = statusItem.button {
+                    button.action = action
+                    button.target = target
+                    button.sendAction(on: [.leftMouseUp, .rightMouseUp])
+                }
+                multiProfileStatusItems[profile.id] = statusItem
+                LoggingService.shared.logUIEvent("Multi-profile: Added status item for profile \(profile.name)")
+            }
+        }
+
+        LoggingService.shared.logUIEvent("Multi-profile config updated: removed=\(idsToRemove.count), added=\(idsToAdd.count), kept=\(currentProfileIds.intersection(newProfileIds).count)")
     }
 
     /// Adds a thin green underline to an image to indicate the active profile

--- a/Claude Usage/Shared/Extensions/Notification+Extensions.swift
+++ b/Claude Usage/Shared/Extensions/Notification+Extensions.swift
@@ -20,6 +20,10 @@ extension Notification.Name {
     /// Posted when the display mode changes (single/multi profile)
     static let displayModeChanged = Notification.Name("displayModeChanged")
 
+    /// Posted when multi-profile visual config changes (icon style, show week, labels, etc.)
+    /// Unlike displayModeChanged, this does NOT recreate status items — only updates their icons.
+    static let multiProfileConfigChanged = Notification.Name("multiProfileConfigChanged")
+
     /// Posted when auto-switch profile is triggered (for UI reactivity)
     static let autoSwitchProfileTriggered = Notification.Name("autoSwitchProfileTriggered")
 

--- a/Claude Usage/Views/Settings/App/ManageProfilesView.swift
+++ b/Claude Usage/Views/Settings/App/ManageProfilesView.swift
@@ -87,8 +87,8 @@ struct ManageProfilesView: View {
                                                 return
                                             }
                                             profileManager.toggleProfileSelection(profile.id)
-                                            // Post notification for menu bar to update
-                                            NotificationCenter.default.post(name: .displayModeChanged, object: nil)
+                                            // Post notification for menu bar to update (incremental, not full recreate)
+                                            NotificationCenter.default.post(name: .multiProfileConfigChanged, object: nil)
                                         }
                                     )
                                 }
@@ -122,7 +122,7 @@ struct ManageProfilesView: View {
                                         var config = profileManager.multiProfileConfig
                                         config.iconStyle = newStyle
                                         profileManager.updateMultiProfileConfig(config)
-                                        NotificationCenter.default.post(name: .displayModeChanged, object: nil)
+                                        NotificationCenter.default.post(name: .multiProfileConfigChanged, object: nil)
                                     }
                                 )) {
                                     ForEach(MultiProfileIconStyle.allCases, id: \.self) { style in
@@ -144,7 +144,7 @@ struct ManageProfilesView: View {
                                         var config = profileManager.multiProfileConfig
                                         config.showWeek = showWeek
                                         profileManager.updateMultiProfileConfig(config)
-                                        NotificationCenter.default.post(name: .displayModeChanged, object: nil)
+                                        NotificationCenter.default.post(name: .multiProfileConfigChanged, object: nil)
                                     }
                                 )
                             )
@@ -159,7 +159,7 @@ struct ManageProfilesView: View {
                                         var config = profileManager.multiProfileConfig
                                         config.showProfileLabel = showLabel
                                         profileManager.updateMultiProfileConfig(config)
-                                        NotificationCenter.default.post(name: .displayModeChanged, object: nil)
+                                        NotificationCenter.default.post(name: .multiProfileConfigChanged, object: nil)
                                     }
                                 )
                             )
@@ -174,7 +174,7 @@ struct ManageProfilesView: View {
                                         var config = profileManager.multiProfileConfig
                                         config.useSystemColor = useSystemColor
                                         profileManager.updateMultiProfileConfig(config)
-                                        NotificationCenter.default.post(name: .displayModeChanged, object: nil)
+                                        NotificationCenter.default.post(name: .multiProfileConfigChanged, object: nil)
                                     }
                                 )
                             )
@@ -189,7 +189,7 @@ struct ManageProfilesView: View {
                                         var config = profileManager.multiProfileConfig
                                         config.showTimeMarker = showMarker
                                         profileManager.updateMultiProfileConfig(config)
-                                        NotificationCenter.default.post(name: .displayModeChanged, object: nil)
+                                        NotificationCenter.default.post(name: .multiProfileConfigChanged, object: nil)
                                     }
                                 )
                             )
@@ -204,7 +204,7 @@ struct ManageProfilesView: View {
                                         var config = profileManager.multiProfileConfig
                                         config.showPaceMarker = showPace
                                         profileManager.updateMultiProfileConfig(config)
-                                        NotificationCenter.default.post(name: .displayModeChanged, object: nil)
+                                        NotificationCenter.default.post(name: .multiProfileConfigChanged, object: nil)
                                     }
                                 )
                             )
@@ -219,7 +219,7 @@ struct ManageProfilesView: View {
                                         var config = profileManager.multiProfileConfig
                                         config.usePaceColoring = usePace
                                         profileManager.updateMultiProfileConfig(config)
-                                        NotificationCenter.default.post(name: .displayModeChanged, object: nil)
+                                        NotificationCenter.default.post(name: .multiProfileConfigChanged, object: nil)
                                     }
                                 )
                             )
@@ -234,7 +234,7 @@ struct ManageProfilesView: View {
                                         var config = profileManager.multiProfileConfig
                                         config.showRemainingPercentage = showRemaining
                                         profileManager.updateMultiProfileConfig(config)
-                                        NotificationCenter.default.post(name: .displayModeChanged, object: nil)
+                                        NotificationCenter.default.post(name: .multiProfileConfigChanged, object: nil)
                                     }
                                 )
                             )
@@ -249,7 +249,7 @@ struct ManageProfilesView: View {
                                         var config = profileManager.multiProfileConfig
                                         config.showActiveProfileIndicator = showIndicator
                                         profileManager.updateMultiProfileConfig(config)
-                                        NotificationCenter.default.post(name: .displayModeChanged, object: nil)
+                                        NotificationCenter.default.post(name: .multiProfileConfigChanged, object: nil)
                                     }
                                 )
                             )


### PR DESCRIPTION
## 🐛 Problems Fixed

Menu bar items were disappearing from their configured positions whenever users toggled settings like icon style, week display, or label options. This affected menu bar managers like [Ice](https://icemenubar.app/) that track item positions.

### Root Causes

1. **Indiscriminate recreation**: Every configuration change (icon style, week display, labels) posted `.displayModeChanged`, triggering full destroy/recreate of all status items. No distinction between real mode switches (single↔multi) and visual tweaks.

2. **Missing observer cleanup**: `peakHoursObserver` was registered but never removed in `cleanup()`, causing observer leaks and duplicate notifications on headless Mac reconnects.

3. **No stable identifiers**: NSStatusItems had no persistent autosave names, so menu bar managers like [Ice](https://icemenubar.app/) couldn't remember item positions across app restarts or legitimate recreations.

---

## ✅ Solutions

### Commit 1: Stop destroying menu bar items on config changes
- New `.multiProfileConfigChanged` notification for visual config tweaks (icon style, show week, labels)
- Config toggles now route through this new notification instead of `.displayModeChanged`
- `.displayModeChanged` reserved for actual mode switches (single ↔ multi)
- New `updateMultiProfileConfiguration()` method that incrementally adds/removes items only when the set of selected profiles actually changes
- Stable placeholder UUID for default logo instead of random `UUID()`

### Commit 2: Remove peakHoursObserver leak
- Remove `peakHoursObserver` in `cleanup()` using the same pattern as all other observers:
  ```swift
  if let obs = obs { removeObserver(obs); self.obs = nil }
  ```
- Prevents observer leaks and duplicate notifications

### Commit 3: Add stable autosave names
- Assign stable `autosaveName` to every NSStatusItem:
  - Single-profile items: keyed by metric type (e.g., `"claudeUsageTracker.metric.session"`)
  - Multi-profile items: keyed by profile UUID
  - Peak hours indicator and default logo also receive stable names
- Allows macOS and menu bar managers to persist item positions


**Important note**: Current implementation **resets** menu items whenever "Multiple profiles display" toggle is updated (as we will have different menuitems identifiers in that case ... I assume this is OK as this is not going to happen very often to toggle this flag)

---

## 📹 Before/After

Recording [here](https://drive.google.com/file/d/1P9JW6-nD2uEttF30D6xcCES0XkJDZMxH/view?usp=sharing), showing settings toggle before and after fix, demonstrating menu bar items remain in their configured positions despite configuration changes

---

## 📊 Changes Overview

- **MenuBarManager.swift**: Multi-profile configuration handling, observer cleanup
- **StatusBarUIManager.swift**: Stable autosave names, incremental updates
- **Notification+Extensions.swift**: New `.multiProfileConfigChanged` notification
- **ManageProfilesView.swift**: Route config changes to new notification