### PR TITLE
Add opt-in local server for a companion mobile app

### DIFF
--- a/Claude Usage/App/AppDelegate.swift
+++ b/Claude Usage/App/AppDelegate.swift
@@ -45,6 +45,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         // Start 24-hour heartbeat ping to track active app usage
         HeartbeatService.shared.start()
 
+        // Start the local companion server if the user has enabled pairing
+        LocalServerService.shared.startIfEnabled()
+
         if !shouldShowSetupWizard() {
             // Initialize menu bar with active profile
             menuBarManager?.setup()
@@ -218,6 +221,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
     func applicationWillTerminate(_ notification: Notification) {
         // Cleanup
         menuBarManager?.cleanup()
+        LocalServerService.shared.stop()
     }
 
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {

--- a/Claude Usage/Shared/Services/LocalServerService.swift
+++ b/Claude Usage/Shared/Services/LocalServerService.swift
@@ -1,0 +1,335 @@
+//
+//  LocalServerService.swift
+//  Claude Usage
+//
+//  An opt-in, read-only HTTP server that exposes the current Claude usage
+//  snapshot to trusted devices on the local network (e.g. a companion mobile
+//  app). See `Claude Usage/Views/Settings/App/MobileAppView.swift` for the
+//  pairing UI.
+//
+//  Security model
+//  ──────────────
+//  • Disabled by default; must be explicitly enabled by the user in Settings.
+//  • Every request must present a matching `Authorization: Bearer <token>`
+//    (or `?token=` query param). The token is generated locally and only
+//    leaves the machine via the QR pairing code the user chooses to show.
+//  • Read-only: the only data endpoint returns the already-computed
+//    `ClaudeUsage` value that the menu bar already displays.
+//  • The Claude session key NEVER leaves this machine — the phone only ever
+//    sees the derived usage numbers.
+//
+
+import Foundation
+import Network
+
+final class LocalServerService {
+    static let shared = LocalServerService()
+
+    /// Version of the wire contract consumed by client apps. Bump when the
+    /// JSON shape changes in a backwards-incompatible way.
+    static let apiVersion = "v1"
+
+    /// Default TCP port. Chosen to avoid common dev ports; user-overridable.
+    static let defaultPort: UInt16 = 47600
+
+    private var listener: NWListener?
+    private let queue = DispatchQueue(label: "com.claudeusagetracker.localserver", qos: .utility)
+
+    private(set) var isRunning = false
+
+    private init() {}
+
+    // MARK: - Lifecycle
+
+    /// Starts the server only if the user has enabled it in Settings.
+    func startIfEnabled() {
+        guard SharedDataStore.shared.loadLocalServerEnabled() else {
+            LoggingService.shared.log("LocalServer: disabled, not starting")
+            return
+        }
+        start()
+    }
+
+    func start() {
+        stop()
+
+        let rawPort = UInt16(SharedDataStore.shared.loadLocalServerPort())
+        let port = NWEndpoint.Port(rawValue: rawPort == 0 ? Self.defaultPort : rawPort)
+            ?? NWEndpoint.Port(rawValue: Self.defaultPort)!
+
+        // Ensure a token exists before we begin accepting connections.
+        _ = SharedDataStore.shared.loadOrCreateLocalServerToken()
+
+        do {
+            let params = NWParameters.tcp
+            params.allowLocalEndpointReuse = true
+            // Bind on all interfaces so devices on the LAN can reach us.
+            let listener = try NWListener(using: params, on: port)
+
+            listener.newConnectionHandler = { [weak self] connection in
+                self?.handle(connection)
+            }
+            listener.stateUpdateHandler = { [weak self] state in
+                switch state {
+                case .ready:
+                    self?.isRunning = true
+                    LoggingService.shared.log("LocalServer: listening on port \(port.rawValue)")
+                case .failed(let error):
+                    self?.isRunning = false
+                    LoggingService.shared.logError("LocalServer: listener failed: \(error.localizedDescription)")
+                case .cancelled:
+                    self?.isRunning = false
+                default:
+                    break
+                }
+            }
+
+            listener.start(queue: queue)
+            self.listener = listener
+        } catch {
+            isRunning = false
+            LoggingService.shared.logError("LocalServer: failed to start: \(error.localizedDescription)")
+        }
+    }
+
+    func stop() {
+        listener?.cancel()
+        listener = nil
+        isRunning = false
+    }
+
+    /// Restart to pick up a changed port or token.
+    func restart() {
+        start()
+    }
+
+    // MARK: - Connection handling
+
+    private func handle(_ connection: NWConnection) {
+        connection.start(queue: queue)
+        receive(on: connection, buffer: Data())
+    }
+
+    /// Accumulate bytes until the end of the HTTP request headers (`\r\n\r\n`).
+    /// We only support GET, so the body (if any) is irrelevant.
+    private func receive(on connection: NWConnection, buffer: Data) {
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 64 * 1024) { [weak self] data, _, isComplete, error in
+            guard let self else { return }
+
+            var buffer = buffer
+            if let data { buffer.append(data) }
+
+            if let headerEnd = buffer.range(of: Data("\r\n\r\n".utf8)) {
+                let headerData = buffer.subdata(in: buffer.startIndex..<headerEnd.lowerBound)
+                self.respond(toHeaders: headerData, on: connection)
+            } else if isComplete || error != nil || buffer.count > 64 * 1024 {
+                connection.cancel()
+            } else {
+                self.receive(on: connection, buffer: buffer)
+            }
+        }
+    }
+
+    // MARK: - Routing
+
+    private func respond(toHeaders headerData: Data, on connection: NWConnection) {
+        guard let headerText = String(data: headerData, encoding: .utf8) else {
+            send(status: "400 Bad Request", json: ["error": "invalid_request"], on: connection)
+            return
+        }
+
+        let lines = headerText.components(separatedBy: "\r\n")
+        guard let requestLine = lines.first else {
+            send(status: "400 Bad Request", json: ["error": "invalid_request"], on: connection)
+            return
+        }
+
+        let parts = requestLine.split(separator: " ")
+        guard parts.count >= 2 else {
+            send(status: "400 Bad Request", json: ["error": "invalid_request"], on: connection)
+            return
+        }
+
+        let method = String(parts[0])
+        let rawTarget = String(parts[1])
+        let (path, query) = Self.splitTarget(rawTarget)
+
+        guard method == "GET" else {
+            send(status: "405 Method Not Allowed", json: ["error": "method_not_allowed"], on: connection)
+            return
+        }
+
+        // Authenticate every request.
+        guard isAuthorized(headerLines: lines, query: query) else {
+            send(status: "401 Unauthorized", json: ["error": "unauthorized"], on: connection)
+            return
+        }
+
+        switch path {
+        case "/\(Self.apiVersion)/ping":
+            send(status: "200 OK", json: [
+                "ok": true,
+                "app": "claude-usage-tracker",
+                "apiVersion": Self.apiVersion
+            ], on: connection)
+
+        case "/\(Self.apiVersion)/usage":
+            sendUsage(on: connection)
+
+        default:
+            send(status: "404 Not Found", json: ["error": "not_found"], on: connection)
+        }
+    }
+
+    // MARK: - Auth
+
+    private func isAuthorized(headerLines: [String], query: [String: String]) -> Bool {
+        let expected = SharedDataStore.shared.loadOrCreateLocalServerToken()
+        guard !expected.isEmpty else { return false }
+
+        var presented: String?
+        for line in headerLines {
+            let lower = line.lowercased()
+            if lower.hasPrefix("authorization:") {
+                let value = line.dropFirst("authorization:".count).trimmingCharacters(in: .whitespaces)
+                if value.lowercased().hasPrefix("bearer ") {
+                    presented = String(value.dropFirst("bearer ".count)).trimmingCharacters(in: .whitespaces)
+                }
+            }
+        }
+        if presented == nil { presented = query["token"] }
+
+        guard let token = presented else { return false }
+        return Self.constantTimeEquals(token, expected)
+    }
+
+    // MARK: - Usage payload
+
+    private func sendUsage(on connection: NWConnection) {
+        let usage = DataStore.shared.loadUsage()
+        let profileName = ProfileManager.shared.activeProfile?.name
+
+        let response = UsageResponse(
+            apiVersion: Self.apiVersion,
+            serverTime: Date(),
+            profileName: profileName,
+            hasData: usage != nil,
+            usage: usage
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.withoutEscapingSlashes]
+
+        do {
+            let body = try encoder.encode(response)
+            send(status: "200 OK", body: body, contentType: "application/json", on: connection)
+        } catch {
+            send(status: "500 Internal Server Error", json: ["error": "encode_failed"], on: connection)
+        }
+    }
+
+    /// Wire envelope around `ClaudeUsage`. Dates are ISO-8601; `userTimezone`
+    /// encodes as its identifier string (e.g. "America/New_York").
+    private struct UsageResponse: Encodable {
+        let apiVersion: String
+        let serverTime: Date
+        let profileName: String?
+        let hasData: Bool
+        let usage: ClaudeUsage?
+    }
+
+    // MARK: - Response writing
+
+    private func send(status: String, json: [String: Any], on connection: NWConnection) {
+        let body = (try? JSONSerialization.data(withJSONObject: json)) ?? Data("{}".utf8)
+        send(status: status, body: body, contentType: "application/json", on: connection)
+    }
+
+    private func send(status: String, body: Data, contentType: String, on connection: NWConnection) {
+        var header = "HTTP/1.1 \(status)\r\n"
+        header += "Content-Type: \(contentType)\r\n"
+        header += "Content-Length: \(body.count)\r\n"
+        header += "Connection: close\r\n"
+        header += "Cache-Control: no-store\r\n"
+        header += "\r\n"
+
+        var response = Data(header.utf8)
+        response.append(body)
+
+        connection.send(content: response, completion: .contentProcessed { _ in
+            connection.cancel()
+        })
+    }
+
+    // MARK: - Helpers
+
+    private static func splitTarget(_ target: String) -> (path: String, query: [String: String]) {
+        guard let qIndex = target.firstIndex(of: "?") else { return (target, [:]) }
+        let path = String(target[target.startIndex..<qIndex])
+        let queryString = String(target[target.index(after: qIndex)...])
+        var query: [String: String] = [:]
+        for pair in queryString.split(separator: "&") {
+            let kv = pair.split(separator: "=", maxSplits: 1)
+            if kv.count == 2 {
+                let key = String(kv[0]).removingPercentEncoding ?? String(kv[0])
+                let value = String(kv[1]).removingPercentEncoding ?? String(kv[1])
+                query[key] = value
+            }
+        }
+        return (path, query)
+    }
+
+    /// Length-independent comparison to avoid leaking the token via timing.
+    private static func constantTimeEquals(_ a: String, _ b: String) -> Bool {
+        let aBytes = Array(a.utf8)
+        let bBytes = Array(b.utf8)
+        guard aBytes.count == bBytes.count else { return false }
+        var diff: UInt8 = 0
+        for i in 0..<aBytes.count {
+            diff |= aBytes[i] ^ bBytes[i]
+        }
+        return diff == 0
+    }
+
+    // MARK: - Network info (for the pairing UI)
+
+    /// Best-guess primary LAN IPv4 address (e.g. "192.168.1.42"), or nil.
+    static func primaryLANAddress() -> String? {
+        var address: String?
+        var ifaddr: UnsafeMutablePointer<ifaddrs>?
+        guard getifaddrs(&ifaddr) == 0, let first = ifaddr else { return nil }
+        defer { freeifaddrs(ifaddr) }
+
+        var candidates: [String: String] = [:]
+        var pointer: UnsafeMutablePointer<ifaddrs>? = first
+        while let ptr = pointer {
+            defer { pointer = ptr.pointee.ifa_next }
+            let interface = ptr.pointee
+            let family = interface.ifa_addr.pointee.sa_family
+            guard family == UInt8(AF_INET) else { continue }
+
+            let name = String(cString: interface.ifa_name)
+            // Skip loopback and virtual interfaces.
+            guard name != "lo0", !name.hasPrefix("utun"), !name.hasPrefix("bridge") else { continue }
+
+            var hostBuffer = [CChar](repeating: 0, count: Int(NI_MAXHOST))
+            let result = getnameinfo(
+                interface.ifa_addr,
+                socklen_t(interface.ifa_addr.pointee.sa_len),
+                &hostBuffer, socklen_t(hostBuffer.count),
+                nil, 0, NI_NUMERICHOST
+            )
+            if result == 0 {
+                candidates[name] = String(cString: hostBuffer)
+            }
+        }
+
+        // Prefer Wi-Fi/Ethernet (en0/en1) when present.
+        for preferred in ["en0", "en1"] {
+            if let addr = candidates[preferred] { address = addr; break }
+        }
+        if address == nil { address = candidates.values.first }
+        return address
+    }
+}

--- a/Claude Usage/Shared/Storage/SharedDataStore.swift
+++ b/Claude Usage/Shared/Storage/SharedDataStore.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Security
 
 /// Manages app-wide settings that are shared across all profiles
 class SharedDataStore {
@@ -76,6 +77,11 @@ class SharedDataStore {
         static let timeFormatPreference = "timeFormatPreference"
         static let peakHoursIndicatorEnabled = "peakHoursIndicatorEnabled"
         static let peakHoursMenuIconEnabled = "peakHoursMenuIconEnabled"
+
+        // Local Server (companion mobile app pairing)
+        static let localServerEnabled = "localServerEnabled"
+        static let localServerPort = "localServerPort"
+        static let localServerToken = "localServerToken"
     }
 
     init() {
@@ -640,6 +646,55 @@ class SharedDataStore {
             return true
         }
         return defaults.bool(forKey: Keys.peakHoursMenuIconEnabled)
+    }
+
+    // MARK: - Local Server (companion mobile app)
+
+    func saveLocalServerEnabled(_ enabled: Bool) {
+        defaults.set(enabled, forKey: Keys.localServerEnabled)
+    }
+
+    func loadLocalServerEnabled() -> Bool {
+        // Off by default — the user must explicitly opt in.
+        return defaults.bool(forKey: Keys.localServerEnabled)
+    }
+
+    func saveLocalServerPort(_ port: Int) {
+        defaults.set(port, forKey: Keys.localServerPort)
+    }
+
+    func loadLocalServerPort() -> Int {
+        let port = defaults.integer(forKey: Keys.localServerPort)
+        return port > 0 ? port : Int(LocalServerService.defaultPort)
+    }
+
+    /// Returns the existing pairing token, generating and persisting a new one
+    /// on first use. The token gates access to the local usage endpoint.
+    func loadOrCreateLocalServerToken() -> String {
+        if let existing = defaults.string(forKey: Keys.localServerToken), !existing.isEmpty {
+            return existing
+        }
+        let token = Self.generateToken()
+        defaults.set(token, forKey: Keys.localServerToken)
+        return token
+    }
+
+    /// Generates a fresh pairing token, invalidating any previously paired device.
+    @discardableResult
+    func regenerateLocalServerToken() -> String {
+        let token = Self.generateToken()
+        defaults.set(token, forKey: Keys.localServerToken)
+        return token
+    }
+
+    private static func generateToken() -> String {
+        var bytes = [UInt8](repeating: 0, count: 24)
+        _ = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        // URL-safe base64 without padding.
+        return Data(bytes).base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
     }
 
     // MARK: - Testing Helpers

--- a/Claude Usage/Views/Settings/App/MobileAppView.swift
+++ b/Claude Usage/Views/Settings/App/MobileAppView.swift
@@ -2,165 +2,196 @@
 //  MobileAppView.swift
 //  Claude Usage
 //
-//  "Painted door" interest-collection view for a potential mobile app.
+//  Pairing screen for the companion mobile app. Lets the user enable a
+//  read-only local server (LocalServerService) and pair a phone by scanning
+//  a QR code that encodes { host, port, token }.
 //
-//  Created by Claude Code on 2026-02-25.
+//  The Claude session key never leaves this machine — the phone only ever
+//  reads the derived usage numbers over the local network.
 //
 
 import SwiftUI
+import CoreImage.CIFilterBuiltins
 
-// ─────────────────────────────────────────────────────────────────────
-// IMPORTANT — Analytics-only endpoint (NO credentials involved)
-// ─────────────────────────────────────────────────────────────────────
-//
-// The URL below is a lightweight Cloudflare Worker that **only** records
-// anonymous interest signals (a single POST with `?type=mobile`).
-//
-// • It does NOT receive, store, or process any user credentials.
-// • It does NOT receive any personally-identifiable information.
-// • It does NOT set cookies or return tracking identifiers.
-// • It is completely separate from the Claude AI / Anthropic APIs.
-//
-// Its sole purpose is to count how many users tap "Notify Me" so the
-// developer can gauge demand before investing in a mobile app.
-//
-// Domain: claude-usage-tracker.hamedelfayome.workers.dev
-// ─────────────────────────────────────────────────────────────────────
-private let kAnalyticsOnlyEndpoint = "https://claude-usage-tracker.hamedelfayome.workers.dev?type=mobile"
-
-/// Mobile app "coming soon" painted-door view.
-/// Collects interest via a single analytics-only POST request.
 struct MobileAppView: View {
-    @State private var hasNotified = UserDefaults.standard.bool(forKey: "mobileApp.notifyMe")
-    @State private var isSubmitting = false
-    @State private var showError = false
+    @State private var isEnabled = SharedDataStore.shared.loadLocalServerEnabled()
+    @State private var lanAddress: String? = LocalServerService.primaryLANAddress()
+    @State private var token: String = ""
+    @State private var didCopy = false
+
+    private var port: Int { SharedDataStore.shared.loadLocalServerPort() }
+
+    /// JSON payload encoded into the pairing QR code.
+    private var pairingPayload: String? {
+        guard let host = lanAddress, !token.isEmpty else { return nil }
+        let dict: [String: Any] = [
+            "v": 1,
+            "host": host,
+            "port": port,
+            "token": token
+        ]
+        guard let data = try? JSONSerialization.data(withJSONObject: dict) else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
 
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: DesignTokens.Spacing.section) {
                 SettingsPageHeader(
-                    title: "mobile.title".localized,
-                    subtitle: "mobile.subtitle".localized
+                    title: "Mobile App",
+                    subtitle: "View your usage on your phone over your local network"
                 )
 
-                // Coming Soon badge + icon
-                HStack {
-                    Spacer()
-                    VStack(spacing: DesignTokens.Spacing.medium) {
-                        Image(systemName: "iphone")
-                            .font(.system(size: 28))
-                            .foregroundColor(.accentColor)
-
-                        Text("mobile.coming_soon_badge".localized)
-                            .font(.system(size: 10, weight: .semibold))
-                            .tracking(1)
-                            .foregroundColor(.accentColor)
-                            .padding(.horizontal, 8)
-                            .padding(.vertical, 3)
-                            .background(
-                                Capsule()
-                                    .fill(Color.accentColor.opacity(0.1))
-                            )
-                    }
-                    Spacer()
-                }
-
-                Divider()
-
-                // Notify Me / Already notified
-                if hasNotified {
-                    HStack(spacing: DesignTokens.Spacing.medium) {
-                        Image(systemName: "checkmark.circle.fill")
-                            .font(.system(size: DesignTokens.Icons.standard))
-                            .foregroundColor(SettingsColors.success)
-
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text("mobile.notified".localized)
-                                .font(DesignTokens.Typography.bodyMedium)
-                            Text("mobile.notified_desc".localized)
-                                .font(DesignTokens.Typography.caption)
-                                .foregroundColor(.secondary)
-                        }
-                    }
-                    .padding(DesignTokens.Spacing.medium)
-                    .background(
-                        RoundedRectangle(cornerRadius: DesignTokens.Radius.small)
-                            .fill(SettingsColors.lightOverlay(.green))
+                SettingToggle(
+                    title: "Enable companion server",
+                    description: "Serves your current usage (read-only) to paired devices on this network. Off by default.",
+                    badge: .beta,
+                    isOn: Binding(
+                        get: { isEnabled },
+                        set: { setEnabled($0) }
                     )
+                )
+
+                if isEnabled {
+                    pairingCard
+                    securityNote
                 } else {
-                    VStack(alignment: .leading, spacing: DesignTokens.Spacing.medium) {
-                        Text("mobile.cta_message".localized)
+                    SettingsCard {
+                        Text("Turn this on to pair the Claude Usage mobile app. Your Mac will serve usage data to your phone while it's awake and on the same Wi-Fi network.")
                             .font(DesignTokens.Typography.body)
                             .foregroundColor(.secondary)
-
-                        SettingsButton.primary(
-                            title: isSubmitting ? "mobile.submitting".localized : "mobile.notify_me".localized,
-                            icon: isSubmitting ? nil : "bell",
-                            action: submitInterest
-                        )
-                        .disabled(isSubmitting)
+                            .fixedSize(horizontal: false, vertical: true)
                     }
-                }
-
-                // Privacy note
-                HStack(spacing: DesignTokens.Spacing.small) {
-                    Image(systemName: "lock.shield")
-                        .font(.system(size: DesignTokens.Icons.tiny))
-                        .foregroundColor(.secondary)
-                    Text("mobile.privacy_note".localized)
-                        .font(DesignTokens.Typography.caption)
-                        .foregroundColor(.secondary)
                 }
 
                 Spacer()
             }
             .padding(28)
         }
-        .alert("mobile.error_title".localized, isPresented: $showError) {
-            Button("common.ok".localized, role: .cancel) {}
-        } message: {
-            Text("mobile.error_message".localized)
+        .onAppear {
+            token = SharedDataStore.shared.loadOrCreateLocalServerToken()
+            lanAddress = LocalServerService.primaryLANAddress()
         }
     }
 
-    // MARK: - Analytics-only POST (no credentials, no PII)
+    // MARK: - Pairing card
 
-    /// Sends a single anonymous POST to the analytics-only endpoint.
-    /// See the comment at the top of this file for full details.
-    private func submitInterest() {
-        guard !isSubmitting, !hasNotified else { return }
-        isSubmitting = true
-
-        Task {
-            do {
-                guard let url = URL(string: kAnalyticsOnlyEndpoint) else { return }
-
-                var request = URLRequest(url: url)
-                request.httpMethod = "POST"
-                request.timeoutInterval = 15
-
-                let (_, response) = try await URLSession.shared.data(for: request)
-
-                await MainActor.run {
-                    if let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) {
-                        hasNotified = true
-                        UserDefaults.standard.set(true, forKey: "mobileApp.notifyMe")
-                    } else {
-                        showError = true
+    private var pairingCard: some View {
+        SettingsCard(title: "Pair your phone") {
+            VStack(alignment: .leading, spacing: DesignTokens.Spacing.medium) {
+                if let payload = pairingPayload, let qr = Self.qrImage(from: payload) {
+                    HStack {
+                        Spacer()
+                        Image(nsImage: qr)
+                            .interpolation(.none)
+                            .resizable()
+                            .frame(width: 180, height: 180)
+                            .padding(8)
+                            .background(Color.white)
+                            .clipShape(RoundedRectangle(cornerRadius: DesignTokens.Radius.small))
+                        Spacer()
                     }
-                    isSubmitting = false
+                    Text("Open the Claude Usage app on your phone and scan this code.")
+                        .font(DesignTokens.Typography.caption)
+                        .foregroundColor(.secondary)
+                } else {
+                    Label("No local network address found. Connect to Wi-Fi and reopen this screen.",
+                          systemImage: "wifi.exclamationmark")
+                        .font(DesignTokens.Typography.caption)
+                        .foregroundColor(SettingsColors.warning)
                 }
-            } catch {
-                await MainActor.run {
-                    showError = true
-                    isSubmitting = false
+
+                Divider()
+
+                detailRow(label: "Address", value: lanAddress.map { "\($0):\(port)" } ?? "—")
+                detailRow(label: "Token", value: token, monospaced: true)
+
+                HStack(spacing: DesignTokens.Spacing.small) {
+                    SettingsButton.subtle(
+                        title: didCopy ? "Copied" : "Copy details",
+                        icon: didCopy ? "checkmark" : "doc.on.doc",
+                        action: copyDetails
+                    )
+                    SettingsButton.subtle(
+                        title: "Regenerate token",
+                        icon: "arrow.triangle.2.circlepath",
+                        action: regenerateToken
+                    )
                 }
             }
         }
+    }
+
+    private func detailRow(label: String, value: String, monospaced: Bool = false) -> some View {
+        HStack(alignment: .top) {
+            Text(label)
+                .font(DesignTokens.Typography.caption)
+                .foregroundColor(.secondary)
+                .frame(width: 70, alignment: .leading)
+            Text(value)
+                .font(monospaced ? .system(.caption, design: .monospaced) : DesignTokens.Typography.caption)
+                .foregroundColor(.primary)
+                .textSelection(.enabled)
+                .lineLimit(2)
+                .truncationMode(.middle)
+        }
+    }
+
+    private var securityNote: some View {
+        HStack(alignment: .top, spacing: DesignTokens.Spacing.small) {
+            Image(systemName: "lock.shield")
+                .font(.system(size: DesignTokens.Icons.tiny))
+                .foregroundColor(.secondary)
+            Text("Read-only and token-protected. Your Claude session key never leaves this Mac — the phone only sees usage numbers. Regenerating the token un-pairs existing devices.")
+                .font(DesignTokens.Typography.caption)
+                .foregroundColor(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    // MARK: - Actions
+
+    private func setEnabled(_ enabled: Bool) {
+        isEnabled = enabled
+        SharedDataStore.shared.saveLocalServerEnabled(enabled)
+        if enabled {
+            token = SharedDataStore.shared.loadOrCreateLocalServerToken()
+            lanAddress = LocalServerService.primaryLANAddress()
+            LocalServerService.shared.start()
+        } else {
+            LocalServerService.shared.stop()
+        }
+    }
+
+    private func regenerateToken() {
+        token = SharedDataStore.shared.regenerateLocalServerToken()
+        if isEnabled { LocalServerService.shared.restart() }
+    }
+
+    private func copyDetails() {
+        let details = "Host: \(lanAddress ?? "?")\nPort: \(port)\nToken: \(token)"
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(details, forType: .string)
+        didCopy = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { didCopy = false }
+    }
+
+    // MARK: - QR generation
+
+    private static func qrImage(from string: String) -> NSImage? {
+        let context = CIContext()
+        let filter = CIFilter.qrCodeGenerator()
+        filter.message = Data(string.utf8)
+        filter.correctionLevel = "M"
+        guard let output = filter.outputImage else { return nil }
+
+        let scaled = output.transformed(by: CGAffineTransform(scaleX: 10, y: 10))
+        guard let cgImage = context.createCGImage(scaled, from: scaled.extent) else { return nil }
+        return NSImage(cgImage: cgImage, size: NSSize(width: scaled.extent.width, height: scaled.extent.height))
     }
 }
 
 #Preview {
     MobileAppView()
-        .frame(width: 520, height: 600)
+        .frame(width: 520, height: 700)
 }


### PR DESCRIPTION
## What

Adds an **opt-in, read-only local HTTP server** so a companion mobile app can display your current usage over the local network. This implements the "Mobile App" settings tab, replacing the previous coming-soon placeholder with a real pairing screen.

A matching open-source Expo app lives here: https://github.com/mahdi-salmanzade/claude-usage-mobile

## How it works

```
Claude API ──sessionKey──▶ this app (LocalServerService)
                                │  GET /v1/usage  (Bearer token, read-only)
                                ▼
                          phone (companion app) over LAN / Tailscale
```

The server simply serves the already-computed `DataStore.shared.loadUsage()` snapshot as JSON. The phone never authenticates to Claude — **the session key never leaves the Mac.**

## Security model

- **Disabled by default** — the user must explicitly enable it in Settings → Mobile App.
- **Token-gated** — every request requires `Authorization: Bearer <token>`; the token is generated locally and only shared via the pairing QR code. Regenerating it un-pairs existing devices.
- **Read-only** — single data endpoint (`GET /v1/usage`) plus `GET /v1/ping`; unknown paths → 404, bad/missing token → 401.

## Changes

- `LocalServerService.swift` (new) — `NWListener`-based HTTP server; token auth; ISO-8601 JSON envelope around `ClaudeUsage`; primary-LAN-address helper.
- `SharedDataStore.swift` — persistence for enabled/port and secure token generation.
- `AppDelegate.swift` — start on launch if enabled, stop on terminate.
- `MobileAppView.swift` — real pairing screen (enable toggle, QR code with `{host,port,token}`, copy/regenerate token, security note).

## Testing

- Builds on Xcode 26.5.
- Verified the endpoint with `curl`: 401 on missing/bad token, 404 on unknown path, and a correct `ClaudeUsage` JSON envelope on a valid request.
- Verified end-to-end against the Expo companion app (fetch + parse + render).

## Notes / follow-ups

- New `MobileAppView` strings are currently English literals — happy to wire them into the localization system if you'd like before merging.
- Enabling the server may trigger the macOS firewall "accept incoming connections" prompt on first run.