### PR TITLE
fix(menubar): avoid NSImage.tiffRepresentation crash on macOS 26 SDK

### DIFF
--- a/Claude Usage/MenuBar/StatusBarUIManager.swift
+++ b/Claude Usage/MenuBar/StatusBarUIManager.swift
@@ -749,7 +749,10 @@ final class StatusBarUIManager {
     /// This prevents triggering effectiveAppearance KVO when the image is identical.
     private func setButtonImage(_ button: NSStatusBarButton, image: NSImage) {
         let buttonId = ObjectIdentifier(button)
-        guard let newData = image.tiffRepresentation else {
+        // Avoid NSImage.tiffRepresentation: macOS 26 SDK crashes in
+        // SetupTIFFErrorHandler dispatch_once. Hash via CGImage bytes instead.
+        guard let cg = image.cgImage(forProposedRect: nil, context: nil, hints: nil),
+              let newData = cg.dataProvider?.data as Data? else {
             button.image = image
             return
         }


### PR DESCRIPTION
## Summary

The menu bar app crashes intermittently on macOS 26 inside `SetupTIFFErrorHandler`'s `dispatch_once`, triggered by `NSImage.tiffRepresentation` in `StatusBarUIManager.setButtonImage(_:image:)`. That call is only used to compute an equality hash so we can skip redundant `button.image =` assignments (which would otherwise wake `effectiveAppearance` KVO).

This PR replaces the TIFF-based hash with `CGImage` data-provider bytes — same purpose, same guard, no TIFF code path.

## Changes

- `Claude Usage/MenuBar/StatusBarUIManager.swift`: hash via `image.cgImage(forProposedRect:context:nil, hints:nil)?.dataProvider?.data` instead of `image.tiffRepresentation`.

## Why this is safe

- Functionally equivalent: identical renders produce identical CGImage bytes, so the no-op-redraw optimization still fires.
- Pre-macOS 26 SDKs are unaffected — `cgImage(forProposedRect:...)` has been the documented bridge between `NSImage` and `CGImage` for years.
- No public API or behavior change beyond avoiding the buggy SDK code path.

## Test plan

- [x] Built locally against current Xcode toolchain (macOS 26 SDK), app launches and the menu bar icon refreshes without the previous intermittent crash.
- [x] Verify on macOS 14/15 hosts that icon refresh still works (no regression).
- [x] Confirm idle-redraw suppression still works (icon doesn't flicker on identical renders).