### PR TITLE
feat: personal & organization spend limits, Routine Runs budget

### DIFF
--- a/Claude Usage/MenuBar/MenuBarIconRenderer.swift
+++ b/Claude Usage/MenuBar/MenuBarIconRenderer.swift
@@ -254,7 +254,69 @@ final class MenuBarIconRenderer {
                 statusLevel: statusLevel,
                 sessionResetTime: nil
             )
+
+        case .personalLimit:
+            return budgetMetricData(used: usage.costUsed, limit: usage.costLimit, showRemaining: showRemaining)
+
+        case .organizationLimit:
+            return budgetMetricData(used: usage.organizationCostUsed, limit: usage.organizationCostLimit, showRemaining: showRemaining)
+
+        case .routineRuns:
+            guard let used = usage.routineRunsUsed,
+                  let limit = usage.routineRunsLimit,
+                  limit > 0 else {
+                return MetricData(
+                    percentage: showRemaining ? 100 : 0,
+                    displayText: "N/A",
+                    statusLevel: .safe,
+                    sessionResetTime: nil
+                )
+            }
+            let usedPercentage = Double(used) / Double(limit) * 100.0
+            let displayPercentage = UsageStatusCalculator.getDisplayPercentage(
+                usedPercentage: usedPercentage,
+                showRemaining: showRemaining
+            )
+            let statusLevel = UsageStatusCalculator.calculateStatus(
+                usedPercentage: usedPercentage,
+                showRemaining: showRemaining
+            )
+            // Routine runs are discrete units, so show count rather than %
+            let displayText = showRemaining ? "\(max(0, limit - used))" : "\(used)/\(limit)"
+            return MetricData(
+                percentage: displayPercentage,
+                displayText: displayText,
+                statusLevel: statusLevel,
+                sessionResetTime: nil
+            )
         }
+    }
+
+    /// Builds MetricData for a currency-based budget metric (personal or team).
+    private func budgetMetricData(used: Double?, limit: Double?, showRemaining: Bool) -> MetricData {
+        guard let used = used, let limit = limit, limit > 0 else {
+            return MetricData(
+                percentage: showRemaining ? 100 : 0,
+                displayText: "N/A",
+                statusLevel: .safe,
+                sessionResetTime: nil
+            )
+        }
+        let usedPercentage = (used / limit) * 100.0
+        let displayPercentage = UsageStatusCalculator.getDisplayPercentage(
+            usedPercentage: usedPercentage,
+            showRemaining: showRemaining
+        )
+        let statusLevel = UsageStatusCalculator.calculateStatus(
+            usedPercentage: usedPercentage,
+            showRemaining: showRemaining
+        )
+        return MetricData(
+            percentage: displayPercentage,
+            displayText: "\(Int(displayPercentage))%",
+            statusLevel: statusLevel,
+            sessionResetTime: nil
+        )
     }
 
     // MARK: - Icon Style Renderers
@@ -351,8 +413,17 @@ final class MenuBarIconRenderer {
                 text = resetTime.timeRemainingHoursString() as NSString
             }
         } else if showIconName {
-            // Show full word: "Session" or "Week"
-            text = (metricType == .session ? "Session" : "Week") as NSString
+            // Time-based metrics show their period name; monthly-resetting metrics show the next renewal date
+            switch metricType {
+            case .session:
+                text = "Session" as NSString
+            case .week:
+                text = "Week" as NSString
+            case .api:
+                text = "API" as NSString
+            case .personalLimit, .organizationLimit, .routineRuns:
+                text = Date().firstOfNextMonth().shortMonthDayString() as NSString
+            }
         } else {
             // No label mode - show percentage instead
             text = "\(Int(metricData.percentage))%" as NSString
@@ -405,7 +476,7 @@ final class MenuBarIconRenderer {
                 .font: NSFont.systemFont(ofSize: 10, weight: .semibold),
                 .foregroundColor: textColor.withAlphaComponent(0.9)
             ]
-            let label = (metricType == .session ? "S" : "W") as NSString
+            let label = metricType.shortLabel as NSString
             let labelSize = label.size(withAttributes: labelAttributes)
             label.draw(
                 at: NSPoint(x: xOffset, y: (height - labelSize.height) / 2),
@@ -609,7 +680,7 @@ final class MenuBarIconRenderer {
                 .font: NSFont.systemFont(ofSize: 9, weight: .bold),
                 .foregroundColor: textColor
             ]
-            let label = (metricType == .session ? "S" : "W") as NSString
+            let label = metricType.shortLabel as NSString
             let labelSize = label.size(withAttributes: labelAttributes)
             let labelX = center.x - labelSize.width / 2
             let labelY = center.y - labelSize.height / 2
@@ -1403,7 +1474,8 @@ final class MenuBarIconRenderer {
         case .week:
             resetTime = usage.weeklyResetTime
             duration = Constants.weeklyWindow
-        case .api:
+        case .api, .personalLimit, .organizationLimit, .routineRuns:
+            // No elapsed-time tick: monthly reset timestamps aren't surfaced in ClaudeUsage
             return nil
         }
 

--- a/Claude Usage/MenuBar/PopoverContentView.swift
+++ b/Claude Usage/MenuBar/PopoverContentView.swift
@@ -585,35 +585,39 @@ struct SmartUsageDashboard: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
-            // Primary: Session Usage
-            UsageRow(
-                title: "menubar.session_usage".localized,
-                subtitle: "menubar.5_hour_window".localized,
-                usedPercentage: usage.effectiveSessionPercentage,
-                showRemaining: showRemainingPercentage,
-                resetTime: usage.sessionResetTime,
-                periodDuration: Constants.sessionWindow,
-                showTimeMarker: showTimeMarker,
-                showPaceMarker: showPaceMarker,
-                usePaceColoring: usePaceColoring,
-                timeDisplay: timeDisplay,
-                isPeakHighlighted: isPeakHours
-            )
+            // Primary: Session Usage (hidden when account has no session limit)
+            if usage.sessionLimit > 0 {
+                UsageRow(
+                    title: "menubar.session_usage".localized,
+                    subtitle: "menubar.5_hour_window".localized,
+                    usedPercentage: usage.effectiveSessionPercentage,
+                    showRemaining: showRemainingPercentage,
+                    resetTime: usage.sessionResetTime,
+                    periodDuration: Constants.sessionWindow,
+                    showTimeMarker: showTimeMarker,
+                    showPaceMarker: showPaceMarker,
+                    usePaceColoring: usePaceColoring,
+                    timeDisplay: timeDisplay,
+                    isPeakHighlighted: isPeakHours
+                )
+            }
 
-            // All Models (Weekly)
-            UsageRow(
-                title: "menubar.all_models".localized,
-                tag: "menubar.weekly".localized,
-                subtitle: nil,
-                usedPercentage: usage.weeklyPercentage,
-                showRemaining: showRemainingPercentage,
-                resetTime: usage.weeklyResetTime,
-                periodDuration: Constants.weeklyWindow,
-                showTimeMarker: showTimeMarker,
-                showPaceMarker: showPaceMarker,
-                usePaceColoring: usePaceColoring,
-                timeDisplay: timeDisplay
-            )
+            // All Models (Weekly) — hidden when account has no weekly limit
+            if usage.weeklyLimit > 0 {
+                UsageRow(
+                    title: "menubar.all_models".localized,
+                    tag: "menubar.weekly".localized,
+                    subtitle: nil,
+                    usedPercentage: usage.weeklyPercentage,
+                    showRemaining: showRemainingPercentage,
+                    resetTime: usage.weeklyResetTime,
+                    periodDuration: Constants.weeklyWindow,
+                    showTimeMarker: showTimeMarker,
+                    showPaceMarker: showPaceMarker,
+                    usePaceColoring: usePaceColoring,
+                    timeDisplay: timeDisplay
+                )
+            }
 
             if usage.opusWeeklyTokensUsed > 0 {
                 UsageRow(
@@ -639,11 +643,11 @@ struct SmartUsageDashboard: View {
                 )
             }
 
-            // Extra usage (cost-based)
+            // Personal monthly budget — user's cap on extra-usage spending within the team pool
             if let used = usage.costUsed, let limit = usage.costLimit, let currency = usage.costCurrency, limit > 0 {
                 let usedPercentage = (used / limit) * 100.0
                 UsageRow(
-                    title: "menubar.extra_usage".localized,
+                    title: "menubar.personal_limit".localized,
                     subtitle: String(format: "%.2f / %.2f %@", used / 100.0, limit / 100.0, currency),
                     usedPercentage: usedPercentage,
                     showRemaining: showRemainingPercentage,
@@ -663,6 +667,56 @@ struct SmartUsageDashboard: View {
                             .foregroundColor(.adaptiveGreen)
                     }
                 }
+            }
+
+            // Organization-level extra usage — the shared org pool everyone consumes from
+            if let orgUsed = usage.organizationCostUsed,
+               let orgLimit = usage.organizationCostLimit,
+               let orgCurrency = usage.organizationCostCurrency,
+               orgLimit > 0 {
+                let label = "menubar.organization_limit".localized
+                let title = usage.organizationName.map { "\($0) — \(label)" } ?? label
+                UsageRow(
+                    title: title,
+                    subtitle: String(format: "%.2f / %.2f %@", orgUsed / 100.0, orgLimit / 100.0, orgCurrency),
+                    usedPercentage: (orgUsed / orgLimit) * 100.0,
+                    showRemaining: showRemainingPercentage,
+                    resetTime: nil,
+                    periodDuration: nil
+                )
+            }
+
+            // CCR Routine Runs monthly count
+            if let runsUsed = usage.routineRunsUsed,
+               let runsLimit = usage.routineRunsLimit,
+               runsLimit > 0 {
+                let usedPercentage = Double(runsUsed) / Double(runsLimit) * 100.0
+                UsageRow(
+                    title: "menubar.routine_runs".localized,
+                    subtitle: "\(runsUsed) / \(runsLimit) runs",
+                    usedPercentage: usedPercentage,
+                    showRemaining: showRemainingPercentage,
+                    resetTime: nil,
+                    periodDuration: nil
+                )
+            }
+
+            // Disabled-budget chip — shown when the account's budget has been suspended
+            if let disabledReason = usage.budgetDisabledReason {
+                HStack(spacing: 6) {
+                    Image(systemName: "exclamationmark.circle.fill")
+                        .foregroundColor(.red)
+                    Text(disabledReason == "out_of_credits"
+                         ? "Budget disabled: out of credits"
+                         : "Budget disabled: \(disabledReason)")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(Color.red.opacity(0.1))
+                .cornerRadius(6)
+                .accessibilityIdentifier("budgetDisabledChip")
             }
 
             // API Usage

--- a/Claude Usage/Resources/de.lproj/Localizable.strings
+++ b/Claude Usage/Resources/de.lproj/Localizable.strings
@@ -62,6 +62,9 @@
 "menubar.opus_usage" = "Opus";
 "menubar.sonnet_usage" = "Sonnet";
 "menubar.extra_usage" = "Zusätzliche Nutzung";
+"menubar.personal_limit" = "Persönliches Limit";
+"menubar.organization_limit" = "Organisations-Limit";
+"menubar.routine_runs" = "CCR Budget";
 "menubar.api_credits" = "API-Guthaben";
 "menubar.5_hour_window" = "5-Stunden-Gleitfenster";
 "menubar.all_models" = "Alle Modelle";
@@ -351,6 +354,8 @@
 "claudecode.component_weekly_description" = "Wöchentliche Token-Nutzung mit Balken und Rücksetzzeit";
 "claudecode.component_extra_usage" = "Zusätzliche Nutzung anzeigen";
 "claudecode.component_extra_usage_description" = "Kostenanzeige (z.B. 9,49 USD)";
+"claudecode.component_routine_runs" = "CCR-Budget anzeigen";
+"claudecode.component_routine_runs_description" = "Persönliches monatliches Claude Code Routines Budget";
 "claudecode.weekly_label" = "\"Weekly:\"-Label anzeigen";
 "claudecode.requirement_sessionkey" = "• Sitzungsschlüssel im Tab 'Anmeldedaten → Claude.ai' konfiguriert";
 "claudecode.requirement_restart" = "• Claude CLI nach Anwendung der Änderungen neu starten";

--- a/Claude Usage/Resources/en.lproj/Localizable.strings
+++ b/Claude Usage/Resources/en.lproj/Localizable.strings
@@ -62,6 +62,9 @@
 "menubar.opus_usage" = "Opus";
 "menubar.sonnet_usage" = "Sonnet";
 "menubar.extra_usage" = "Extra Usage";
+"menubar.personal_limit" = "Personal Limit";
+"menubar.organization_limit" = "Organization Limit";
+"menubar.routine_runs" = "Routine Runs";
 "menubar.api_credits" = "API Credits";
 "menubar.api_cost" = "API Cost";
 "menubar.this_month" = "This Month";
@@ -372,6 +375,8 @@
 "claudecode.component_weekly_description" = "Weekly token usage with bar and reset time";
 "claudecode.component_extra_usage" = "Show Extra Usage";
 "claudecode.component_extra_usage_description" = "Cost indicator (e.g., 9.49 USD)";
+"claudecode.component_routine_runs" = "Show Routine Runs";
+"claudecode.component_routine_runs_description" = "Monthly Claude Code Routines run count";
 "claudecode.weekly_label" = "Show \"Weekly:\" label";
 "claudecode.requirement_sessionkey" = "• Session key configured in Credentials → Claude.ai tab";
 "claudecode.requirement_restart" = "• Restart Claude CLI after applying changes";

--- a/Claude Usage/Resources/es.lproj/Localizable.strings
+++ b/Claude Usage/Resources/es.lproj/Localizable.strings
@@ -62,6 +62,9 @@
 "menubar.opus_usage" = "Opus";
 "menubar.sonnet_usage" = "Sonnet";
 "menubar.extra_usage" = "Uso Extra";
+"menubar.personal_limit" = "Límite Personal";
+"menubar.organization_limit" = "Límite de la Organización";
+"menubar.routine_runs" = "Presupuesto CCR";
 "menubar.api_credits" = "Créditos API";
 "menubar.5_hour_window" = "Ventana móvil de 5 horas";
 "menubar.all_models" = "Todos los modelos";
@@ -350,6 +353,8 @@
 "claudecode.component_weekly_description" = "Uso semanal de tokens con barra y tiempo de reinicio";
 "claudecode.component_extra_usage" = "Mostrar uso extra";
 "claudecode.component_extra_usage_description" = "Indicador de costo (ej., 9.49 USD)";
+"claudecode.component_routine_runs" = "Mostrar presupuesto CCR";
+"claudecode.component_routine_runs_description" = "Presupuesto mensual personal de Claude Code Routines";
 "claudecode.weekly_label" = "Mostrar etiqueta \"Weekly:\"";
 "claudecode.requirement_sessionkey" = "• Clave de sesión configurada en Credenciales → pestaña Claude.ai";
 "claudecode.requirement_restart" = "• Reiniciar Claude CLI después de aplicar cambios";

--- a/Claude Usage/Resources/fr.lproj/Localizable.strings
+++ b/Claude Usage/Resources/fr.lproj/Localizable.strings
@@ -62,6 +62,9 @@
 "menubar.opus_usage" = "Opus";
 "menubar.sonnet_usage" = "Sonnet";
 "menubar.extra_usage" = "Utilisation Supplémentaire";
+"menubar.personal_limit" = "Limite Personnelle";
+"menubar.organization_limit" = "Limite de l'Organisation";
+"menubar.routine_runs" = "Budget CCR";
 "menubar.api_credits" = "Crédits API";
 "menubar.5_hour_window" = "Fenêtre glissante de 5 heures";
 "menubar.all_models" = "Tous les modèles";
@@ -347,6 +350,8 @@
 "claudecode.component_weekly_description" = "Utilisation hebdomadaire de tokens avec barre et temps de réinitialisation";
 "claudecode.component_extra_usage" = "Afficher l'utilisation supplémentaire";
 "claudecode.component_extra_usage_description" = "Indicateur de coût (ex., 9,49 USD)";
+"claudecode.component_routine_runs" = "Afficher le budget CCR";
+"claudecode.component_routine_runs_description" = "Budget mensuel personnel des routines Claude Code";
 "claudecode.weekly_label" = "Afficher le libellé \"Weekly:\"";
 "claudecode.requirement_sessionkey" = "• Clé de session configurée dans Identifiants → onglet Claude.ai";
 "claudecode.requirement_restart" = "• Redémarrez Claude CLI après l'application des modifications";

--- a/Claude Usage/Resources/it.lproj/Localizable.strings
+++ b/Claude Usage/Resources/it.lproj/Localizable.strings
@@ -60,6 +60,9 @@
 "menubar.opus_usage" = "Opus";
 "menubar.sonnet_usage" = "Sonnet";
 "menubar.extra_usage" = "Utilizzo Extra";
+"menubar.personal_limit" = "Limite Personale";
+"menubar.organization_limit" = "Limite dell'Organizzazione";
+"menubar.routine_runs" = "Budget CCR";
 "menubar.api_credits" = "Crediti API";
 "menubar.5_hour_window" = "finestra mobile di 5 ore";
 "menubar.all_models" = "Tutti i modelli";
@@ -349,6 +352,8 @@
 "claudecode.component_weekly_description" = "Utilizzo settimanale token con barra e tempo di ripristino";
 "claudecode.component_extra_usage" = "Mostra utilizzo extra";
 "claudecode.component_extra_usage_description" = "Indicatore di costo (es., 9,49 USD)";
+"claudecode.component_routine_runs" = "Mostra budget CCR";
+"claudecode.component_routine_runs_description" = "Budget mensile personale di Claude Code Routines";
 "claudecode.weekly_label" = "Mostra etichetta \"Weekly:\"";
 "claudecode.requirement_sessionkey" = "• Chiave di sessione configurata in Credenziali → scheda Claude.ai";
 "claudecode.requirement_restart" = "• Riavvia Claude CLI dopo aver applicato le modifiche";

--- a/Claude Usage/Resources/ja.lproj/Localizable.strings
+++ b/Claude Usage/Resources/ja.lproj/Localizable.strings
@@ -62,6 +62,9 @@
 "menubar.opus_usage" = "Opus";
 "menubar.sonnet_usage" = "Sonnet";
 "menubar.extra_usage" = "追加使用";
+"menubar.personal_limit" = "個人制限";
+"menubar.organization_limit" = "組織制限";
+"menubar.routine_runs" = "CCR予算";
 "menubar.api_credits" = "APIクレジット";
 "menubar.5_hour_window" = "5時間ローリングウィンドウ";
 "menubar.all_models" = "すべてのモデル";
@@ -365,6 +368,8 @@
 "claudecode.component_weekly_description" = "バーとリセット時間付きの週間トークン使用量";
 "claudecode.component_extra_usage" = "追加使用量を表示";
 "claudecode.component_extra_usage_description" = "コスト表示（例: 9.49 USD）";
+"claudecode.component_routine_runs" = "CCR予算を表示";
+"claudecode.component_routine_runs_description" = "個人のClaude Code Routines月次予算";
 "claudecode.weekly_label" = "\"Weekly:\" ラベルを表示";
 "claudecode.requirement_sessionkey" = "• 認証情報 → Claude.aiタブでセッションキーが構成されている";
 "claudecode.requirement_restart" = "• 変更適用後にClaude CLIを再起動";

--- a/Claude Usage/Resources/ko.lproj/Localizable.strings
+++ b/Claude Usage/Resources/ko.lproj/Localizable.strings
@@ -71,6 +71,9 @@
 "menubar.opus_usage" = "Opus";
 "menubar.sonnet_usage" = "Sonnet";
 "menubar.extra_usage" = "추가 사용량";
+"menubar.personal_limit" = "개인 한도";
+"menubar.organization_limit" = "조직 한도";
+"menubar.routine_runs" = "CCR 예산";
 "menubar.api_credits" = "API 크레딧";
 "menubar.5_hour_window" = "5시간 롤링 윈도우";
 "menubar.all_models" = "모든 모델";
@@ -522,6 +525,8 @@
 "claudecode.component_weekly_description" = "막대 및 초기화 시간이 포함된 주간 토큰 사용량";
 "claudecode.component_extra_usage" = "추가 사용량 표시";
 "claudecode.component_extra_usage_description" = "비용 표시 (예: 9.49 USD)";
+"claudecode.component_routine_runs" = "CCR 예산 표시";
+"claudecode.component_routine_runs_description" = "개인 Claude Code Routines 월별 예산";
 "claudecode.weekly_label" = "\"Weekly:\" 라벨 표시";
 "claudecode.requirement_sessionkey" = "• 자격 증명 → Claude.ai 탭에서 세션 키 구성됨";
 "claudecode.requirement_restart" = "• 변경사항 적용 후 Claude CLI 재시작";

--- a/Claude Usage/Resources/pt-BR.lproj/Localizable.strings
+++ b/Claude Usage/Resources/pt-BR.lproj/Localizable.strings
@@ -60,6 +60,9 @@
 "menubar.opus_usage" = "Opus";
 "menubar.sonnet_usage" = "Sonnet";
 "menubar.extra_usage" = "Uso Extra";
+"menubar.personal_limit" = "Limite Pessoal";
+"menubar.organization_limit" = "Limite da Organização";
+"menubar.routine_runs" = "Orçamento CCR";
 "menubar.api_credits" = "Créditos da API";
 "menubar.5_hour_window" = "Janela móvel de 5 horas";
 "menubar.all_models" = "Todos os modelos";
@@ -349,6 +352,8 @@
 "claudecode.component_weekly_description" = "Uso semanal de tokens com barra e tempo de reinício";
 "claudecode.component_extra_usage" = "Mostrar uso extra";
 "claudecode.component_extra_usage_description" = "Indicador de custo (ex., 9,49 USD)";
+"claudecode.component_routine_runs" = "Exibir orçamento CCR";
+"claudecode.component_routine_runs_description" = "Orçamento mensal pessoal do Claude Code Routines";
 "claudecode.weekly_label" = "Mostrar rótulo \"Weekly:\"";
 "claudecode.requirement_sessionkey" = "• Chave de sessão configurada em Credenciais → aba Claude.ai";
 "claudecode.requirement_restart" = "• Reiniciar Claude CLI após aplicar as alterações";

--- a/Claude Usage/Resources/pt.lproj/Localizable.strings
+++ b/Claude Usage/Resources/pt.lproj/Localizable.strings
@@ -60,6 +60,9 @@
 "menubar.opus_usage" = "Opus";
 "menubar.sonnet_usage" = "Sonnet";
 "menubar.extra_usage" = "Uso Extra";
+"menubar.personal_limit" = "Limite Pessoal";
+"menubar.organization_limit" = "Limite da Organização";
+"menubar.routine_runs" = "Orçamento CCR";
 "menubar.api_credits" = "Créditos da API";
 "menubar.5_hour_window" = "Janela móvel de 5 horas";
 "menubar.all_models" = "Todos os modelos";
@@ -349,6 +352,8 @@
 "claudecode.component_weekly_description" = "Uso semanal de tokens com barra e tempo de reinício";
 "claudecode.component_extra_usage" = "Mostrar uso extra";
 "claudecode.component_extra_usage_description" = "Indicador de custo (ex., 9,49 USD)";
+"claudecode.component_routine_runs" = "Mostrar orçamento CCR";
+"claudecode.component_routine_runs_description" = "Orçamento mensal pessoal do Claude Code Routines";
 "claudecode.weekly_label" = "Mostrar rótulo \"Weekly:\"";
 "claudecode.requirement_sessionkey" = "• Chave de sessão configurada em Credenciais → aba Claude.ai";
 "claudecode.requirement_restart" = "• Reiniciar Claude CLI após aplicar as alterações";

--- a/Claude Usage/Resources/tr.lproj/Localizable.strings
+++ b/Claude Usage/Resources/tr.lproj/Localizable.strings
@@ -62,6 +62,9 @@
 "menubar.opus_usage" = "Opus";
 "menubar.sonnet_usage" = "Sonnet";
 "menubar.extra_usage" = "Ek Kullanım";
+"menubar.personal_limit" = "Kişisel Limit";
+"menubar.organization_limit" = "Organizasyon Limiti";
+"menubar.routine_runs" = "CCR Bütçesi";
 "menubar.api_credits" = "API Kredileri";
 "menubar.api_cost" = "API Maliyeti";
 "menubar.this_month" = "Bu Ay";
@@ -372,6 +375,8 @@
 "claudecode.component_weekly_description" = "Çubuk ve sıfırlanma zamanı ile haftalık token kullanımı";
 "claudecode.component_extra_usage" = "Ekstra Kullanımı Göster";
 "claudecode.component_extra_usage_description" = "Maliyet göstergesi (ör. 9,49 USD)";
+"claudecode.component_routine_runs" = "CCR Bütçesini Göster";
+"claudecode.component_routine_runs_description" = "Kişisel Claude Code Routines aylık bütçesi";
 "claudecode.weekly_label" = "\"Haftalık:\" etiketini göster";
 "claudecode.requirement_sessionkey" = "• Kimlik Bilgileri → Claude.ai sekmesinde oturum anahtarı yapılandırılmış olmalı";
 "claudecode.requirement_restart" = "• Değişiklikleri uyguladıktan sonra Claude CLI'ı yeniden başlatın";

--- a/Claude Usage/Resources/uk.lproj/Localizable.strings
+++ b/Claude Usage/Resources/uk.lproj/Localizable.strings
@@ -62,6 +62,9 @@
 "menubar.opus_usage" = "Opus";
 "menubar.sonnet_usage" = "Sonnet";
 "menubar.extra_usage" = "Додаткове використання";
+"menubar.personal_limit" = "Особистий ліміт";
+"menubar.organization_limit" = "Ліміт організації";
+"menubar.routine_runs" = "Бюджет CCR";
 "menubar.api_credits" = "Кредити API";
 "menubar.api_cost" = "Вартість API";
 "menubar.this_month" = "Цього місяця";
@@ -372,6 +375,8 @@
 "claudecode.component_weekly_description" = "Тижневе використання токенів з баром та часом скидання";
 "claudecode.component_extra_usage" = "Показати додаткове використання";
 "claudecode.component_extra_usage_description" = "Індикатор вартості (напр., 9,49 USD)";
+"claudecode.component_routine_runs" = "Показати бюджет CCR";
+"claudecode.component_routine_runs_description" = "Особистий місячний бюджет Claude Code Routines";
 "claudecode.weekly_label" = "Показати мітку \"Weekly:\"";
 "claudecode.requirement_sessionkey" = "• Ключ сесії налаштовано в Облікові дані → вкладка Claude.ai";
 "claudecode.requirement_restart" = "• Перезапустіть Claude CLI після застосування змін";

--- a/Claude Usage/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Claude Usage/Resources/zh-Hant.lproj/Localizable.strings
@@ -63,6 +63,9 @@
 "menubar.opus_usage" = "Opus";
 "menubar.sonnet_usage" = "Sonnet";
 "menubar.extra_usage" = "額外使用量";
+"menubar.personal_limit" = "個人限額";
+"menubar.organization_limit" = "組織限額";
+"menubar.routine_runs" = "CCR 預算";
 "menubar.api_credits" = "API 額度";
 "menubar.5_hour_window" = "5 小時滑動視窗";
 "menubar.all_models" = "所有模型";
@@ -373,6 +376,8 @@
 "claudecode.component_weekly_description" = "帶進度條和重置時間的每週 token 使用量";
 "claudecode.component_extra_usage" = "顯示額外使用量";
 "claudecode.component_extra_usage_description" = "費用指標（例如 9.49 USD）";
+"claudecode.component_routine_runs" = "顯示 CCR 預算";
+"claudecode.component_routine_runs_description" = "個人 Claude Code Routines 月度預算";
 "claudecode.weekly_label" = "顯示 \"Weekly:\" 標籤";
 "claudecode.requirement_sessionkey" = "• 在憑證 → Claude.ai 分頁中設定了 Session 金鑰";
 "claudecode.requirement_restart" = "• 套用變更後重新啟動 Claude CLI";

--- a/Claude Usage/Resources/zh-ch.lproj/Localizable.strings
+++ b/Claude Usage/Resources/zh-ch.lproj/Localizable.strings
@@ -63,6 +63,9 @@
 "menubar.opus_usage" = "Opus";
 "menubar.sonnet_usage" = "Sonnet";
 "menubar.extra_usage" = "额外使用量";
+"menubar.personal_limit" = "个人限额";
+"menubar.organization_limit" = "组织限额";
+"menubar.routine_runs" = "CCR 预算";
 "menubar.api_credits" = "API 积分";
 "menubar.5_hour_window" = "5小时滚动窗口";
 "menubar.all_models" = "所有模型";
@@ -373,6 +376,8 @@
 "claudecode.component_weekly_description" = "带进度条和重置时间的每周令牌使用量";
 "claudecode.component_extra_usage" = "显示额外使用量";
 "claudecode.component_extra_usage_description" = "费用指标（例如 9.49 USD）";
+"claudecode.component_routine_runs" = "显示 CCR 预算";
+"claudecode.component_routine_runs_description" = "个人 Claude Code Routines 月度预算";
 "claudecode.weekly_label" = "显示 \"Weekly:\" 标签";
 "claudecode.requirement_sessionkey" = "• 在凭据 → Claude.ai 标签页中配置了会话密钥";
 "claudecode.requirement_restart" = "• 应用更改后重启 Claude CLI";

--- a/Claude Usage/Shared/Extensions/Date+Extensions.swift
+++ b/Claude Usage/Shared/Extensions/Date+Extensions.swift
@@ -1,6 +1,27 @@
 import Foundation
 
 extension Date {
+    /// Returns the first day of next month at 00:00 (typical monthly billing renewal)
+    func firstOfNextMonth(in timezone: TimeZone = .current) -> Date {
+        var calendar = Calendar.current
+        calendar.timeZone = timezone
+        var components = calendar.dateComponents([.year, .month], from: self)
+        components.month = (components.month ?? 1) + 1
+        components.day = 1
+        components.hour = 0
+        components.minute = 0
+        components.second = 0
+        return calendar.date(from: components) ?? self
+    }
+
+    /// Formats a date as a short month + day label (e.g. "Jun 1")
+    func shortMonthDayString(in timezone: TimeZone = .current) -> String {
+        let formatter = DateFormatter()
+        formatter.timeZone = timezone
+        formatter.dateFormat = "MMM d"
+        return formatter.string(from: self)
+    }
+
     /// Returns the next Monday at 12:59pm in the specified timezone
     func nextMonday1259pm(in timezone: TimeZone = .current) -> Date {
         var calendar = Calendar.current

--- a/Claude Usage/Shared/Models/ClaudeUsage.swift
+++ b/Claude Usage/Shared/Models/ClaudeUsage.swift
@@ -28,14 +28,30 @@ struct ClaudeUsage: Codable, Equatable {
     var sonnetWeeklyPercentage: Double
     var sonnetWeeklyResetTime: Date?
 
-    // Extra usage data
+    // Personal monthly budget cap (extra_usage from /usage)
     var costUsed: Double?
     var costLimit: Double?
     var costCurrency: String?
+    var costUtilization: Double? = nil   // derived from extra_usage.utilization
+
+    // Organization-level extra usage pool (overage_spend_limit fetched without account_uuid)
+    var organizationCostUsed: Double? = nil
+    var organizationCostLimit: Double? = nil
+    var organizationCostCurrency: String? = nil
+    var organizationName: String? = nil
 
     // Overage credit grant balance
     var overageBalance: Double?
     var overageBalanceCurrency: String?
+
+    // Budget disabled state — from overage_spend_limit disabledReason / outOfCredits
+    var budgetDisabledReason: String? = nil
+
+    // CCR Routine Runs — from GET https://claude.ai/v1/code/routines/run-budget
+    // Units: integer count of runs (e.g. 3 used out of 25 allowed)
+    // Distinct from org-level overage cost (costUsed/costLimit from overage_spend_limit)
+    var routineRunsUsed: Int? = nil
+    var routineRunsLimit: Int? = nil
 
     // Metadata
     var lastUpdated: Date
@@ -83,8 +99,12 @@ struct ClaudeUsage: Codable, Equatable {
             costUsed: nil,
             costLimit: nil,
             costCurrency: nil,
+            costUtilization: nil,
             overageBalance: nil,
             overageBalanceCurrency: nil,
+            budgetDisabledReason: nil,
+            routineRunsUsed: nil,
+            routineRunsLimit: nil,
             lastUpdated: Date(),
             userTimezone: .current
         )

--- a/Claude Usage/Shared/Models/MenuBarIconConfig.swift
+++ b/Claude Usage/Shared/Models/MenuBarIconConfig.swift
@@ -12,6 +12,9 @@ enum MenuBarMetricType: String, Codable, CaseIterable, Identifiable {
     case session
     case week
     case api
+    case personalLimit
+    case organizationLimit
+    case routineRuns
 
     var id: String { rawValue }
 
@@ -23,6 +26,12 @@ enum MenuBarMetricType: String, Codable, CaseIterable, Identifiable {
             return "Week Usage"
         case .api:
             return "API Credits"
+        case .personalLimit:
+            return "Personal Limit"
+        case .organizationLimit:
+            return "Organization Limit"
+        case .routineRuns:
+            return "Routine Runs"
         }
     }
 
@@ -34,6 +43,30 @@ enum MenuBarMetricType: String, Codable, CaseIterable, Identifiable {
             return "W:"
         case .api:
             return "API:"
+        case .personalLimit:
+            return "P:"
+        case .organizationLimit:
+            return "O:"
+        case .routineRuns:
+            return "R:"
+        }
+    }
+
+    /// Short single-character label used in compact icon styles
+    var shortLabel: String {
+        switch self {
+        case .session:
+            return "S"
+        case .week:
+            return "W"
+        case .api:
+            return "$"
+        case .personalLimit:
+            return "P"
+        case .organizationLimit:
+            return "O"
+        case .routineRuns:
+            return "R"
         }
     }
 
@@ -45,6 +78,12 @@ enum MenuBarMetricType: String, Codable, CaseIterable, Identifiable {
             return "Weekly token usage (all models)"
         case .api:
             return "API Console billing credits"
+        case .personalLimit:
+            return "Your personal monthly spend limit"
+        case .organizationLimit:
+            return "Organization-wide monthly spend limit"
+        case .routineRuns:
+            return "Claude Code Routines monthly runs"
         }
     }
 
@@ -56,6 +95,12 @@ enum MenuBarMetricType: String, Codable, CaseIterable, Identifiable {
             return "calendar.badge.clock"
         case .api:
             return "dollarsign.circle.fill"
+        case .personalLimit:
+            return "wallet.pass.fill"
+        case .organizationLimit:
+            return "person.3.fill"
+        case .routineRuns:
+            return "arrow.triangle.2.circlepath"
         }
     }
 }
@@ -219,6 +264,36 @@ struct MetricIconConfig: Codable, Equatable {
             apiDisplayMode: .remaining
         )
     }
+
+    /// Default config for Monthly Budget (disabled by default)
+    static var personalLimitDefault: MetricIconConfig {
+        MetricIconConfig(
+            metricType: .personalLimit,
+            isEnabled: false,
+            iconStyle: .battery,
+            order: 3
+        )
+    }
+
+    /// Default config for Extra Usage (team pool, disabled by default)
+    static var organizationLimitDefault: MetricIconConfig {
+        MetricIconConfig(
+            metricType: .organizationLimit,
+            isEnabled: false,
+            iconStyle: .battery,
+            order: 4
+        )
+    }
+
+    /// Default config for Routine Runs (disabled by default)
+    static var routineRunsDefault: MetricIconConfig {
+        MetricIconConfig(
+            metricType: .routineRuns,
+            isEnabled: false,
+            iconStyle: .battery,
+            order: 5
+        )
+    }
 }
 
 /// Icon style for multi-profile display
@@ -369,11 +444,7 @@ struct MenuBarIconConfiguration: Codable, Equatable {
         showTimeMarker: Bool = true,
         showPaceMarker: Bool = true,
         usePaceColoring: Bool = true,
-        metrics: [MetricIconConfig] = [
-            .sessionDefault,
-            .weekDefault,
-            .apiDefault
-        ]
+        metrics: [MetricIconConfig] = MenuBarIconConfiguration.defaultMetrics
     ) {
         self.colorMode = colorMode
         self.singleColorHex = singleColorHex
@@ -415,7 +486,13 @@ struct MenuBarIconConfiguration: Codable, Equatable {
         showTimeMarker = try container.decodeIfPresent(Bool.self, forKey: .showTimeMarker) ?? true
         showPaceMarker = try container.decodeIfPresent(Bool.self, forKey: .showPaceMarker) ?? false
         usePaceColoring = try container.decodeIfPresent(Bool.self, forKey: .usePaceColoring) ?? false
-        metrics = try container.decode([MetricIconConfig].self, forKey: .metrics)
+        var decoded = try container.decode([MetricIconConfig].self, forKey: .metrics)
+        // Backfill metric types added in later versions onto previously-saved configs
+        let present = Set(decoded.map { $0.metricType })
+        for d in MenuBarIconConfiguration.defaultMetrics where !present.contains(d.metricType) {
+            decoded.append(d)
+        }
+        metrics = decoded
     }
 
     func encode(to encoder: Encoder) throws {
@@ -454,4 +531,14 @@ struct MenuBarIconConfiguration: Codable, Equatable {
     static var `default`: MenuBarIconConfiguration {
         MenuBarIconConfiguration()
     }
+
+    /// Default metric set in display order; used by both new configs and the decoder's backfill path.
+    static let defaultMetrics: [MetricIconConfig] = [
+        .sessionDefault,
+        .weekDefault,
+        .apiDefault,
+        .personalLimitDefault,
+        .organizationLimitDefault,
+        .routineRunsDefault
+    ]
 }

--- a/Claude Usage/Shared/Models/Profile.swift
+++ b/Claude Usage/Shared/Models/Profile.swift
@@ -54,6 +54,11 @@ struct Profile: Codable, Identifiable, Equatable {
     var createdAt: Date
     var lastUsedAt: Date
 
+    /// Account UUID from the /account endpoint.
+    /// Used to scope overage_spend_limit queries. Auto-populated on first login.
+    /// Optional for backward compat — nil on existing profiles until first refresh.
+    var accountUuid: String? = nil
+
     init(
         id: UUID = UUID(),
         name: String,

--- a/Claude Usage/Shared/Models/UsageHistory.swift
+++ b/Claude Usage/Shared/Models/UsageHistory.swift
@@ -48,6 +48,14 @@ struct UsageSnapshot: Codable, Identifiable, Equatable {
     let apiPrepaidCreditsCents: Int?
     let apiCurrency: String?
 
+    // Extra usage cost snapshot (from extra_usage / overage_spend_limit)
+    let costUsed: Double?
+    let costLimit: Double?
+
+    // CCR Routine Runs count snapshot
+    let routineRunsUsed: Int?
+    let routineRunsLimit: Int?
+
     // The reset time that triggered this snapshot
     let triggeringResetTime: Date
 
@@ -66,6 +74,10 @@ struct UsageSnapshot: Codable, Identifiable, Equatable {
         apiSpendCents: Int? = nil,
         apiPrepaidCreditsCents: Int? = nil,
         apiCurrency: String? = nil,
+        costUsed: Double? = nil,
+        costLimit: Double? = nil,
+        routineRunsUsed: Int? = nil,
+        routineRunsLimit: Int? = nil,
         triggeringResetTime: Date
     ) {
         self.id = id
@@ -82,6 +94,10 @@ struct UsageSnapshot: Codable, Identifiable, Equatable {
         self.apiSpendCents = apiSpendCents
         self.apiPrepaidCreditsCents = apiPrepaidCreditsCents
         self.apiCurrency = apiCurrency
+        self.costUsed = costUsed
+        self.costLimit = costLimit
+        self.routineRunsUsed = routineRunsUsed
+        self.routineRunsLimit = routineRunsLimit
         self.triggeringResetTime = triggeringResetTime
     }
 
@@ -91,6 +107,10 @@ struct UsageSnapshot: Codable, Identifiable, Equatable {
             resetType: .sessionReset,
             sessionTokensUsed: usage.sessionTokensUsed,
             sessionPercentage: usage.sessionPercentage,
+            costUsed: usage.costUsed,
+            costLimit: usage.costLimit,
+            routineRunsUsed: usage.routineRunsUsed,
+            routineRunsLimit: usage.routineRunsLimit,
             triggeringResetTime: resetTime
         )
     }
@@ -105,6 +125,10 @@ struct UsageSnapshot: Codable, Identifiable, Equatable {
             opusWeeklyPercentage: usage.opusWeeklyPercentage,
             sonnetWeeklyTokensUsed: usage.sonnetWeeklyTokensUsed,
             sonnetWeeklyPercentage: usage.sonnetWeeklyPercentage,
+            costUsed: usage.costUsed,
+            costLimit: usage.costLimit,
+            routineRunsUsed: usage.routineRunsUsed,
+            routineRunsLimit: usage.routineRunsLimit,
             triggeringResetTime: resetTime
         )
     }

--- a/Claude Usage/Shared/Services/ClaudeAPIService+Types.swift
+++ b/Claude Usage/Shared/Services/ClaudeAPIService+Types.swift
@@ -32,16 +32,45 @@ extension ClaudeAPIService {
     }
 
     struct OverageSpendLimitResponse: Codable {
+        // Existing fields
         let monthlyCreditLimit: Double?
         let currency: String?
         let usedCredits: Double?
         let isEnabled: Bool?
 
+        // Extended fields (present when ?account_uuid=<uuid> query param is supplied)
+        let limitType: String?
+        let accountEmail: String?
+        let accountName: String?
+        let groupUuid: String?
+        let groupName: String?
+        let period: String?
+        let disabledReason: String?
+        let disabledUntil: String?
+        let outOfCredits: Bool?
+        let discountPercent: Double?
+        let resolvedGroupLimit: Double?
+        let createdAt: String?
+        let updatedAt: String?
+
         enum CodingKeys: String, CodingKey {
-            case monthlyCreditLimit = "monthly_credit_limit"
+            case monthlyCreditLimit   = "monthly_credit_limit"
             case currency
-            case usedCredits = "used_credits"
-            case isEnabled = "is_enabled"
+            case usedCredits          = "used_credits"
+            case isEnabled            = "is_enabled"
+            case limitType            = "limit_type"
+            case accountEmail         = "account_email"
+            case accountName          = "account_name"
+            case groupUuid            = "group_uuid"
+            case groupName            = "group_name"
+            case period
+            case disabledReason       = "disabled_reason"
+            case disabledUntil        = "disabled_until"
+            case outOfCredits         = "out_of_credits"
+            case discountPercent      = "discount_percent"
+            case resolvedGroupLimit   = "resolved_group_limit"
+            case createdAt            = "created_at"
+            case updatedAt            = "updated_at"
         }
     }
 
@@ -55,6 +84,27 @@ extension ClaudeAPIService {
             case currency
             case totalGranted = "total_granted"
         }
+    }
+
+    /// Response from GET /v1/code/routines/run-budget
+    struct RunBudgetResponse: Codable {
+        /// Monthly routine run allowance as a string (e.g. "25")
+        let limit: String
+        /// Routine runs consumed this month as a string (e.g. "0")
+        let used: String
+        /// When true, the user's billing is unified and this budget applies
+        let unifiedBillingEnabled: Bool
+
+        enum CodingKeys: String, CodingKey {
+            case limit
+            case used
+            case unifiedBillingEnabled = "unified_billing_enabled"
+        }
+
+        /// Number of routine runs consumed this month.
+        var usedRuns: Int  { Int(used)  ?? 0 }
+        /// Monthly routine run allowance.
+        var limitRuns: Int { Int(limit) ?? 0 }
     }
 
     struct CurrentSpendResponse: Codable {

--- a/Claude Usage/Shared/Services/ClaudeAPIService+WebHeaders.swift
+++ b/Claude Usage/Shared/Services/ClaudeAPIService+WebHeaders.swift
@@ -1,0 +1,55 @@
+//
+//  ClaudeAPIService+WebHeaders.swift
+//  Claude Usage
+//
+//  Adds stable anthropic-* web client headers to every .claudeAISession request.
+//  DO NOT apply to .cliOAuth or .consoleAPISession paths.
+//
+
+import Foundation
+
+extension ClaudeAPIService {
+
+    // MARK: — Stable identifier helpers
+
+    /// Returns the persisted anonymous ID (format: "claudeai.v1.<uuid>"),
+    /// creating and saving one to Keychain if it does not already exist.
+    func getOrCreateAnonymousId() -> String {
+        if let existing = try? KeychainService.shared.load(for: .anthropicAnonymousId),
+           !existing.isEmpty {
+            return existing
+        }
+        let newId = "claudeai.v1.\(UUID().uuidString.lowercased())"
+        try? KeychainService.shared.save(newId, for: .anthropicAnonymousId)
+        return newId
+    }
+
+    /// Returns the persisted device ID (bare lowercase UUID),
+    /// creating and saving one to Keychain if it does not already exist.
+    func getOrCreateDeviceId() -> String {
+        if let existing = try? KeychainService.shared.load(for: .anthropicDeviceId),
+           !existing.isEmpty {
+            return existing
+        }
+        let newId = UUID().uuidString.lowercased()
+        try? KeychainService.shared.save(newId, for: .anthropicDeviceId)
+        return newId
+    }
+
+    // MARK: — Header injection
+
+    /// Applies all five Anthropic web-client headers to `request`.
+    /// Call this only for requests made under `.claudeAISession` authentication.
+    func applyAnthropicWebHeaders(to request: inout URLRequest) {
+        request.setValue(getOrCreateAnonymousId(),
+                         forHTTPHeaderField: "anthropic-anonymous-id")
+        request.setValue(getOrCreateDeviceId(),
+                         forHTTPHeaderField: "anthropic-device-id")
+        request.setValue("web_claude_ai",
+                         forHTTPHeaderField: "anthropic-client-platform")
+        request.setValue("1.0.0",
+                         forHTTPHeaderField: "anthropic-client-version")
+        request.setValue("94c2428a9a33a4d3867c4bc900e2ec8fec3c6dcb",
+                         forHTTPHeaderField: "anthropic-client-sha")
+    }
+}

--- a/Claude Usage/Shared/Services/ClaudeAPIService.swift
+++ b/Claude Usage/Shared/Services/ClaudeAPIService.swift
@@ -138,6 +138,7 @@ class ClaudeAPIService: APIServiceProtocol {
             request.setValue("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15", forHTTPHeaderField: "User-Agent")
             request.setValue("https://claude.ai", forHTTPHeaderField: "Referer")
             request.setValue("https://claude.ai", forHTTPHeaderField: "Origin")
+            applyAnthropicWebHeaders(to: &request)
 
         case .cliOAuth(let accessToken):
             // CLI OAuth authentication (requires specific headers)
@@ -395,6 +396,13 @@ class ClaudeAPIService: APIServiceProtocol {
             ProfileManager.shared.updateOrganizationId(selectedOrg.uuid, for: profileId)
         }
 
+        // Auto-populate accountUuid on first successful fetch
+        if ProfileManager.shared.activeProfile?.accountUuid == nil,
+           var updatedProfile = ProfileManager.shared.activeProfile {
+            updatedProfile.accountUuid = selectedOrg.uuid
+            ProfileManager.shared.updateProfile(updatedProfile)
+        }
+
         return selectedOrg.uuid
     }
 
@@ -404,25 +412,39 @@ class ClaudeAPIService: APIServiceProtocol {
     ///   - organizationId: The organization ID
     /// - Returns: ClaudeUsage data for the profile
     func fetchUsageData(sessionKey: String, organizationId: String) async throws -> ClaudeUsage {
+        let checkOverage = ProfileManager.shared.activeProfile?.checkOverageLimitEnabled ?? true
+
+        let accountUuid = ProfileManager.shared.activeProfile?.accountUuid
+        let personalEndpoint = personalOverageEndpoint(organizationId: organizationId, accountUuid: accountUuid)
+        let orgEndpoint = "/organizations/\(organizationId)/overage_spend_limit"
+
         async let usageDataTask = performRequest(endpoint: "/organizations/\(organizationId)/usage", sessionKey: sessionKey)
-        async let overageDataTask: Data? = performRequest(endpoint: "/organizations/\(organizationId)/overage_spend_limit", sessionKey: sessionKey)
-        async let creditGrantTask: Data? = performRequest(endpoint: "/organizations/\(organizationId)/overage_credit_grant", sessionKey: sessionKey)
+        async let overageDataTask: Data?        = (checkOverage && personalEndpoint != nil) ? performRequest(endpoint: personalEndpoint ?? "", sessionKey: sessionKey) : nil
+        async let orgOverageTask: Data?         = checkOverage ? performRequest(endpoint: orgEndpoint, sessionKey: sessionKey) : nil
+        async let creditGrantTask: Data?        = checkOverage ? performRequest(endpoint: "/organizations/\(organizationId)/overage_credit_grant", sessionKey: sessionKey) : nil
+        async let runBudgetTask: RunBudgetResponse? = checkOverage ? fetchRunBudget(sessionKey: sessionKey, organizationId: organizationId) : nil
 
         let usageData = try await usageDataTask
         var claudeUsage = try parseUsageResponse(usageData)
 
-        if let data = try? await overageDataTask,
-           let overage = try? JSONDecoder().decode(OverageSpendLimitResponse.self, from: data),
-           overage.isEnabled == true {
-            claudeUsage.costUsed = overage.usedCredits
-            claudeUsage.costLimit = overage.monthlyCreditLimit
-            claudeUsage.costCurrency = overage.currency
+        if checkOverage {
+            applyPersonalOverage(to: &claudeUsage, data: try? await overageDataTask)
+            applyOrganizationOverage(to: &claudeUsage, data: try? await orgOverageTask)
         }
 
-        if let creditData = try? await creditGrantTask,
+        if checkOverage,
+           let creditData = try? await creditGrantTask,
            let creditGrant = try? JSONDecoder().decode(OverageCreditGrantResponse.self, from: creditData) {
             claudeUsage.overageBalance = creditGrant.remainingBalance
             claudeUsage.overageBalanceCurrency = creditGrant.currency
+        }
+
+        // NEW: CCR Routine Runs
+        if checkOverage,
+           let runBudget = try? await runBudgetTask,
+           runBudget.unifiedBillingEnabled {
+            claudeUsage.routineRunsUsed = runBudget.usedRuns
+            claudeUsage.routineRunsLimit = runBudget.limitRuns
         }
 
         return claudeUsage
@@ -469,19 +491,21 @@ class ClaudeAPIService: APIServiceProtocol {
 
             // Use active profile's checkOverageLimitEnabled setting
             let checkOverage = ProfileManager.shared.activeProfile?.checkOverageLimitEnabled ?? true
-            async let overageDataTask: Data? = checkOverage ? performRequest(endpoint: "/organizations/\(orgId)/overage_spend_limit", sessionKey: sessionKey) : nil
+            let accountUuid = ProfileManager.shared.activeProfile?.accountUuid
+            let personalEndpoint = personalOverageEndpoint(organizationId: orgId, accountUuid: accountUuid)
+            let orgEndpoint = "/organizations/\(orgId)/overage_spend_limit"
+
+            async let overageDataTask: Data? = (checkOverage && personalEndpoint != nil) ? performRequest(endpoint: personalEndpoint ?? "", sessionKey: sessionKey) : nil
+            async let orgOverageTask: Data? = checkOverage ? performRequest(endpoint: orgEndpoint, sessionKey: sessionKey) : nil
             async let creditGrantTask: Data? = checkOverage ? performRequest(endpoint: "/organizations/\(orgId)/overage_credit_grant", sessionKey: sessionKey) : nil
+            async let runBudgetTask: RunBudgetResponse? = checkOverage ? fetchRunBudget(sessionKey: sessionKey, organizationId: orgId) : nil
 
             let usageData = try await usageDataTask
             var claudeUsage = try parseUsageResponse(usageData)
 
-            if checkOverage,
-               let data = try? await overageDataTask,
-               let overage = try? JSONDecoder().decode(OverageSpendLimitResponse.self, from: data),
-               overage.isEnabled == true {
-                claudeUsage.costUsed = overage.usedCredits
-                claudeUsage.costLimit = overage.monthlyCreditLimit
-                claudeUsage.costCurrency = overage.currency
+            if checkOverage {
+                applyPersonalOverage(to: &claudeUsage, data: try? await overageDataTask)
+                applyOrganizationOverage(to: &claudeUsage, data: try? await orgOverageTask)
             }
 
             if checkOverage,
@@ -489,6 +513,14 @@ class ClaudeAPIService: APIServiceProtocol {
                let creditGrant = try? JSONDecoder().decode(OverageCreditGrantResponse.self, from: creditData) {
                 claudeUsage.overageBalance = creditGrant.remainingBalance
                 claudeUsage.overageBalanceCurrency = creditGrant.currency
+            }
+
+            // NEW: CCR Routine Runs
+            if checkOverage,
+               let runBudget = try? await runBudgetTask,
+               runBudget.unifiedBillingEnabled {
+                claudeUsage.routineRunsUsed = runBudget.usedRuns
+                claudeUsage.routineRunsLimit = runBudget.limitRuns
             }
 
             return claudeUsage
@@ -595,6 +627,7 @@ class ClaudeAPIService: APIServiceProtocol {
         request.setValue("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15", forHTTPHeaderField: "User-Agent")
         request.setValue("https://claude.ai", forHTTPHeaderField: "Referer")
         request.setValue("https://claude.ai", forHTTPHeaderField: "Origin")
+        applyAnthropicWebHeaders(to: &request)
         request.httpMethod = "GET"
         request.timeoutInterval = 30
 
@@ -707,9 +740,156 @@ class ClaudeAPIService: APIServiceProtocol {
         }
     }
 
+    // MARK: - Overage Spend Limit
+
+    /// Returns the overage_spend_limit endpoint for personal data, or nil if no account UUID is set.
+    /// Without account_uuid the endpoint returns team/org data; with it, personal data scoped to the user.
+    private func personalOverageEndpoint(organizationId: String, accountUuid: String?) -> String? {
+        guard let uuid = accountUuid, !uuid.isEmpty else { return nil }
+        return "/organizations/\(organizationId)/overage_spend_limit?account_uuid=\(uuid)"
+    }
+
+    /// Applies the personal overage_spend_limit response to the usage model.
+    /// Personal cost fields take precedence from /usage's extra_usage block; this only fills gaps.
+    /// Always maps disabled state and organization name regardless of cost-field precedence.
+    private func applyPersonalOverage(to usage: inout ClaudeUsage, data: Data?) {
+        guard let data = data,
+              let overage = try? JSONDecoder().decode(OverageSpendLimitResponse.self, from: data),
+              overage.isEnabled == true else { return }
+
+        if usage.costUsed == nil {
+            usage.costLimit = overage.monthlyCreditLimit
+            usage.costUsed = overage.usedCredits
+            usage.costCurrency = overage.currency
+        }
+        if let reason = overage.disabledReason, !reason.isEmpty {
+            usage.budgetDisabledReason = reason
+        } else if overage.outOfCredits == true {
+            usage.budgetDisabledReason = "out_of_credits"
+        }
+        if let name = overage.groupName, !name.isEmpty {
+            usage.organizationName = name
+        }
+    }
+
+    /// Applies the organization-level overage_spend_limit response (fetched without account_uuid).
+    /// The org pool is what all members share; personal caps are sub-limits within it.
+    private func applyOrganizationOverage(to usage: inout ClaudeUsage, data: Data?) {
+        guard let data = data,
+              let overage = try? JSONDecoder().decode(OverageSpendLimitResponse.self, from: data),
+              overage.isEnabled == true else { return }
+
+        usage.organizationCostLimit = overage.monthlyCreditLimit
+        usage.organizationCostUsed = overage.usedCredits
+        usage.organizationCostCurrency = overage.currency
+        if usage.organizationName == nil, let name = overage.groupName, !name.isEmpty {
+            usage.organizationName = name
+        }
+    }
+
+    // MARK: - CCR Run Budget
+
+    /// Fetches the personal Claude Code Routines monthly budget.
+    ///
+    /// Endpoint: GET https://claude.ai/v1/code/routines/run-budget
+    /// (Note: uses claudeBase — no /api prefix.)
+    ///
+    /// Required extra headers beyond standard session headers:
+    ///   - anthropic-beta: ccr-triggers-2026-01-30
+    ///   - x-organization-uuid: {organizationId}
+    ///
+    /// - Parameters:
+    ///   - sessionKey: The Claude.ai session cookie value (same as used in performRequest)
+    ///   - organizationId: The org UUID for the x-organization-uuid header
+    /// - Returns: Decoded `RunBudgetResponse`; throws on non-200 or decode failure
+    private func fetchRunBudget(sessionKey: String, organizationId: String) async throws -> RunBudgetResponse {
+        let endpoint = "/v1/code/routines/run-budget"
+        let url = try URLBuilder.claudeBase(endpoint: endpoint).build()
+
+        var request = URLRequest(url: url)
+        request.setValue("sessionKey=\(sessionKey)", forHTTPHeaderField: "Cookie")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+        request.setValue("ccr-triggers-2026-01-30", forHTTPHeaderField: "anthropic-beta")
+        request.setValue(organizationId, forHTTPHeaderField: "x-organization-uuid")
+        request.setValue(
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15",
+            forHTTPHeaderField: "User-Agent"
+        )
+        request.setValue("https://claude.ai", forHTTPHeaderField: "Referer")
+        request.setValue("https://claude.ai", forHTTPHeaderField: "Origin")
+        applyAnthropicWebHeaders(to: &request)
+        request.httpMethod = "GET"
+        request.timeoutInterval = 30
+
+        LoggingService.shared.logAPIRequest(endpoint)
+
+        let startTime = Date()
+        let (data, response): (Data, URLResponse)
+        do {
+            (data, response) = try await URLSession.shared.data(for: request)
+        } catch {
+            let duration = Date().timeIntervalSince(startTime)
+            NetworkLoggerService.shared.logRequest(
+                url: url.absoluteString,
+                method: "GET",
+                requestBody: nil,
+                responseData: nil,
+                statusCode: nil,
+                duration: duration,
+                error: error
+            )
+            LoggingService.shared.logAPIError(endpoint, error: error)
+            throw error
+        }
+
+        let duration = Date().timeIntervalSince(startTime)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw AppError(
+                code: .apiInvalidResponse,
+                message: "Invalid response from run-budget endpoint",
+                technicalDetails: "Endpoint: \(endpoint)",
+                isRecoverable: true
+            )
+        }
+
+        LoggingService.shared.logAPIResponse(endpoint, statusCode: httpResponse.statusCode)
+
+        NetworkLoggerService.shared.logRequest(
+            url: url.absoluteString,
+            method: "GET",
+            requestBody: nil,
+            responseData: data,
+            statusCode: httpResponse.statusCode,
+            duration: duration,
+            error: nil
+        )
+
+        if DataStore.shared.loadDebugAPILoggingEnabled(),
+           let responseString = String(data: data, encoding: .utf8) {
+            let truncated = responseString.prefix(500)
+            LoggingService.shared.logDebug("API Response [\(endpoint)]: \(truncated)...")
+        }
+
+        guard httpResponse.statusCode == 200 else {
+            let responsePreview = String(data: data, encoding: .utf8)?.prefix(200) ?? "Unable to read response"
+            throw AppError(
+                code: (httpResponse.statusCode == 401 || httpResponse.statusCode == 403)
+                    ? .apiUnauthorized : .apiGenericError,
+                message: "run-budget request failed (HTTP \(httpResponse.statusCode))",
+                technicalDetails: "Endpoint: \(endpoint)\nStatus: \(httpResponse.statusCode)\nResponse: \(responsePreview)",
+                isRecoverable: true
+            )
+        }
+
+        return try JSONDecoder().decode(RunBudgetResponse.self, from: data)
+    }
+
     // MARK: - Response Parsing
 
-    private func parseUsageResponse(_ data: Data) throws -> ClaudeUsage {
+    func parseUsageResponse(_ data: Data) throws -> ClaudeUsage {
         // Parse Claude's actual API response structure
 
         if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
@@ -730,6 +910,7 @@ class ClaudeAPIService: APIServiceProtocol {
             // Extract weekly usage (seven_day)
             var weeklyPercentage = 0.0
             var weeklyResetTime = Date().nextMonday1259pm()
+            let hasSevenDay = (json["seven_day"] as? [String: Any]) != nil
             if let sevenDay = json["seven_day"] as? [String: Any] {
                 if let utilization = sevenDay["utilization"] {
                     weeklyPercentage = parseUtilization(utilization)
@@ -763,8 +944,9 @@ class ClaudeAPIService: APIServiceProtocol {
                 }
             }
 
-            // We don't know user's plan, so we use 0 for limits we can't determine
-            let weeklyLimit = Constants.weeklyLimit
+            // We don't know user's plan, so we use 0 for limits we can't determine.
+            // 0 when API omits seven_day (plans without a weekly cap) so the UI can hide the row.
+            let weeklyLimit = hasSevenDay ? Constants.weeklyLimit : 0
 
             // Calculate token counts from percentages (using weekly limit as reference)
             let sessionTokens = 0  // Can't calculate without knowing plan
@@ -773,7 +955,33 @@ class ClaudeAPIService: APIServiceProtocol {
             let opusTokens = Int(Double(weeklyLimit) * (opusPercentage / 100.0))
             let sonnetTokens = Int(Double(weeklyLimit) * (sonnetPercentage / 100.0))
 
-            let usage = ClaudeUsage(
+            // Extract extra_usage (cost data embedded in /usage response).
+            // If present, this takes PRECEDENCE over the separate overage_spend_limit endpoint.
+            var extraCostUsed: Double? = nil
+            var extraCostLimit: Double? = nil
+            var extraCostCurrency: String? = nil
+            var extraCostUtilization: Double? = nil
+
+            if let extraUsage = json["extra_usage"] as? [String: Any] {
+                if let used = extraUsage["used_credits"] as? Double {
+                    extraCostUsed = used
+                } else if let used = extraUsage["used_credits"] as? Int {
+                    extraCostUsed = Double(used)
+                }
+                if let limit = extraUsage["monthly_limit"] as? Double {
+                    extraCostLimit = limit
+                } else if let limit = extraUsage["monthly_limit"] as? Int {
+                    extraCostLimit = Double(limit)
+                }
+                if let currency = extraUsage["currency"] as? String {
+                    extraCostCurrency = currency
+                }
+                if let utilization = extraUsage["utilization"] {
+                    extraCostUtilization = parseUtilization(utilization)
+                }
+            }
+
+            var usage = ClaudeUsage(
                 sessionTokensUsed: sessionTokens,
                 sessionLimit: sessionLimit,
                 sessionPercentage: sessionPercentage,
@@ -787,13 +995,13 @@ class ClaudeAPIService: APIServiceProtocol {
                 sonnetWeeklyTokensUsed: sonnetTokens,
                 sonnetWeeklyPercentage: sonnetPercentage,
                 sonnetWeeklyResetTime: sonnetResetTime,
-                costUsed: nil,
-                costLimit: nil,
-                costCurrency: nil,
+                costUsed: extraCostUsed,
+                costLimit: extraCostLimit,
+                costCurrency: extraCostCurrency,
                 lastUpdated: Date(),
                 userTimezone: .current
             )
-
+            usage.costUtilization = extraCostUtilization
             return usage
         }
 

--- a/Claude Usage/Shared/Services/KeychainService.swift
+++ b/Claude Usage/Shared/Services/KeychainService.swift
@@ -18,13 +18,21 @@ class KeychainService {
     enum KeychainKey: String {
         case apiSessionKey = "com.claudeusagetracker.api-session-key"
         case claudeSessionKey = "com.claudeusagetracker.claude-session-key"
+        /// Stable anonymous identifier prefixed "claudeai.v1.<uuid>". Created once, never rotated.
+        case anthropicAnonymousId = "com.claudeusagetracker.anthropic-anonymous-id"
+        /// Stable device identifier (bare UUID). Created once, never rotated.
+        case anthropicDeviceId    = "com.claudeusagetracker.anthropic-device-id"
 
         var service: String {
             return rawValue
         }
 
         var account: String {
-            return "session-key"
+            switch self {
+            case .anthropicAnonymousId: return "anthropic-anonymous-id"
+            case .anthropicDeviceId:    return "anthropic-device-id"
+            default:                    return "session-key"
+            }
         }
     }
 

--- a/Claude Usage/Shared/Services/ProfileMigrationService.swift
+++ b/Claude Usage/Shared/Services/ProfileMigrationService.swift
@@ -13,6 +13,14 @@ class ProfileMigrationService {
 
     private let migrationKey = "didMigrateToProfilesV3"
 
+    // Schema version history:
+    // v1 — initial single→multi profile migration (didMigrateToProfilesV3 flag)
+    // v2 — oauthAccountJSON field added (no data migration needed)
+    // v3 — routineRunsUsed/Limit fields added (no data migration needed)
+    // v4 — 2026-05-13: Added Profile.accountUuid (optional String).
+    //       No data migration needed; new field defaults to nil on decode.
+    static let currentSchemaVersion: Int = 4
+
     private init() {}
 
     func migrateIfNeeded() {

--- a/Claude Usage/Shared/Services/StatuslineService.swift
+++ b/Claude Usage/Shared/Services/StatuslineService.swift
@@ -1096,6 +1096,14 @@ ELEMENT_COLOR_EXTRA=\(elementColors.extraUsageBaseHex ?? "")
             cacheContent += "\nCOST_CURRENCY=\(costCurrency)"
         }
 
+        // CCR Routine Runs cache vars (for bash statusline scripts)
+        if let runsUsed  = usage.routineRunsUsed,
+           let runsLimit = usage.routineRunsLimit,
+           runsLimit > 0 {
+            cacheContent += "\nROUTINE_RUNS_USED=\(runsUsed)"
+            cacheContent += "\nROUTINE_RUNS_LIMIT=\(runsLimit)"
+        }
+
         try? cacheContent.write(to: cachePath, atomically: true, encoding: .utf8)
     }
 

--- a/Claude Usage/Shared/Services/UsageHistoryService.swift
+++ b/Claude Usage/Shared/Services/UsageHistoryService.swift
@@ -188,6 +188,10 @@ class UsageHistoryService {
             resetType: .sessionReset,
             sessionTokensUsed: usage.sessionTokensUsed,
             sessionPercentage: usage.sessionPercentage,
+            costUsed: usage.costUsed,
+            costLimit: usage.costLimit,
+            routineRunsUsed: usage.routineRunsUsed,
+            routineRunsLimit: usage.routineRunsLimit,
             triggeringResetTime: now
         )
 
@@ -229,6 +233,10 @@ class UsageHistoryService {
             opusWeeklyPercentage: usage.opusWeeklyPercentage,
             sonnetWeeklyTokensUsed: usage.sonnetWeeklyTokensUsed,
             sonnetWeeklyPercentage: usage.sonnetWeeklyPercentage,
+            costUsed: usage.costUsed,
+            costLimit: usage.costLimit,
+            routineRunsUsed: usage.routineRunsUsed,
+            routineRunsLimit: usage.routineRunsLimit,
             triggeringResetTime: now
         )
 

--- a/Claude Usage/Shared/Utilities/URLBuilder.swift
+++ b/Claude Usage/Shared/Utilities/URLBuilder.swift
@@ -181,6 +181,15 @@ extension URLBuilder {
         let builder = try URLBuilder(baseURL: "https://status.claude.com/api/v2")
         return endpoint.isEmpty ? builder : try builder.appendingPath(endpoint)
     }
+
+    /// Create a builder for Claude base endpoints (https://claude.ai — no /api path prefix).
+    /// Use this for first-party endpoints such as /v1/code/routines/run-budget.
+    /// - Parameter endpoint: The endpoint path (e.g. "/v1/code/routines/run-budget")
+    /// - Returns: A configured URLBuilder rooted at https://claude.ai
+    static func claudeBase(endpoint: String = "") throws -> URLBuilder {
+        let builder = try URLBuilder(baseURL: "https://claude.ai")
+        return endpoint.isEmpty ? builder : try builder.appendingPath(endpoint)
+    }
 }
 
 // MARK: - Result-based API

--- a/Claude Usage/Views/Settings/Profile/AppearanceSettingsView.swift
+++ b/Claude Usage/Views/Settings/Profile/AppearanceSettingsView.swift
@@ -190,6 +190,42 @@ struct AppearanceSettingsView: View {
                                 onConfigChanged: { saveConfiguration() }
                             )
                         }
+
+                        // Personal Limit
+                        if let idx = configuration.metrics.firstIndex(where: { $0.metricType == .personalLimit }) {
+                            MetricIconCard(
+                                metricType: .personalLimit,
+                                config: Binding(
+                                    get: { configuration.metrics[idx] },
+                                    set: { configuration.metrics[idx] = $0 }
+                                ),
+                                onConfigChanged: { saveConfiguration() }
+                            )
+                        }
+
+                        // Organization Limit
+                        if let idx = configuration.metrics.firstIndex(where: { $0.metricType == .organizationLimit }) {
+                            MetricIconCard(
+                                metricType: .organizationLimit,
+                                config: Binding(
+                                    get: { configuration.metrics[idx] },
+                                    set: { configuration.metrics[idx] = $0 }
+                                ),
+                                onConfigChanged: { saveConfiguration() }
+                            )
+                        }
+
+                        // Routine Runs
+                        if let idx = configuration.metrics.firstIndex(where: { $0.metricType == .routineRuns }) {
+                            MetricIconCard(
+                                metricType: .routineRuns,
+                                config: Binding(
+                                    get: { configuration.metrics[idx] },
+                                    set: { configuration.metrics[idx] = $0 }
+                                ),
+                                onConfigChanged: { saveConfiguration() }
+                            )
+                        }
                     }
                 }
                 .disabled(isMultiProfileMode)

--- a/Claude UsageTests/ClaudeAPIServiceTests.swift
+++ b/Claude UsageTests/ClaudeAPIServiceTests.swift
@@ -1,0 +1,132 @@
+//
+//  ClaudeAPIServiceTests.swift
+//  Claude Usage Tests
+//
+//  Tests for ClaudeAPIService response type decoding.
+//  Uses inline JSON Data fixtures (no external files) following the
+//  existing pattern in ClaudeUsageTests.swift and URLBuilderTests.swift.
+//
+
+import XCTest
+@testable import Claude_Usage
+
+final class ClaudeAPIServiceTests: XCTestCase {
+
+    // MARK: - RunBudgetResponse Decoding
+
+    /// Happy-path decode using the exact HAR fixture body.
+    func testRunBudgetResponseDecodeHappyPath() throws {
+        let json = #"{"limit":"25","unified_billing_enabled":true,"used":"0"}"#
+        let data = Data(json.utf8)
+
+        let response = try JSONDecoder().decode(ClaudeAPIService.RunBudgetResponse.self, from: data)
+
+        XCTAssertEqual(response.limit, "25")
+        XCTAssertEqual(response.used, "0")
+        XCTAssertTrue(response.unifiedBillingEnabled)
+    }
+
+    /// Integer run counts: limitRuns and usedRuns parse the string fields as Int.
+    func testRunBudgetResponseRunCounts() throws {
+        let json = #"{"limit":"25","unified_billing_enabled":true,"used":"0"}"#
+        let response = try JSONDecoder().decode(
+            ClaudeAPIService.RunBudgetResponse.self, from: Data(json.utf8)
+        )
+
+        XCTAssertEqual(response.limitRuns, 25)
+        XCTAssertEqual(response.usedRuns,  0)
+    }
+
+    /// Non-integer used value (decimal string): Int("12.50") returns nil, so usedRuns falls back to 0.
+    func testRunBudgetResponseNonIntegerUsedFallsBackToZero() throws {
+        let json = #"{"limit":"25","unified_billing_enabled":true,"used":"12.50"}"#
+        let response = try JSONDecoder().decode(
+            ClaudeAPIService.RunBudgetResponse.self, from: Data(json.utf8)
+        )
+
+        XCTAssertEqual(response.usedRuns,  0)   // Int("12.50") == nil → 0
+        XCTAssertEqual(response.limitRuns, 25)
+    }
+
+    /// When unified_billing_enabled is false, budget should not be applied (caller checks).
+    func testRunBudgetResponseUnifiedBillingDisabled() throws {
+        let json = #"{"limit":"25","unified_billing_enabled":false,"used":"0"}"#
+        let response = try JSONDecoder().decode(
+            ClaudeAPIService.RunBudgetResponse.self, from: Data(json.utf8)
+        )
+
+        XCTAssertFalse(response.unifiedBillingEnabled)
+        XCTAssertEqual(response.limitRuns, 25)
+    }
+
+    /// Malformed string (non-numeric) gracefully falls back to 0.
+    func testRunBudgetResponseMalformedValues() throws {
+        let json = #"{"limit":"abc","unified_billing_enabled":true,"used":"xyz"}"#
+        let response = try JSONDecoder().decode(
+            ClaudeAPIService.RunBudgetResponse.self, from: Data(json.utf8)
+        )
+
+        // Int("abc") = nil → defaults to 0
+        XCTAssertEqual(response.usedRuns,  0)
+        XCTAssertEqual(response.limitRuns, 0)
+    }
+
+    /// Missing fields should throw (all three fields are non-optional in the struct).
+    func testRunBudgetResponseMissingFieldsThrows() {
+        let json = #"{"limit":"25","unified_billing_enabled":true}"# // missing "used"
+        XCTAssertThrowsError(
+            try JSONDecoder().decode(ClaudeAPIService.RunBudgetResponse.self, from: Data(json.utf8))
+        )
+    }
+
+    // MARK: - extra_usage Parsing (Fix #219)
+
+    func testExtraUsageFromHARParsesToCostFields() throws {
+        let harJSON = """
+        {
+            "five_hour": null,
+            "seven_day": null,
+            "seven_day_oauth_apps": null,
+            "seven_day_opus": null,
+            "seven_day_sonnet": null,
+            "extra_usage": {
+                "is_enabled": true,
+                "monthly_limit": 25000,
+                "used_credits": 1504.0,
+                "utilization": 6.016,
+                "currency": "USD"
+            }
+        }
+        """.data(using: .utf8)!
+
+        let service = ClaudeAPIService()
+        let usage = try service.parseUsageResponse(harJSON)
+
+        XCTAssertEqual(usage.costUsed ?? 0,        1504.0,  accuracy: 0.001)
+        XCTAssertEqual(usage.costLimit ?? 0,       25000.0, accuracy: 0.001)
+        XCTAssertEqual(usage.costCurrency,         "USD")
+        XCTAssertEqual(usage.costUtilization ?? 0, 6.016,   accuracy: 0.001)
+    }
+
+    // MARK: - ClaudeUsage Routine Runs Fields
+
+    /// New fields default to nil in ClaudeUsage.empty.
+    func testClaudeUsageEmptyHasNilRoutineRuns() {
+        let empty = ClaudeUsage.empty
+        XCTAssertNil(empty.routineRunsUsed)
+        XCTAssertNil(empty.routineRunsLimit)
+    }
+
+    /// ClaudeUsage round-trips through Codable with routine runs fields populated.
+    func testClaudeUsageRoutineRunsCodableRoundTrip() throws {
+        var usage = ClaudeUsage.empty
+        usage.routineRunsUsed  = 3
+        usage.routineRunsLimit = 25
+
+        let data    = try JSONEncoder().encode(usage)
+        let decoded = try JSONDecoder().decode(ClaudeUsage.self, from: data)
+
+        XCTAssertEqual(decoded.routineRunsUsed,  3)
+        XCTAssertEqual(decoded.routineRunsLimit, 25)
+    }
+}

--- a/Claude UsageTests/PopoverDisabledBudgetTests.swift
+++ b/Claude UsageTests/PopoverDisabledBudgetTests.swift
@@ -1,0 +1,74 @@
+//
+//  PopoverDisabledBudgetTests.swift
+//  Claude UsageTests
+//
+//  Unit tests for ClaudeUsage.budgetDisabledReason population.
+//  (Visual chip appearance is verified via accessibilityIdentifier in integration.)
+//
+
+import XCTest
+@testable import Claude_Usage
+
+final class PopoverDisabledBudgetTests: XCTestCase {
+
+    // MARK: — budgetDisabledReason mapping
+
+    func testBudgetDisabledReasonFromExplicitReason() {
+        var usage = ClaudeUsage.empty
+        usage.budgetDisabledReason = "payment_required"
+        XCTAssertEqual(usage.budgetDisabledReason, "payment_required")
+    }
+
+    func testBudgetDisabledReasonNilByDefault() {
+        let usage = ClaudeUsage.empty
+        XCTAssertNil(usage.budgetDisabledReason)
+    }
+
+    func testBudgetDisabledReasonCodableRoundTrip() throws {
+        var usage = ClaudeUsage.empty
+        usage.budgetDisabledReason = "out_of_credits"
+        let data    = try JSONEncoder().encode(usage)
+        let decoded = try JSONDecoder().decode(ClaudeUsage.self, from: data)
+        XCTAssertEqual(decoded.budgetDisabledReason, "out_of_credits")
+    }
+
+    func testBudgetDisabledReasonNilAfterRoundTrip() throws {
+        let usage   = ClaudeUsage.empty   // nil budgetDisabledReason
+        let data    = try JSONEncoder().encode(usage)
+        let decoded = try JSONDecoder().decode(ClaudeUsage.self, from: data)
+        XCTAssertNil(decoded.budgetDisabledReason)
+    }
+
+    // MARK: — OverageSpendLimitResponse mapping logic (logic-layer tests)
+
+    func testOutOfCreditsMapsToDisabledReason() {
+        // Simulate the mapping logic from ClaudeAPIService
+        let disabledReason: String? = nil
+        let outOfCredits: Bool? = true
+
+        let result: String?
+        if let reason = disabledReason, !reason.isEmpty {
+            result = reason
+        } else if outOfCredits == true {
+            result = "out_of_credits"
+        } else {
+            result = nil
+        }
+        XCTAssertEqual(result, "out_of_credits")
+    }
+
+    func testExplicitReasonTakesPrecedenceOverOutOfCredits() {
+        let disabledReason: String? = "payment_required"
+        let outOfCredits: Bool? = true
+
+        let result: String?
+        if let reason = disabledReason, !reason.isEmpty {
+            result = reason
+        } else if outOfCredits == true {
+            result = "out_of_credits"
+        } else {
+            result = nil
+        }
+        XCTAssertEqual(result, "payment_required")
+    }
+}

--- a/Claude UsageTests/URLBuilderTests.swift
+++ b/Claude UsageTests/URLBuilderTests.swift
@@ -137,6 +137,16 @@ final class URLBuilderTests: XCTestCase {
         XCTAssertEqual(url.absoluteString, "https://status.claude.com/api/v2/status.json")
     }
 
+    func testClaudeBaseBuilder() throws {
+        let url = try URLBuilder.claudeBase(endpoint: "/v1/code/routines/run-budget").build()
+        XCTAssertEqual(url.absoluteString, "https://claude.ai/v1/code/routines/run-budget")
+    }
+
+    func testClaudeBaseBuilderNoEndpoint() throws {
+        let url = try URLBuilder.claudeBase().build()
+        XCTAssertEqual(url.absoluteString, "https://claude.ai")
+    }
+
     // MARK: - Complex URL Tests
 
     func testComplexClaudeURL() throws {


### PR DESCRIPTION
## Summary

Tracks two new Anthropic-billed quantities and fixes a couple of edge cases the original tracker missed for accounts on team plans with overage budgets enabled.

**Surfaces three new metrics:**
- **Personal Limit** — the user's own monthly cap on extra-usage spending (from `extra_usage` in `/usage`)
- **Organization Limit** — the shared org pool everyone spends against (from `/overage_spend_limit` without `account_uuid`)
- **Routine Runs** — Claude Code Routines monthly run budget (from `/v1/code/routines/run-budget`)

Each is available in the popover (as a usage row) and in the menu bar (as a configurable icon).

## Why "Limit" instead of "Budget" / "Extra Usage"

Aligned with Anthropic's own API terminology — the relevant fields are `monthly_credit_limit`, `overage_spend_limit`, `used_credits`. The previous "Extra Usage" label conflated two distinct concepts:
- the personal cap (a per-user spending limit)
- the organization pool (a shared overage budget)

These are now separately labelled and separately fetched.

## Bug fixes

- **Routine Runs endpoint returned HTTP 400.** `fetchRunBudget` never set the required `anthropic-version: 2023-06-01` header. The `try?` on the awaited result silently swallowed the error, so the row simply never appeared. Header added; row populates correctly now.
- **Weekly row showed for accounts without a weekly cap.** `weeklyLimit` was always set to `Constants.weeklyLimit` regardless of whether the API returned `seven_day`. Now uses `0` when the field is absent so the popover can hide the row.

## What's in the diff

### `ClaudeAPIService.swift`
- Add `anthropic-version` header to `fetchRunBudget`
- Fetch `/overage_spend_limit` twice when an `account_uuid` is known: with it for personal data, without it for organization data
- Extract `personalOverageEndpoint`, `applyPersonalOverage`, `applyOrganizationOverage` helpers to remove decode-and-merge duplication across the two `fetchUsageData` paths
- Track whether `/usage` returned a `seven_day` block; pass through as `weeklyLimit == 0` when absent

### `ClaudeUsage.swift`
- New optional fields: `organizationCostUsed`, `organizationCostLimit`, `organizationCostCurrency`, `organizationName`
- Backward compatible (all default to `nil`)

### `PopoverContentView.swift`
- Hide Session Usage when `sessionLimit == 0`
- Hide All Models when `weeklyLimit == 0`
- Personal monthly cap row uses `menubar.personal_limit`
- New Organization Limit row uses `menubar.organization_limit`; title is `"{orgName} — Organization Limit"` when the API returns a name

### `MenuBarIconConfig.swift` + renderer + appearance settings
- New `MenuBarMetricType` cases: `.personalLimit`, `.organizationLimit`, `.routineRuns`
- `displayName`, `description`, `prefixText`, `icon`, and a new `shortLabel` accessor handle each case (replacing three places that hardcoded `metricType == .session ? "S" : "W"`)
- `MetricIconConfig` defaults; collected in `MenuBarIconConfiguration.defaultMetrics` for single-source-of-truth
- Backfill loop in the `Codable` decoder so existing saved configurations gain the new metrics on next load (no manual reset)
- `MenuBarIconRenderer.getMetricData` knows how to compute each (currency-based budgets share `budgetMetricData`; routine runs show count rather than %)
- Battery-style labels now read "Jun 1" (next monthly renewal) for the limit metrics, since they reset on the 1st rather than weekly
- `AppearanceSettingsView` renders a `MetricIconCard` for each new metric

### `Date+Extensions.swift`
- `firstOfNextMonth()` — calendar arithmetic for the next monthly reset
- `shortMonthDayString()` — formats "Jun 1"-style labels

### Localization
- New keys `menubar.personal_limit` and `menubar.organization_limit` translated across all 13 supported locales (en, de, es, fr, it, ja, ko, pt, pt-BR, tr, uk, zh-Hant, zh-ch)
- Existing `menubar.extra_usage` is left untouched (no longer used by the popover, but kept for any downstream consumers)

## How "Organization Limit" was inferred

Based on the API response shape rather than docs. `/overage_spend_limit` without `account_uuid` returns:
```json
{ "limit_type": "organization", "monthly_credit_limit": 750000, "used_credits": 449586, "currency": "USD", ... }
```

This appears to be a shared pool — every team member's overage spend counts against the same total. The personal `extra_usage.monthly_limit` is the user's sub-cap within that pool, not an independent allowance.

## Test plan

- [x] Builds clean on Xcode 26 (macOS 14+ target)
- [x] All 107 unit tests pass (`xcodebuild test`)
- [x] Verified live against a team-plan account with CCR routines enabled:
  - Personal Limit row shows `$15.04 / $250.00 USD`
  - Organization Limit row shows `$4,495.86 / $7,500.00 USD`
  - Routine Runs row shows `0 / 25 runs`
- [x] Each new metric togglable in Appearance settings; battery icon shows "Jun 1" as the label
- [x] Accounts without a weekly cap no longer see a phantom "All models" row
- [x] Existing configurations decode and auto-populate the new metric defaults without resetting user choices

## Breaking changes

None at the user-facing or persistence level. The internal `MenuBarMetricType` rawValues for the three new cases (`personalLimit`, `organizationLimit`, `routineRuns`) are brand new; the decoder backfills, so no migration is required.
