### PR TITLE
fix(credentials): Prevent cross-profile credential contamination

### DIFF
--- a/Claude Usage/MenuBar/MenuBarManager.swift
+++ b/Claude Usage/MenuBar/MenuBarManager.swift
@@ -1100,7 +1100,11 @@ class MenuBarManager: NSObject, ObservableObject {
         }
 
         // Priority 3: System Keychain CLI OAuth token
-        if let systemCredentials = try? ClaudeCodeSyncService.shared.readSystemCredentials(),
+        // Only use system keychain for the active profile — the keychain/credentials file
+        // reflects the currently active `claude` CLI session. Using it for a non-active
+        // profile would silently return the active profile's stats.
+        if profile.id == profileManager.activeProfile?.id,
+           let systemCredentials = try? ClaudeCodeSyncService.shared.readSystemCredentials(),
            !ClaudeCodeSyncService.shared.isTokenExpired(systemCredentials),
            let accessToken = ClaudeCodeSyncService.shared.extractAccessToken(from: systemCredentials) {
             return try await apiService.fetchUsageData(oauthAccessToken: accessToken)

--- a/Claude Usage/Shared/Services/ClaudeCodeSyncService.swift
+++ b/Claude Usage/Shared/Services/ClaudeCodeSyncService.swift
@@ -553,6 +553,16 @@ class ClaudeCodeSyncService {
         return token
     }
 
+    func extractRefreshToken(from jsonData: String) -> String? {
+        guard let data = jsonData.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let oauth = json["claudeAiOauth"] as? [String: Any],
+              let token = oauth["refreshToken"] as? String else {
+            return nil
+        }
+        return token
+    }
+
     func extractSubscriptionInfo(from jsonData: String) -> (type: String, scopes: [String])? {
         guard let data = jsonData.data(using: .utf8),
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
@@ -610,13 +620,27 @@ class ClaudeCodeSyncService {
             return
         }
 
+        // Verify the system credentials belong to the same account as this profile.
+        // The refreshToken is session-scoped and only changes on explicit /login — a
+        // mismatch means the keychain holds another account's data (written by
+        // applyProfileCredentials for a different profile). Saving would corrupt this profile.
+        var profiles = ProfileStore.shared.loadProfiles()
+        if let profile = profiles.first(where: { $0.id == profileId }),
+           let storedJSON = profile.cliCredentialsJSON {
+            let freshRefreshToken = extractRefreshToken(from: freshJSON)
+            let storedRefreshToken = extractRefreshToken(from: storedJSON)
+            if let fresh = freshRefreshToken, let stored = storedRefreshToken, fresh != stored {
+                LoggingService.shared.log("⚠️ resyncBeforeSwitching: skipping for '\(profile.name)' — system refresh token differs (different account)")
+                return
+            }
+        }
+
         // Capture latest oauthAccount too, so if the user logged in with a
         // different account since the last sync we keep the profile's
         // `.claude.json` identity in sync with its keychain credentials.
         let freshOAuthAccount = readOAuthAccount()
 
-        // Update profile's stored credentials with fresh ones
-        var profiles = ProfileStore.shared.loadProfiles()
+        // Update profile's stored credentials with fresh ones (profiles already loaded above)
         guard let index = profiles.firstIndex(where: { $0.id == profileId }) else {
             return
         }


### PR DESCRIPTION
## Description

Fixes a cross-profile credential contamination bug that caused subscriptions and
account data to get swapped between profiles when switching back and forth.

### Root Cause

The bug is a feedback loop triggered by `resyncBeforeSwitching()`:

1. Profile "Perso" somehow acquires "4SH" credentials (initial contamination)
2. Switch 4SH → Perso: `resyncBeforeSwitching(4SH)` reads personal creds from
   keychain (just overwritten by `applyProfileCredentials`) → saves them to 4SH
3. Switch Perso → 4SH: `resyncBeforeSwitching(Perso)` reads 4SH creds (now in
   keychain) → saves them to Perso again
4. The swap perpetuates on every profile switch cycle

The keychain is the shared mutable state: `applyProfileCredentials` writes the
incoming profile's credentials there, and if `resyncBeforeSwitching` runs
afterwards for the outgoing profile, it blindly reads whatever is in the keychain
and saves it — regardless of whether those credentials belong to that profile.

A second contributing factor: when `~/.claude/.credentials.json` is invalid or
missing, `readSystemCredentials()` falls back to the system keychain, which is
writable by `applyProfileCredentials`. This makes the file-based fallback path
susceptible to the same contamination.

There was also a separate visible symptom: non-active profiles without their own
`claudeSessionKey` or `cliCredentialsJSON` were silently falling through to the
system keychain Priority 3 fallback in `fetchUsageForProfile()`, displaying the
active profile's stats instead of raising an error.

## Changes

- **`ClaudeCodeSyncService.swift`**: Add `extractRefreshToken(from:)` helper
  (mirrors existing `extractAccessToken`). In `resyncBeforeSwitching()`, compare
  the system refresh token against the stored profile refresh token before saving;
  if they differ, the keychain holds another account's data — skip the update.
  The `refreshToken` is session-scoped and only changes on explicit `/login`, so
  a mismatch is a reliable cross-account signal.

- **`MenuBarManager.swift`**: Guard the system keychain fallback path in
  `fetchUsageForProfile()` with `profile.id == profileManager.activeProfile?.id`.
  Non-active profiles without their own credentials now raise
  `AppError.sessionKeyNotFound` instead of silently returning the active
  profile's data.

- **`ClaudeCodeSyncServiceTests.swift`** *(new)*: Unit tests for
  `extractRefreshToken(from:)` and `extractAccessToken(from:)` covering valid
  JSON, missing keys, empty strings, and invalid input — ensuring the identity
  guard in `resyncBeforeSwitching` cannot silently no-op due to a wrong key path.

### Edge cases handled

| Scenario | Behaviour |
|----------|-----------|
| First sync (profile has no stored credentials) | Guard skipped → update proceeds (correct for initial setup) |
| Either JSON missing `refreshToken` | Both tokens nil → guard skipped → update proceeds (safe fallback) |
| Tokens match | Update proceeds as normal |
| Tokens differ | Update skipped with warning log |

> **Note for existing affected users**: this fix prevents future contamination
> but does not auto-repair already-swapped profiles. Users should re-sync each
> profile manually via Settings → CLI Account → Re-sync.

## Screenshots / Screen Recordings

N/A - no visual changes (internal credential-sync logic only)

## Checklist

- [x] I have tested these changes on a running build
- [x] I have attached screenshots/recordings for any visual changes
- [x] I have not introduced App Group or grouped Keychain usage
- [x] I have added localization keys for any new user-facing strings