### PR TITLE
feat(notifications): Schedule 5-hour and weekly reset notifications

### DIFF
--- a/Claude Usage/MenuBar/MenuBarManager.swift
+++ b/Claude Usage/MenuBar/MenuBarManager.swift
@@ -1004,7 +1004,11 @@ class MenuBarManager: NSObject, ObservableObject {
 
     /// Refreshes usage data for all profiles selected for multi-profile display
     private func refreshAllSelectedProfiles() {
-        let selectedProfiles = profileManager.profiles.filter { $0.isSelectedForDisplay && $0.hasUsageCredentials }
+        // Filter on `hasAnyCredentials` (not `hasUsageCredentials`) so that profiles
+        // whose CLI OAuth token has expired are still polled — `fetchUsageForProfile`
+        // will transparently refresh expired tokens via the refresh_token grant.
+        // Excluding them here would prevent the refresh path from ever running.
+        let selectedProfiles = profileManager.profiles.filter { $0.isSelectedForDisplay && $0.hasAnyCredentials }
 
         guard !selectedProfiles.isEmpty else {
             LoggingService.shared.log("MenuBarManager: No selected profiles with usage credentials to refresh")
@@ -1142,11 +1146,23 @@ class MenuBarManager: NSObject, ObservableObject {
             return try await apiService.fetchUsageData(sessionKey: sessionKey, organizationId: orgId)
         }
 
-        // Priority 2: Saved CLI OAuth token from profile
-        if let cliJSON = profile.cliCredentialsJSON,
-           !ClaudeCodeSyncService.shared.isTokenExpired(cliJSON),
-           let accessToken = ClaudeCodeSyncService.shared.extractAccessToken(from: cliJSON) {
-            return try await apiService.fetchUsageData(oauthAccessToken: accessToken)
+        // Priority 2: CLI OAuth credentials.
+        // `ensureFreshCredentials` picks the source automatically:
+        //   - If `profile.customKeychainServiceName` is set → pull fresh from that keychain entry
+        //     (which Claude Code rotates during normal CLI use). No network refresh needed when
+        //     the token there is still valid; otherwise transparently refresh via the
+        //     refresh_token grant and write back to both keychain and profile cache.
+        //   - Otherwise → use the profile's cached `cliCredentialsJSON`, refreshing if expired.
+        // If `ensureFreshCredentials` returns nil (e.g. network failure during refresh), fall
+        // back to the stored cliCredentialsJSON so a still-valid cached token isn't wasted.
+        if profile.cliCredentialsJSON != nil || profile.customKeychainServiceName != nil {
+            let usableJSON = await ClaudeCodeSyncService.shared.ensureFreshCredentials(for: profile.id)
+                ?? profile.cliCredentialsJSON
+            if let usableJSON = usableJSON,
+               !ClaudeCodeSyncService.shared.isTokenExpired(usableJSON),
+               let accessToken = ClaudeCodeSyncService.shared.extractAccessToken(from: usableJSON) {
+                return try await apiService.fetchUsageData(oauthAccessToken: accessToken)
+            }
         }
 
         // Priority 3: System Keychain CLI OAuth token

--- a/Claude Usage/MenuBar/MenuBarManager.swift
+++ b/Claude Usage/MenuBar/MenuBarManager.swift
@@ -1075,6 +1075,10 @@ class MenuBarManager: NSObject, ObservableObject {
                         self.profileManager.saveClaudeUsage(newUsage, for: profile.id)
                         LoggingService.shared.log("MenuBarManager: Saved usage for profile '\(profile.name)' - session: \(newUsage.sessionPercentage)%")
 
+                        // Re-schedule local reset alerts for this profile against the freshly
+                        // fetched reset times so we still alert even if the app is later quit.
+                        self.scheduleResetAlertsIfEnabled(profile: profile, newUsage: newUsage)
+
                         // If this is the active profile, also update the manager's usage
                         if profile.id == self.profileManager.activeProfile?.id {
                             self.usage = newUsage
@@ -1293,6 +1297,12 @@ class MenuBarManager: NSObject, ObservableObject {
                         self.profileManager.saveClaudeUsage(newUsage, for: profileId)
                     }
 
+                    // Pre-schedule local reset alerts so they fire even if the app is quit
+                    // before the actual reset moment.
+                    if let activeProfile = self.profileManager.activeProfile {
+                        self.scheduleResetAlertsIfEnabled(profile: activeProfile, newUsage: newUsage)
+                    }
+
                     // Write statusline cache for instant CLI rendering
                     if StatuslineService.shared.isInstalled {
                         StatuslineService.shared.writeUsageCache(
@@ -1505,6 +1515,46 @@ class MenuBarManager: NSObject, ObservableObject {
         let calendar = Calendar.current
         let components = calendar.dateComponents([.year, .month, .day, .hour, .minute], from: date)
         return calendar.date(from: components) ?? date
+    }
+
+    /// Schedules (or cancels) local reset notifications for this profile based on its
+    /// NotificationSettings toggles. Called after every successful usage fetch so the
+    /// pending alerts always reflect the latest server-reported reset times — adding a
+    /// request with the same identifier replaces any prior pending one, so the user
+    /// gets one alert per actual reset event even across reschedules.
+    /// macOS delivers `UNCalendarNotificationTrigger`-based notifications even when
+    /// the app is offline or quit, which is the whole point of pre-scheduling.
+    private func scheduleResetAlertsIfEnabled(profile: Profile, newUsage: ClaudeUsage) {
+        let settings = profile.notificationSettings
+        guard settings.enabled else {
+            NotificationManager.shared.cancelResetNotification(profileId: profile.id, type: .sessionReset)
+            NotificationManager.shared.cancelResetNotification(profileId: profile.id, type: .weeklyReset)
+            return
+        }
+
+        if settings.sessionResetEnabled {
+            NotificationManager.shared.scheduleResetNotification(
+                profileId: profile.id,
+                profileName: profile.name,
+                type: .sessionReset,
+                resetTime: newUsage.sessionResetTime,
+                soundName: settings.soundName
+            )
+        } else {
+            NotificationManager.shared.cancelResetNotification(profileId: profile.id, type: .sessionReset)
+        }
+
+        if settings.weeklyResetEnabled {
+            NotificationManager.shared.scheduleResetNotification(
+                profileId: profile.id,
+                profileName: profile.name,
+                type: .weeklyReset,
+                resetTime: newUsage.weeklyResetTime,
+                soundName: settings.soundName
+            )
+        } else {
+            NotificationManager.shared.cancelResetNotification(profileId: profile.id, type: .weeklyReset)
+        }
     }
 
     /// Checks if a session reset occurred and records a snapshot if so

--- a/Claude Usage/Shared/Localization/LocalizationManager.swift
+++ b/Claude Usage/Shared/Localization/LocalizationManager.swift
@@ -23,6 +23,12 @@ extension String {
     func localized(comment: String) -> String {
         return NSLocalizedString(self, comment: comment)
     }
+
+    /// Returns the localized string for this key, or `fallback` if the key is missing.
+    /// `NSLocalizedString(value:)` already returns `value` on a table miss.
+    func localizedOrFallback(_ fallback: String) -> String {
+        return NSLocalizedString(self, value: fallback, comment: "")
+    }
 }
 
 /// Type-safe localization keys (optional but recommended)

--- a/Claude Usage/Shared/Models/NotificationSettings.swift
+++ b/Claude Usage/Shared/Models/NotificationSettings.swift
@@ -16,6 +16,16 @@ struct NotificationSettings: Codable, Equatable {
     var soundName: String
     var customThresholds: [Int]
 
+    /// Fires a notification at the moment the 5-hour rolling session window resets.
+    /// Scheduled via UNCalendarNotificationTrigger using the upcoming
+    /// `sessionResetTime` reported by the API, so the alert delivers even if the
+    /// app is offline or quit at the time of reset.
+    var sessionResetEnabled: Bool
+
+    /// Fires a notification at the moment the weekly limit window resets.
+    /// Scheduled the same way as the session reset alert.
+    var weeklyResetEnabled: Bool
+
     /// All active thresholds (built-in + custom), sorted ascending
     var sortedThresholds: [Int] {
         var thresholds: [Int] = []
@@ -44,7 +54,9 @@ struct NotificationSettings: Codable, Equatable {
         threshold90Enabled: Bool = true,
         threshold95Enabled: Bool = true,
         soundName: String = "default",
-        customThresholds: [Int] = []
+        customThresholds: [Int] = [],
+        sessionResetEnabled: Bool = false,
+        weeklyResetEnabled: Bool = false
     ) {
         self.enabled = enabled
         self.threshold75Enabled = threshold75Enabled
@@ -52,6 +64,8 @@ struct NotificationSettings: Codable, Equatable {
         self.threshold95Enabled = threshold95Enabled
         self.soundName = soundName
         self.customThresholds = customThresholds
+        self.sessionResetEnabled = sessionResetEnabled
+        self.weeklyResetEnabled = weeklyResetEnabled
     }
 
     // Backwards-compatible decoding for existing saved settings
@@ -63,5 +77,7 @@ struct NotificationSettings: Codable, Equatable {
         threshold95Enabled = try container.decode(Bool.self, forKey: .threshold95Enabled)
         soundName = try container.decodeIfPresent(String.self, forKey: .soundName) ?? "default"
         customThresholds = try container.decodeIfPresent([Int].self, forKey: .customThresholds) ?? []
+        sessionResetEnabled = try container.decodeIfPresent(Bool.self, forKey: .sessionResetEnabled) ?? false
+        weeklyResetEnabled = try container.decodeIfPresent(Bool.self, forKey: .weeklyResetEnabled) ?? false
     }
 }

--- a/Claude Usage/Shared/Models/Profile.swift
+++ b/Claude Usage/Shared/Models/Profile.swift
@@ -25,6 +25,14 @@ struct Profile: Codable, Identifiable, Equatable {
     var hasCliAccount: Bool
     var cliAccountSyncedAt: Date?
 
+    /// Optional override that pins this profile to a specific Claude Code keychain
+    /// service entry (e.g. `Claude Code-credentials-11e1b79e`) as the source of truth
+    /// for OAuth credentials. When set, refresh-aware reads bypass the cached
+    /// `cliCredentialsJSON` and pull fresh tokens directly from that keychain item —
+    /// which is what Claude Code rotates during normal use. Lets users with multiple
+    /// CLAUDE_CONFIG_DIR installs map each Tracker profile to its own keychain entry.
+    var customKeychainServiceName: String?
+
     /// Serialized `oauthAccount` object from Claude Code's `.claude.json` config file.
     /// Captured at sync time and re-applied during profile switches so that
     /// Claude Code's `/status` command shows the correct account for the active
@@ -65,6 +73,7 @@ struct Profile: Codable, Identifiable, Equatable {
         cliCredentialsJSON: String? = nil,
         hasCliAccount: Bool = false,
         cliAccountSyncedAt: Date? = nil,
+        customKeychainServiceName: String? = nil,
         oauthAccountJSON: String? = nil,
         claudeUsage: ClaudeUsage? = nil,
         apiUsage: APIUsage? = nil,
@@ -87,6 +96,7 @@ struct Profile: Codable, Identifiable, Equatable {
         self.cliCredentialsJSON = cliCredentialsJSON
         self.hasCliAccount = hasCliAccount
         self.cliAccountSyncedAt = cliAccountSyncedAt
+        self.customKeychainServiceName = customKeychainServiceName
         self.oauthAccountJSON = oauthAccountJSON
         self.claudeUsage = claudeUsage
         self.apiUsage = apiUsage
@@ -122,7 +132,7 @@ struct Profile: Codable, Identifiable, Equatable {
     }
 
     var hasAnyCredentials: Bool {
-        hasClaudeAI || hasAPIConsole || cliCredentialsJSON != nil
+        hasClaudeAI || hasAPIConsole || cliCredentialsJSON != nil || customKeychainServiceName != nil
     }
 }
 

--- a/Claude Usage/Shared/Services/ClaudeCodeSyncService.swift
+++ b/Claude Usage/Shared/Services/ClaudeCodeSyncService.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Security
+import CryptoKit
 
 /// Manages synchronization of Claude Code CLI credentials between system Keychain and profiles
 class ClaudeCodeSyncService {
@@ -288,6 +289,188 @@ class ClaudeCodeSyncService {
             return false
         }
         return result.exitCode == 0
+    }
+
+    /// Human-readable summary of a keychain entry, used to label the picker so the user
+    /// doesn't have to memorize raw hashes.
+    struct KeychainEntryDescription {
+        let serviceName: String
+        let emailAddress: String?
+        let organizationName: String?
+        let subscriptionType: String?
+
+        /// Picker label combining the most identifying info available with the
+        /// keychain svc shorthand so two similarly-described accounts stay distinct.
+        var displayLabel: String {
+            let svcShort: String
+            if serviceName == "Claude Code-credentials" {
+                svcShort = "default"
+            } else if serviceName.hasPrefix("Claude Code-credentials-") {
+                svcShort = String(serviceName.dropFirst("Claude Code-credentials-".count))
+            } else {
+                svcShort = serviceName
+            }
+
+            if let email = emailAddress {
+                if let org = organizationName, !org.isEmpty {
+                    return "\(email) — \(org) · \(svcShort)"
+                }
+                return "\(email) · \(svcShort)"
+            }
+            if let sub = subscriptionType, !sub.isEmpty {
+                return "\(svcShort) — \(sub)"
+            }
+            return serviceName
+        }
+    }
+
+    /// Builds a `KeychainEntryDescription` for the given service name. Tries to enrich
+    /// the raw hash with human-readable info by:
+    /// 1. Reading the keychain payload for `subscriptionType` + `organizationUuid`
+    /// 2. Matching that organizationUuid against any of `knownProfiles`' `oauthAccountJSON`
+    ///    to recover `emailAddress` + `organizationName`
+    /// 3. If still unknown, consulting `accountMap` (built once via
+    ///    `discoverAccountLabels()`) which derives hashes from local `.claude*` dirs.
+    /// Returns a description that always at least falls back to a sensible svc shorthand.
+    func describeKeychainEntry(
+        serviceName: String,
+        knownProfiles: [Profile],
+        accountMap: [String: (email: String, organizationName: String?)] = [:]
+    ) -> KeychainEntryDescription {
+        var subscription: String?
+        var orgUuid: String?
+
+        if let payload = readKeychainCredentials(serviceName: serviceName),
+           let data = payload.data(using: .utf8),
+           let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            let oauth = (root["claudeAiOauth"] as? [String: Any]) ?? [:]
+            subscription = oauth["subscriptionType"] as? String
+            orgUuid = (root["organizationUuid"] as? String) ?? (oauth["organizationUuid"] as? String)
+        }
+
+        var email: String?
+        var orgName: String?
+        if let orgUuid = orgUuid {
+            for profile in knownProfiles {
+                guard let json = profile.oauthAccountJSON,
+                      let d = json.data(using: .utf8),
+                      let r = try? JSONSerialization.jsonObject(with: d) as? [String: Any],
+                      (r["organizationUuid"] as? String) == orgUuid else {
+                    continue
+                }
+                email = r["emailAddress"] as? String
+                orgName = r["organizationName"] as? String
+                break
+            }
+        }
+
+        // Fall back to the path-derived account map (covers entries whose keychain
+        // payload doesn't carry an organizationUuid — newer Claude Code schemas).
+        if email == nil, let mapped = accountMap[serviceName] {
+            email = mapped.email
+            orgName = mapped.organizationName
+        }
+
+        return KeychainEntryDescription(
+            serviceName: serviceName,
+            emailAddress: email,
+            organizationName: orgName,
+            subscriptionType: subscription
+        )
+    }
+
+    /// Discovers a `keychain-svc → (email, org)` mapping by walking the user's home
+    /// directory for `.claude` and `.claude-*` config dirs, reading each one's
+    /// `.claude.json` `oauthAccount`, and computing the keychain hash Claude Code
+    /// derives from each directory path.
+    ///
+    /// Reverse-engineered fact (validated against live entries): for any non-default
+    /// CLAUDE_CONFIG_DIR, Claude Code stores credentials under
+    /// `Claude Code-credentials-<SHA256(absolute path)[:8]>`. The default `~/.claude`
+    /// maps to the unsuffixed `Claude Code-credentials` entry.
+    ///
+    /// This is the best path-independent way to label a keychain entry when its
+    /// payload doesn't include an organizationUuid (no token data is ever read here —
+    /// only `.claude.json` `oauthAccount` metadata, which is plain user identity info).
+    func discoverAccountLabels() -> [String: (email: String, organizationName: String?)] {
+        var labels: [String: (email: String, organizationName: String?)] = [:]
+        let fm = FileManager.default
+        let homeURL = fm.homeDirectoryForCurrentUser
+        let homePath = homeURL.path
+
+        var candidates: [String] = ["\(homePath)/.claude"]
+        if let entries = try? fm.contentsOfDirectory(atPath: homePath) {
+            for name in entries where name.hasPrefix(".claude-") {
+                candidates.append("\(homePath)/\(name)")
+            }
+        }
+
+        for dir in candidates {
+            let configFile = "\(dir)/.claude.json"
+            guard fm.fileExists(atPath: configFile),
+                  let data = try? Data(contentsOf: URL(fileURLWithPath: configFile)),
+                  let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let oa = root["oauthAccount"] as? [String: Any],
+                  let email = oa["emailAddress"] as? String else {
+                continue
+            }
+            let orgName = oa["organizationName"] as? String
+
+            let svc: String
+            if dir == "\(homePath)/.claude" {
+                svc = "Claude Code-credentials"
+            } else {
+                let hash = sha256HexPrefix(dir, length: 8)
+                svc = "Claude Code-credentials-\(hash)"
+            }
+            labels[svc] = (email, orgName)
+        }
+        return labels
+    }
+
+    // internal (not private) so unit tests can pin the live-validated hash algorithm.
+    func sha256HexPrefix(_ s: String, length: Int) -> String {
+        let digest = SHA256.hash(data: Data(s.utf8))
+        let hex = digest.map { String(format: "%02x", $0) }.joined()
+        return String(hex.prefix(length))
+    }
+
+    /// Enumerates every Claude Code credentials keychain item — both the legacy
+    /// unsuffixed `Claude Code-credentials` entry and all hash-suffix variants
+    /// (`Claude Code-credentials-<HASH>`). Used by the Advanced settings UI so the
+    /// user can pick the exact entry to pin a profile to.
+    ///
+    /// Uses `SecItemCopyMatching` (Security.framework) instead of shelling out to
+    /// `security dump-keychain` — the shell tool requires broad keychain-access
+    /// authorization and on macOS 26.x has been observed to hang indefinitely when
+    /// invoked from a background-app context where the keychain prompt cannot be
+    /// presented. The Security API is fast, doesn't spawn a subprocess, and only
+    /// returns attributes for items the app is already entitled to read.
+    func listClaudeCodeKeychainServices() -> [String] {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecMatchLimit as String: kSecMatchLimitAll,
+            kSecReturnAttributes as String: true,
+        ]
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess else {
+            if status != errSecItemNotFound {
+                LoggingService.shared.log("listClaudeCodeKeychainServices: SecItemCopyMatching failed (status=\(status))")
+            }
+            return []
+        }
+        guard let items = result as? [[String: Any]] else { return [] }
+
+        let prefix = "Claude Code-credentials"
+        var found: Set<String> = []
+        for item in items {
+            guard let name = item[kSecAttrService as String] as? String else { continue }
+            if name == prefix || name.hasPrefix("\(prefix)-") {
+                found.insert(name)
+            }
+        }
+        return found.sorted()
     }
 
     /// Searches the keychain for a hashed service name matching "Claude Code-credentials-*".
@@ -599,6 +782,245 @@ class ClaudeCodeSyncService {
         return Date() > expiryDate
     }
 
+    // MARK: - OAuth Token Auto-Refresh
+
+    /// Endpoint used by Claude Code's HUD to swap a refresh token for a fresh access token.
+    /// Mirrors `TOKEN_REFRESH_URL_*` in `oh-my-claude-sisyphus/dist/hud/usage-api.js`.
+    private static let oauthRefreshURL = URL(string: "https://platform.claude.com/v1/oauth/token")!
+
+    /// Public OAuth client ID for Claude Code, as shipped in the HUD source.
+    /// Overridable via `CLAUDE_CODE_OAUTH_CLIENT_ID` for parity with the HUD.
+    private static let defaultOAuthClientID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
+
+    /// How many seconds before expiry we proactively refresh the token.
+    /// Matches the HUD's 60-second leeway so a request never goes out with a token
+    /// that's about to expire mid-flight.
+    private static let refreshLeewaySeconds: TimeInterval = 60
+
+    /// Reads a specific Claude Code keychain item (e.g. `Claude Code-credentials-11e1b79e`)
+    /// by explicit service name, bypassing the `resolveServiceName()` chain. Used when a
+    /// profile pins itself to a non-default keychain entry via
+    /// `Profile.customKeychainServiceName`, so the Tracker can target the same entry Claude
+    /// Code rotates during normal CLI use. Returns nil if the entry is missing, the
+    /// security command timed out, or stdout was empty.
+    func readKeychainCredentials(serviceName: String) -> String? {
+        guard let result = runSecurityCommand(arguments: [
+            "find-generic-password", "-s", serviceName, "-a", NSUserName(), "-w"
+        ]) else {
+            return nil
+        }
+        if result.timedOut {
+            LoggingService.shared.log("readKeychainCredentials(svc=\(serviceName)): security command timed out")
+            return nil
+        }
+        if result.exitCode != 0 {
+            return nil
+        }
+        let value = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        return value.isEmpty ? nil : value
+    }
+
+    /// Writes a credentials JSON string into a specific keychain item by explicit service name.
+    /// Mirrors `writeSystemCredentials` but does not consult `resolveServiceName()` — callers
+    /// supply the exact target (e.g. a hash-suffix entry tied to one Claude Code account) so
+    /// rotated tokens from auto-refresh can be written back to the same place Claude Code reads.
+    func writeKeychainCredentials(serviceName: String, jsonData: String) throws {
+        // `-U` already updates an existing entry in place, so the previous delete-then-add
+        // pattern is unnecessary and was observed to leave the entry in a partially-overwritten
+        // (invalid-JSON) state under concurrent refreshes. Rely on a single atomic `-U` add.
+        guard let result = runSecurityCommand(arguments: [
+            "add-generic-password", "-s", serviceName, "-a", NSUserName(), "-w", jsonData, "-U"
+        ]) else {
+            throw ClaudeCodeError.keychainWriteFailed(status: -1)
+        }
+        if result.timedOut {
+            throw ClaudeCodeError.keychainWriteFailed(status: -1)
+        }
+        if result.exitCode != 0 {
+            throw ClaudeCodeError.keychainWriteFailed(status: OSStatus(result.exitCode))
+        }
+    }
+
+    // internal so unit tests can construct fixtures to feed mergeRefreshedCredentials.
+    struct OAuthRefreshResponse: Decodable {
+        let access_token: String
+        let refresh_token: String?
+        let expires_in: Int
+        let token_type: String?
+    }
+
+    /// Posts the `refresh_token` grant to platform.claude.com and decodes the response.
+    private func performTokenRefresh(refreshToken: String) async throws -> OAuthRefreshResponse {
+        let clientId = ProcessInfo.processInfo.environment["CLAUDE_CODE_OAUTH_CLIENT_ID"]
+            ?? Self.defaultOAuthClientID
+
+        var components = URLComponents()
+        components.queryItems = [
+            URLQueryItem(name: "grant_type", value: "refresh_token"),
+            URLQueryItem(name: "refresh_token", value: refreshToken),
+            URLQueryItem(name: "client_id", value: clientId),
+        ]
+        let bodyString = components.percentEncodedQuery ?? ""
+        let body = Data(bodyString.utf8)
+
+        var request = URLRequest(url: Self.oauthRefreshURL)
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.httpBody = body
+        request.timeoutInterval = 10
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw ClaudeCodeError.refreshFailed(status: -1, body: "No HTTP response")
+        }
+        guard http.statusCode == 200 else {
+            let snippet = String(data: data, encoding: .utf8)?.prefix(200) ?? "<binary>"
+            throw ClaudeCodeError.refreshFailed(status: http.statusCode, body: String(snippet))
+        }
+        return try JSONDecoder().decode(OAuthRefreshResponse.self, from: data)
+    }
+
+    /// Ensures the given profile's OAuth credentials are usable, refreshing them via the
+    /// `refresh_token` grant if expired (or near-expired). Returns the up-to-date credentials
+    /// JSON on success, or `nil` if the profile has no usable source, no refresh token, or
+    /// the network refresh failed.
+    ///
+    /// Source-of-truth selection:
+    /// - If `profile.customKeychainServiceName` is set, the Tracker reads the latest tokens
+    ///   directly from that keychain entry. Claude Code rotates tokens into the same entry
+    ///   during normal CLI use, so the read is usually already fresh — no network call needed.
+    /// - Otherwise, falls back to `profile.cliCredentialsJSON` (legacy behavior).
+    ///
+    /// On a successful refresh, the new credentials are written back to BOTH the profile's
+    /// cached JSON AND (when applicable) the custom keychain entry, so Claude Code and the
+    /// Tracker stay in sync.
+    func ensureFreshCredentials(for profileId: UUID) async -> String? {
+        let profiles = ProfileStore.shared.loadProfiles()
+        guard let profile = profiles.first(where: { $0.id == profileId }) else {
+            return nil
+        }
+
+        let customSvc = profile.customKeychainServiceName
+        var initialJSON: String?
+        if let svc = customSvc {
+            initialJSON = readKeychainCredentials(serviceName: svc)
+            if initialJSON == nil {
+                LoggingService.shared.logError("ensureFreshCredentials: profile '\(profile.name)' pins keychain '\(svc)' but it was not found")
+            } else if extractRefreshToken(from: initialJSON!) == nil {
+                // Keychain payload exists but is corrupt (e.g. invalid JSON after a prior bad
+                // write). Fall back to the profile's cached plist credentials so we still have
+                // a refresh_token to try — better than going dormant.
+                LoggingService.shared.logError("ensureFreshCredentials: keychain '\(svc)' payload for '\(profile.name)' is unparseable; falling back to plist cliCredentialsJSON")
+                initialJSON = profile.cliCredentialsJSON
+            }
+        } else {
+            initialJSON = profile.cliCredentialsJSON
+        }
+
+        guard let cliJSON = initialJSON else {
+            return nil
+        }
+
+        // Fast path: token still valid beyond the leeway window.
+        if let expiryDate = extractTokenExpiry(from: cliJSON),
+           expiryDate.timeIntervalSinceNow > Self.refreshLeewaySeconds {
+            // If we sourced from a custom keychain entry, mirror its current contents into the
+            // profile cache so display code (menu bar, popover) sees the up-to-date tokens.
+            if customSvc != nil {
+                persistProfileCredentialsJSON(profileId: profileId, json: cliJSON)
+            }
+            return cliJSON
+        }
+
+        guard let refreshToken = extractRefreshToken(from: cliJSON) else {
+            LoggingService.shared.log("ensureFreshCredentials: profile '\(profile.name)' has no refresh token; cannot auto-refresh")
+            return nil
+        }
+
+        let sourceTag = customSvc.map { "keychain:\($0)" } ?? "plist"
+        LoggingService.shared.log("ensureFreshCredentials: refreshing OAuth token for profile '\(profile.name)' (source=\(sourceTag))")
+
+        let refreshed: OAuthRefreshResponse
+        do {
+            refreshed = try await performTokenRefresh(refreshToken: refreshToken)
+        } catch let ClaudeCodeError.refreshFailed(status, body) {
+            // Surface the error body for diagnosis. 4xx responses never contain access
+            // tokens — only `{ "error": "...", "error_description": "..." }` style payloads —
+            // so logging it is safe.
+            LoggingService.shared.logError("ensureFreshCredentials: refresh failed for '\(profile.name)' (HTTP \(status)) body=\(body)")
+            return nil
+        } catch {
+            LoggingService.shared.logError("ensureFreshCredentials: refresh failed for '\(profile.name)'", error: error)
+            return nil
+        }
+
+        guard let updatedJSON = mergeRefreshedCredentials(into: cliJSON, refreshed: refreshed) else {
+            LoggingService.shared.logError("ensureFreshCredentials: failed to merge refreshed credentials for '\(profile.name)'")
+            return nil
+        }
+
+        // Write back: always update the profile cache; if we sourced from a custom keychain
+        // entry, also persist the rotated tokens there so Claude Code's next read picks them up.
+        persistProfileCredentialsJSON(profileId: profileId, json: updatedJSON)
+        if let svc = customSvc {
+            do {
+                try writeKeychainCredentials(serviceName: svc, jsonData: updatedJSON)
+            } catch {
+                LoggingService.shared.logError("ensureFreshCredentials: refreshed but failed to write back to keychain '\(svc)'", error: error)
+            }
+        }
+
+        LoggingService.shared.log("✓ ensureFreshCredentials: refreshed and saved for profile '\(profile.name)'")
+        return updatedJSON
+    }
+
+    /// Re-loads profiles and writes `json` into the profile's `cliCredentialsJSON` if it
+    /// differs from what's already stored. Re-loading inside the call minimizes the risk
+    /// of clobbering concurrent edits to other profile fields.
+    private func persistProfileCredentialsJSON(profileId: UUID, json: String) {
+        var reloaded = ProfileStore.shared.loadProfiles()
+        guard let idx = reloaded.firstIndex(where: { $0.id == profileId }),
+              reloaded[idx].cliCredentialsJSON != json else {
+            return
+        }
+        reloaded[idx].cliCredentialsJSON = json
+        ProfileStore.shared.saveProfiles(reloaded)
+    }
+
+    /// Merges an OAuth refresh response into the existing `claudeAiOauth` payload,
+    /// preserving fields the refresh response does not touch (scopes, subscriptionType, etc.).
+    // internal so unit tests can verify the merge correctness against fixtures.
+    func mergeRefreshedCredentials(into cliJSON: String, refreshed: OAuthRefreshResponse) -> String? {
+        guard let data = cliJSON.data(using: .utf8),
+              var root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              var oauth = root["claudeAiOauth"] as? [String: Any] else {
+            return nil
+        }
+
+        oauth["accessToken"] = refreshed.access_token
+        if let newRT = refreshed.refresh_token {
+            oauth["refreshToken"] = newRT
+        }
+        // Claude Code persists `expiresAt` in milliseconds since the Unix epoch.
+        let newExpiryMs = Int64(Date().timeIntervalSince1970 * 1000)
+            + Int64(refreshed.expires_in) * 1000
+        oauth["expiresAt"] = newExpiryMs
+
+        root["claudeAiOauth"] = oauth
+
+        // Single-line, sorted-keys output. Avoid `prettyPrinted` here because the
+        // resulting JSON is round-tripped through `security add-generic-password -w`,
+        // and embedded newlines have been observed to corrupt the stored payload on
+        // some macOS builds — readers then see "Extra data" parse errors.
+        guard let outData = try? JSONSerialization.data(
+                withJSONObject: root,
+                options: [.sortedKeys]),
+              let outString = String(data: outData, encoding: .utf8) else {
+            return nil
+        }
+        return outString
+    }
+
     // MARK: - Auto Re-sync Before Switching
 
     /// Re-syncs credentials from system Keychain before profile switching
@@ -664,6 +1086,7 @@ enum ClaudeCodeError: LocalizedError {
     case keychainReadFailed(status: OSStatus)
     case keychainWriteFailed(status: OSStatus)
     case noProfileCredentials
+    case refreshFailed(status: Int, body: String)
 
     var errorDescription: String? {
         switch self {
@@ -677,6 +1100,8 @@ enum ClaudeCodeError: LocalizedError {
             return "Failed to write credentials to system Keychain (status: \(status))."
         case .noProfileCredentials:
             return "This profile has no synced CLI account."
+        case .refreshFailed(let status, _):
+            return "OAuth token refresh failed (status: \(status))."
         }
     }
 }

--- a/Claude Usage/Shared/Services/NotificationManager.swift
+++ b/Claude Usage/Shared/Services/NotificationManager.swift
@@ -359,6 +359,75 @@ class NotificationManager: NotificationServiceProtocol {
     }
 }
 
+// MARK: - Reset Notifications (calendar-trigger-based)
+
+extension NotificationManager {
+    /// Schedules a local notification to fire when the upcoming usage reset occurs
+    /// (5-hour session window or weekly limit window).
+    ///
+    /// Uses `UNCalendarNotificationTrigger`, so macOS delivers the alert at the exact
+    /// reset instant — even when the app is quit, the machine is asleep, or the network
+    /// is offline at the moment of reset. Adding a new request with the same identifier
+    /// replaces any previously pending one, so this is safe to call on every API refresh:
+    /// if the server later reports a different reset time, the pending alert is updated
+    /// in place. Reset times that are already past or less than 5 seconds out are skipped.
+    func scheduleResetNotification(
+        profileId: UUID,
+        profileName: String,
+        type: AlertType,
+        resetTime: Date,
+        soundName: String = "default"
+    ) {
+        guard type == .sessionReset || type == .weeklyReset else { return }
+        guard resetTime.timeIntervalSinceNow > 5 else {
+            LoggingService.shared.log("scheduleResetNotification: skipping \(type.rawValue) for '\(profileName)' (resetTime in the past or <5s away)")
+            return
+        }
+
+        let identifier = resetNotificationIdentifier(profileId: profileId, type: type)
+
+        let content = UNMutableNotificationContent()
+        content.title = "\(profileName) - \(type.title)"
+        content.body = type.message(percentage: 0, resetTime: resetTime)
+        content.categoryIdentifier = "RESET_ALERT"
+        if soundName == "default" {
+            content.sound = .default
+        } else if soundName != "none" {
+            content.sound = UNNotificationSound(named: UNNotificationSoundName(soundName))
+        }
+
+        let components = Calendar.current.dateComponents(
+            [.year, .month, .day, .hour, .minute, .second],
+            from: resetTime
+        )
+        let trigger = UNCalendarNotificationTrigger(dateMatching: components, repeats: false)
+        let request = UNNotificationRequest(identifier: identifier, content: content, trigger: trigger)
+
+        UNUserNotificationCenter.current().add(request) { error in
+            if let error = error {
+                LoggingService.shared.logError("Failed to schedule reset notification for '\(profileName)' (\(type.rawValue)) at \(resetTime): \(error.localizedDescription)")
+            } else {
+                LoggingService.shared.log("✓ scheduled \(type.rawValue) for '\(profileName)' at \(resetTime) (id=\(identifier))")
+            }
+        }
+    }
+
+    /// Cancels any pending reset notification for the given profile + reset type.
+    /// Call this when the user disables the corresponding toggle or when a profile is removed.
+    func cancelResetNotification(profileId: UUID, type: AlertType) {
+        guard type == .sessionReset || type == .weeklyReset else { return }
+        let identifier = resetNotificationIdentifier(profileId: profileId, type: type)
+        UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: [identifier])
+    }
+
+    /// Uses the profile's UUID (not display name) so two profiles sharing the same name
+    /// can't silently collide and overwrite each other's pending reset alerts; renaming
+    /// a profile also doesn't leak orphan pending requests.
+    private func resetNotificationIdentifier(profileId: UUID, type: AlertType) -> String {
+        return "reset_\(type.rawValue)_\(profileId.uuidString)"
+    }
+}
+
 // MARK: - Alert Types
 
 extension NotificationManager {
@@ -367,6 +436,7 @@ extension NotificationManager {
         case sessionWarning = "session_warning"  // 90% threshold
         case sessionCritical = "session_critical"  // 95% threshold
         case sessionReset = "session_reset"
+        case weeklyReset = "weekly_reset"
         case sessionAutoStarted = "session_auto_started"
         case sessionAutoStartFailed = "session_auto_start_failed"
         case weeklyWarning = "weekly_warning"
@@ -386,6 +456,8 @@ extension NotificationManager {
                 return "notification.session_critical.title".localized
             case .sessionReset:
                 return "notification.session_reset.title".localized
+            case .weeklyReset:
+                return "notification.weekly_reset.title".localizedOrFallback("Weekly Limit Reset")
             case .sessionAutoStarted:
                 return "notification.session_auto_started.title".localized
             case .sessionAutoStartFailed:
@@ -418,6 +490,8 @@ extension NotificationManager {
                 return "notification.session_critical.message".localized(with: percentStr, resetStr)
             case .sessionReset:
                 return "notification.session_reset.message".localized
+            case .weeklyReset:
+                return "notification.weekly_reset.message".localizedOrFallback("Your weekly usage window just reset. You're back to 0%.")
             case .sessionAutoStarted:
                 return "notification.session_auto_started.message".localized
             case .sessionAutoStartFailed:

--- a/Claude Usage/Views/Settings/Credentials/CLIAccountView.swift
+++ b/Claude Usage/Views/Settings/Credentials/CLIAccountView.swift
@@ -13,6 +13,12 @@ struct CLIAccountView: View {
     @State private var syncError: String?
     @State private var cliAccountInfo: CLIAccountInfo?
 
+    // Advanced: custom keychain source override
+    @State private var availableKeychainServices: [String] = []
+    @State private var keychainLabels: [String: String] = [:]
+    @State private var selectedKeychainSvc: String? = nil
+    @State private var isLoadingKeychainList = false
+
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: DesignTokens.Spacing.section) {
@@ -189,6 +195,59 @@ struct CLIAccountView: View {
                         }
                     }
 
+                    // Advanced — pin profile to a specific Claude Code keychain entry so
+                    // Tracker reads the same token Claude Code rotates. See PR description
+                    // for the multi-account/token-rotation context.
+                    SettingsSectionCard(
+                        title: "Advanced — Credentials source",
+                        subtitle: "Pin this profile to a specific Claude Code keychain entry (multi-account setups)."
+                    ) {
+                        VStack(alignment: .leading, spacing: DesignTokens.Spacing.medium) {
+                            HStack(spacing: DesignTokens.Spacing.iconText) {
+                                Picker(selection: $selectedKeychainSvc) {
+                                    Text("(Automatic: default behavior)").tag(Optional<String>.none)
+                                    ForEach(availableKeychainServices, id: \.self) { svc in
+                                        Text(keychainLabels[svc] ?? svc).tag(Optional(svc))
+                                    }
+                                } label: {
+                                    Text("Keychain entry")
+                                }
+                                .pickerStyle(.menu)
+                                .onChange(of: selectedKeychainSvc) { _, newValue in
+                                    updateCustomKeychain(newValue)
+                                }
+
+                                Button(action: reloadKeychainList) {
+                                    HStack(spacing: DesignTokens.Spacing.extraSmall) {
+                                        if isLoadingKeychainList {
+                                            ProgressView()
+                                                .scaleEffect(0.7)
+                                                .frame(width: DesignTokens.Icons.small, height: DesignTokens.Icons.small)
+                                        } else {
+                                            Image(systemName: "arrow.clockwise")
+                                                .font(.system(size: DesignTokens.Icons.small))
+                                        }
+                                        Text("Refresh")
+                                            .font(DesignTokens.Typography.body)
+                                    }
+                                }
+                                .buttonStyle(.bordered)
+                                .controlSize(.small)
+                                .disabled(isLoadingKeychainList)
+                            }
+
+                            if availableKeychainServices.isEmpty && !isLoadingKeychainList {
+                                Text("No Claude Code keychain entries found. Log into the CLI, then Refresh.")
+                                    .font(DesignTokens.Typography.caption)
+                                    .foregroundColor(.secondary)
+                            } else if !availableKeychainServices.isEmpty {
+                                Text("Leave on (Automatic) unless you use multiple CLAUDE_CONFIG_DIRs.")
+                                    .font(DesignTokens.Typography.caption)
+                                    .foregroundColor(.secondary)
+                            }
+                        }
+                    }
+
                     // Info Card
                     SettingsContentCard {
                         VStack(alignment: .leading, spacing: DesignTokens.Spacing.medium) {
@@ -224,12 +283,61 @@ struct CLIAccountView: View {
         }
         .onAppear {
             loadCLIAccountInfo()
+            syncSelectedKeychainFromProfile()
+            reloadKeychainList()
         }
         .onChange(of: profileManager.activeProfile?.id) { _, _ in
             // Reload when profile changes
             loadCLIAccountInfo()
             syncError = nil
+            syncSelectedKeychainFromProfile()
         }
+    }
+
+    /// Loads the currently-pinned keychain svc into the picker selection so the UI
+    /// reflects the active profile's stored value when the view appears or the
+    /// profile changes.
+    private func syncSelectedKeychainFromProfile() {
+        selectedKeychainSvc = profileManager.activeProfile?.customKeychainServiceName
+    }
+
+    /// Enumerates Claude Code keychain entries via SecItemCopyMatching and also
+    /// builds a human-readable label for each (email + org from any matching
+    /// profile.oauthAccountJSON; subscription type as fallback). Runs off the main
+    /// thread so the UI stays responsive even if the keychain is large.
+    private func reloadKeychainList() {
+        isLoadingKeychainList = true
+        let knownProfiles = profileManager.profiles
+        DispatchQueue.global(qos: .userInitiated).async {
+            let services = ClaudeCodeSyncService.shared.listClaudeCodeKeychainServices()
+            // Build the path-derived account map once per refresh; reused for every entry.
+            let accountMap = ClaudeCodeSyncService.shared.discoverAccountLabels()
+            var labels: [String: String] = [:]
+            for svc in services {
+                let desc = ClaudeCodeSyncService.shared.describeKeychainEntry(
+                    serviceName: svc,
+                    knownProfiles: knownProfiles,
+                    accountMap: accountMap
+                )
+                labels[svc] = desc.displayLabel
+            }
+            DispatchQueue.main.async {
+                self.availableKeychainServices = services
+                self.keychainLabels = labels
+                self.isLoadingKeychainList = false
+            }
+        }
+    }
+
+    /// Persists the selected keychain service name onto the active profile so the
+    /// menu bar fetch path picks it up on the next refresh cycle.
+    private func updateCustomKeychain(_ svc: String?) {
+        guard var updated = profileManager.activeProfile else { return }
+        let normalized = (svc?.isEmpty ?? true) ? nil : svc
+        if updated.customKeychainServiceName == normalized { return }
+        updated.customKeychainServiceName = normalized
+        profileManager.updateProfile(updated)
+        LoggingService.shared.log("CLIAccountView: profile '\(updated.name)' customKeychainServiceName set to \(normalized ?? "<nil>")")
     }
 
     private func syncFromCLI() {

--- a/Claude Usage/Views/Settings/Profile/GeneralSettingsView.swift
+++ b/Claude Usage/Views/Settings/Profile/GeneralSettingsView.swift
@@ -175,6 +175,42 @@ struct GeneralSettingsView: View {
                                     }
                                 }
 
+                                // Reset alerts (calendar-trigger; fires even when app is quit/offline)
+                                Divider()
+
+                                VStack(alignment: .leading, spacing: DesignTokens.Spacing.medium) {
+                                    Text("Reset alerts")
+                                        .font(DesignTokens.Typography.body)
+                                        .fontWeight(.medium)
+                                        .foregroundColor(.secondary)
+
+                                    SettingToggle(
+                                        title: "Notify on 5-hour session reset",
+                                        description: "Schedule a local notification at the moment your 5-hour usage window rolls over for this profile.",
+                                        isOn: Binding(
+                                            get: { profile.notificationSettings.sessionResetEnabled },
+                                            set: { newValue in
+                                                var updated = profile
+                                                updated.notificationSettings.sessionResetEnabled = newValue
+                                                profileManager.updateProfile(updated)
+                                            }
+                                        )
+                                    )
+
+                                    SettingToggle(
+                                        title: "Notify on weekly limit reset",
+                                        description: "Schedule a local notification at the moment your weekly usage window resets for this profile.",
+                                        isOn: Binding(
+                                            get: { profile.notificationSettings.weeklyResetEnabled },
+                                            set: { newValue in
+                                                var updated = profile
+                                                updated.notificationSettings.weeklyResetEnabled = newValue
+                                                profileManager.updateProfile(updated)
+                                            }
+                                        )
+                                    )
+                                }
+
                                 // Custom thresholds
                                 Divider()
 

--- a/Claude UsageTests/ClaudeUsageTests.swift
+++ b/Claude UsageTests/ClaudeUsageTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import CryptoKit
 @testable import Claude_Usage
 
 final class ClaudeUsageTests: XCTestCase {
@@ -94,3 +95,157 @@ final class ClaudeUsageTests: XCTestCase {
         )
     }
 }
+
+// MARK: - Profile custom keychain field
+
+final class ProfileCustomKeychainTests: XCTestCase {
+    func testDecodesOldPlistWithoutCustomKeychainField() throws {
+        // Simulate an older-shape plist by encoding then stripping the new key.
+        let original = Profile(id: UUID(), name: "AccountA")
+        let data = try JSONEncoder().encode(original)
+        var obj = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        obj.removeValue(forKey: "customKeychainServiceName")
+        let pruned = try JSONSerialization.data(withJSONObject: obj)
+        let decoded = try JSONDecoder().decode(Profile.self, from: pruned)
+        XCTAssertNil(decoded.customKeychainServiceName)
+    }
+
+    func testHasAnyCredentialsRecognizesCustomKeychainPin() {
+        let bare = Profile(id: UUID(), name: "AccountA")
+        XCTAssertFalse(bare.hasAnyCredentials)
+
+        let pinned = Profile(
+            id: UUID(),
+            name: "AccountA",
+            customKeychainServiceName: "Claude Code-credentials-abcd1234"
+        )
+        XCTAssertTrue(pinned.hasAnyCredentials)
+    }
+}
+
+// MARK: - ClaudeCodeSyncService logic helpers
+
+final class ClaudeCodeSyncServiceLogicTests: XCTestCase {
+    private var service: ClaudeCodeSyncService { ClaudeCodeSyncService.shared }
+
+    // Locks the hash algorithm Claude Code uses to derive
+    // `Claude Code-credentials-<HASH>` from a CLAUDE_CONFIG_DIR path so a future
+    // change in either side is caught immediately.
+    func testSha256HexPrefixMatchesClaudeCodeKeychainHashAlgorithm() {
+        let path = "/tmp/fixture-config-dir"
+        let expected = SHA256.hash(data: Data(path.utf8))
+            .map { String(format: "%02x", $0) }
+            .joined()
+            .prefix(8)
+        XCTAssertEqual(service.sha256HexPrefix(path, length: 8), String(expected))
+    }
+
+    func testMergeRefreshedCredentialsUpdatesAccessTokenAndExpiresAt() throws {
+        let cliJSON = #"""
+        {
+            "claudeAiOauth": {
+                "accessToken": "OLD",
+                "refreshToken": "OLD-RT",
+                "expiresAt": 1000,
+                "scopes": ["a", "b"],
+                "subscriptionType": "max"
+            },
+            "organizationUuid": "org-1"
+        }
+        """#
+        let refreshed = ClaudeCodeSyncService.OAuthRefreshResponse(
+            access_token: "NEW",
+            refresh_token: nil,
+            expires_in: 3600,
+            token_type: "Bearer"
+        )
+        let merged = try XCTUnwrap(service.mergeRefreshedCredentials(into: cliJSON, refreshed: refreshed))
+        let obj = try JSONSerialization.jsonObject(with: Data(merged.utf8)) as! [String: Any]
+        let oauth = obj["claudeAiOauth"] as! [String: Any]
+        XCTAssertEqual(oauth["accessToken"] as? String, "NEW")
+        // Refresh token preserved when response omits it
+        XCTAssertEqual(oauth["refreshToken"] as? String, "OLD-RT")
+        // expiresAt persisted as ms-since-epoch, ~now()+3600s
+        let exp = (oauth["expiresAt"] as? NSNumber)?.int64Value ?? 0
+        let nowMs = Int64(Date().timeIntervalSince1970 * 1000)
+        XCTAssertGreaterThan(exp, nowMs + 3500 * 1000)
+        XCTAssertLessThan(exp, nowMs + 3700 * 1000)
+        // Untouched fields preserved
+        XCTAssertEqual(obj["organizationUuid"] as? String, "org-1")
+        XCTAssertEqual(oauth["subscriptionType"] as? String, "max")
+        XCTAssertEqual(oauth["scopes"] as? [String], ["a", "b"])
+    }
+
+    func testMergeRefreshedCredentialsRotatesRefreshTokenWhenProvided() throws {
+        let cliJSON = #"{"claudeAiOauth":{"accessToken":"old","refreshToken":"old-rt","expiresAt":0}}"#
+        let refreshed = ClaudeCodeSyncService.OAuthRefreshResponse(
+            access_token: "new",
+            refresh_token: "new-rt",
+            expires_in: 60,
+            token_type: nil
+        )
+        let merged = try XCTUnwrap(service.mergeRefreshedCredentials(into: cliJSON, refreshed: refreshed))
+        let obj = try JSONSerialization.jsonObject(with: Data(merged.utf8)) as! [String: Any]
+        let oauth = obj["claudeAiOauth"] as! [String: Any]
+        XCTAssertEqual(oauth["refreshToken"] as? String, "new-rt")
+    }
+
+    func testMergeRefreshedCredentialsRejectsInputWithoutClaudeAiOauth() {
+        let cliJSON = #"{"unknownRoot": {}}"#
+        let refreshed = ClaudeCodeSyncService.OAuthRefreshResponse(
+            access_token: "x", refresh_token: nil, expires_in: 60, token_type: nil
+        )
+        XCTAssertNil(service.mergeRefreshedCredentials(into: cliJSON, refreshed: refreshed))
+    }
+
+    func testDisplayLabelEmailAndOrg() {
+        let d = ClaudeCodeSyncService.KeychainEntryDescription(
+            serviceName: "Claude Code-credentials-abcd1234",
+            emailAddress: "user@example.com",
+            organizationName: "ExampleOrg",
+            subscriptionType: "max"
+        )
+        XCTAssertEqual(d.displayLabel, "user@example.com — ExampleOrg · abcd1234")
+    }
+
+    func testDisplayLabelEmailOnly() {
+        let d = ClaudeCodeSyncService.KeychainEntryDescription(
+            serviceName: "Claude Code-credentials-abcd1234",
+            emailAddress: "user@example.com",
+            organizationName: nil,
+            subscriptionType: nil
+        )
+        XCTAssertEqual(d.displayLabel, "user@example.com · abcd1234")
+    }
+
+    func testDisplayLabelDefaultShorthand() {
+        let d = ClaudeCodeSyncService.KeychainEntryDescription(
+            serviceName: "Claude Code-credentials",
+            emailAddress: "user@example.com",
+            organizationName: nil,
+            subscriptionType: nil
+        )
+        XCTAssertEqual(d.displayLabel, "user@example.com · default")
+    }
+
+    func testDisplayLabelSubscriptionFallback() {
+        let d = ClaudeCodeSyncService.KeychainEntryDescription(
+            serviceName: "Claude Code-credentials-abcd1234",
+            emailAddress: nil,
+            organizationName: nil,
+            subscriptionType: "team"
+        )
+        XCTAssertEqual(d.displayLabel, "abcd1234 — team")
+    }
+
+    func testDisplayLabelRawSvcFallback() {
+        let d = ClaudeCodeSyncService.KeychainEntryDescription(
+            serviceName: "Claude Code-credentials-abcd1234",
+            emailAddress: nil,
+            organizationName: nil,
+            subscriptionType: nil
+        )
+        XCTAssertEqual(d.displayLabel, "Claude Code-credentials-abcd1234")
+    }
+}
+

--- a/Claude UsageTests/ClaudeUsageTests.swift
+++ b/Claude UsageTests/ClaudeUsageTests.swift
@@ -96,6 +96,30 @@ final class ClaudeUsageTests: XCTestCase {
     }
 }
 
+// MARK: - NotificationSettings backwards-compat
+
+final class NotificationSettingsCodableTests: XCTestCase {
+    func testDecodesOldPlistWithoutResetFlags() throws {
+        let json = #"{"enabled":true,"threshold75Enabled":true,"threshold90Enabled":true,"threshold95Enabled":true}"#.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(NotificationSettings.self, from: json)
+        XCTAssertFalse(decoded.sessionResetEnabled)
+        XCTAssertFalse(decoded.weeklyResetEnabled)
+        XCTAssertEqual(decoded.soundName, "default")
+        XCTAssertEqual(decoded.customThresholds, [])
+    }
+
+    func testRoundTripsResetFlags() throws {
+        let original = NotificationSettings(
+            sessionResetEnabled: true,
+            weeklyResetEnabled: true
+        )
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(NotificationSettings.self, from: data)
+        XCTAssertTrue(decoded.sessionResetEnabled)
+        XCTAssertTrue(decoded.weeklyResetEnabled)
+    }
+}
+
 // MARK: - Profile custom keychain field
 
 final class ProfileCustomKeychainTests: XCTestCase {
@@ -249,3 +273,11 @@ final class ClaudeCodeSyncServiceLogicTests: XCTestCase {
     }
 }
 
+// MARK: - LocalizationManager fallback
+
+final class LocalizationFallbackTests: XCTestCase {
+    func testReturnsFallbackForMissingKey() {
+        let missingKey = "test.surely.missing.\(UUID().uuidString)"
+        XCTAssertEqual(missingKey.localizedOrFallback("FB"), "FB")
+    }
+}


### PR DESCRIPTION
Fixes #241. **Depends on #242** — diff temporarily includes the keychain-source-pin changes; please review/merge #242 first, then this PR's `base` can be re-targeted to a clean `main`.

## Summary

Adds per-profile local notifications that fire at the exact reset moment of the 5-hour session window and the weekly limit window — delivered by macOS even when Tracker is quit or the machine is offline at the time of reset.

## What this PR adds on top of #242

| File | Change |
|---|---|
| `Claude Usage/Shared/Models/NotificationSettings.swift` | two reset toggles + `decodeIfPresent` |
| `Claude Usage/Shared/Localization/LocalizationManager.swift` | `localizedOrFallback(_:)` |
| `Claude Usage/Shared/Services/NotificationManager.swift` | `AlertType.weeklyReset`, `scheduleResetNotification`, `cancelResetNotification`, UUID-keyed identifier |
| `Claude Usage/MenuBar/MenuBarManager.swift` | `scheduleResetAlertsIfEnabled` + wired into both fetch paths |
| `Claude Usage/Views/Settings/Profile/GeneralSettingsView.swift` | two per-profile UI toggles |
| `Claude UsageTests/ClaudeUsageTests.swift` | 3 unit tests (Codable back-compat for reset flags + `localizedOrFallback` fallback) |

Files also touched by #242 are unchanged here from that PR's content; the diff in this PR will collapse to just the table above once #242 merges and this branch is rebased.

## Implementation

- `UNCalendarNotificationTrigger` so macOS holds the pending request and fires it at the exact target date regardless of app state.
- Identifier is `reset_<type>_<profile.id.uuidString>` (UUID, not display name) so renames don't leak orphan pending alerts and two profiles sharing a display name can't collide.
- `MenuBarManager.scheduleResetAlertsIfEnabled` runs after every successful usage fetch in both the multi-profile loop and the single-profile path, re-scheduling against the freshly fetched reset times. Re-adding a request with the same identifier cleanly replaces any prior pending one, so this is safe to call on every cycle.

## Test plan

1. With the toggles ON for a profile, observe the log line on every fetch:
   ```
   ✓ scheduled session_reset for 'AccountA' at <UTC instant> (id=reset_session_reset_<uuid>)
   ✓ scheduled weekly_reset for 'AccountA' at <UTC instant> (id=reset_weekly_reset_<uuid>)
   ```
2. Quit Tracker; at the scheduled instant, macOS delivers the alert via the system notification daemon (verified locally).
3. Toggle OFF → `cancelResetNotification` removes the pending request immediately.
4. Unit tests run via Xcode's `Test` action; all new cases pass alongside the existing suite (`** TEST SUCCEEDED **`).

## Dependency rationale

#241 needs reliable per-profile fetch results to know the correct reset times for *inactive* profiles. Without the keychain-source pin from PR #242, an inactive profile in a multi-account setup eventually stops receiving fresh reset times (HTTP 400 invalid_grant) and its scheduled alert would freeze on whatever the last fetch saw. Single-profile users don't hit that path, so this PR is still useful standalone — but it really shines stacked on top of #242.

## Optional follow-ups (out of scope)

- `Localizable.strings` entries for `notification.weekly_reset.{title,message}` (currently English via `localizedOrFallback`).
