### PR TITLE
  Fix menu bar icon reverting to default for CLI-authenticated users

### DIFF
--- a/Claude Usage/MenuBar/MenuBarManager.swift
+++ b/Claude Usage/MenuBar/MenuBarManager.swift
@@ -394,8 +394,9 @@ class MenuBarManager: NSObject, ObservableObject {
         // 4. Recreate popover with new profile data
         recreatePopover()
 
-        // 5. Trigger immediate refresh ONLY if profile has usage credentials
-        if profile.hasUsageCredentials {
+        // 5. Trigger immediate refresh if any credentials are available, including
+        // system Keychain CLI fallback used by ClaudeAPIService.
+        if hasAnyAvailableCredentials() {
             self.lastRefreshTriggerTime = Date()
             refreshUsage()
         } else {
@@ -429,8 +430,9 @@ class MenuBarManager: NSObject, ObservableObject {
             return
         }
 
-        // Check if active profile has usage credentials (not just CLI)
-        let hasUsageCredentials = profileManager.activeProfile?.hasUsageCredentials ?? false
+        // Keep configuration decisions aligned with the fetch path so users with
+        // only system Keychain CLI credentials keep their configured metric items.
+        let hasUsageCredentials = hasAnyAvailableCredentials()
 
         // If no usage credentials, use an empty config (will show default logo)
         let displayConfig: MenuBarIconConfiguration
@@ -789,8 +791,9 @@ class MenuBarManager: NSObject, ObservableObject {
             guard let self = self else { return }
 
             Task { @MainActor in
-                // Check if active profile has usage credentials
-                guard let profile = self.profileManager.activeProfile, profile.hasUsageCredentials else {
+                // Check if active profile has any credentials, including system
+                // Keychain CLI fallback.
+                guard let profile = self.profileManager.activeProfile, self.hasAnyAvailableCredentials() else {
                     LoggingService.shared.logInfo("Credentials changed but no usage credentials - showing default logo")
 
                     // Reconfigure menu bar to show default logo
@@ -1170,7 +1173,7 @@ class MenuBarManager: NSObject, ObservableObject {
     private func setupSingleProfileMode() {
         guard let profile = profileManager.activeProfile else { return }
 
-        let hasUsageCredentials = profile.hasUsageCredentials
+        let hasUsageCredentials = hasAnyAvailableCredentials()
         let config = profile.iconConfig
 
         // If no usage credentials, create empty config to show default logo

--- a/Claude Usage/MenuBar/StatusBarUIManager.swift
+++ b/Claude Usage/MenuBar/StatusBarUIManager.swift
@@ -613,9 +613,11 @@ final class StatusBarUIManager {
         let profile = ProfileManager.shared.activeProfile
         let config = profile?.iconConfig ?? .default
 
-        // Check if we should show default logo (no usage credentials OR no enabled metrics)
-        let hasUsageCredentials = profile?.hasUsageCredentials ?? false
-        if !hasUsageCredentials || config.enabledMetrics.isEmpty {
+        // Keep the render path aligned with ClaudeAPIService/MenuBarManager auth
+        // fallback logic so users authenticated only via `claude login` don't
+        // periodically repaint to the default logo after successful refreshes.
+        let hasAnyCredentials = hasAnyAvailableCredentials(for: profile)
+        if !hasAnyCredentials || config.enabledMetrics.isEmpty {
             // Show default app logo
             if let statusItem = statusItems[.session],  // We use .session as placeholder key
                let button = statusItem.button {
@@ -693,6 +695,26 @@ final class StatusBarUIManager {
 
         image.isTemplate = config.colorMode == .monochrome && !config.showPaceMarker
         button.image = image
+    }
+
+    /// Mirrors the auth fallback used for actual usage fetches so UI gating does
+    /// not disagree with the network layer.
+    private func hasAnyAvailableCredentials(for profile: Profile?) -> Bool {
+        guard let profile else { return false }
+
+        if profile.hasUsageCredentials { return true }
+
+        do {
+            if let systemCreds = try ClaudeCodeSyncService.shared.readSystemCredentials(),
+               !ClaudeCodeSyncService.shared.isTokenExpired(systemCreds),
+               ClaudeCodeSyncService.shared.extractAccessToken(from: systemCreds) != nil {
+                return true
+            }
+        } catch {
+            LoggingService.shared.log("StatusBarUIManager.hasAnyAvailableCredentials: system keychain check failed: \(error.localizedDescription)")
+        }
+
+        return false
     }
 
     /// Get button for a specific metric (used for popover positioning)


### PR DESCRIPTION
## Description

Claude Usage was successfully fetching my data and showing it in the popup, but the icon would periodically revert to default.

## Changes

Align menu bar rendering with the existing Claude fetch auth fallback. The app could successfully fetch usage via system Keychain CLI credentials from claude login, but some UI paths still treated the profile as unauthenticated and repainted the default icon. This updates the single-profile menu bar/config checks to use the same “any available credentials” logic as the fetch path, so custom icon styles like “icon with bar” persist correctly.

## Screenshots / Screen Recordings

Example of the problem:

<img width="316" height="271" alt="Image" src="https://github.com/user-attachments/assets/ac0640f3-8276-44e1-81aa-d7d5c1676670" />

## Checklist

- [x] I have tested these changes on a running build
- [x] I have attached screenshots/recordings for any visual changes
- [x] I have not introduced App Group or grouped Keychain usage
- [x] I have added localization keys for any new user-facing strings
