### PR TITLE
fix(statusbar): Force isVisible after creation to override persisted state

### DIFF
--- a/Claude Usage/MenuBar/StatusBarUIManager.swift
+++ b/Claude Usage/MenuBar/StatusBarUIManager.swift
@@ -79,6 +79,8 @@ final class StatusBarUIManager {
             // No credentials/metrics - show default app logo
             let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
             statusItem.autosaveName = Self.defaultLogoAutosaveName
+            // Override any persisted false from a prior cmd-drag.
+            statusItem.isVisible = true
 
             if let button = statusItem.button {
                 button.action = action
@@ -98,6 +100,8 @@ final class StatusBarUIManager {
             for metricConfig in config.enabledMetrics {
                 let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
                 statusItem.autosaveName = Self.autosaveName(for: metricConfig.metricType)
+                // Override any persisted false from a prior cmd-drag.
+                statusItem.isVisible = true
 
                 if let button = statusItem.button {
                     button.action = action
@@ -152,6 +156,8 @@ final class StatusBarUIManager {
             statusItem.autosaveName = config.enabledMetrics.isEmpty
                 ? Self.defaultLogoAutosaveName
                 : Self.autosaveName(for: metricType)
+            // Override any persisted false from a prior cmd-drag.
+            statusItem.isVisible = true
 
             if let button = statusItem.button {
                 button.action = action
@@ -244,6 +250,8 @@ final class StatusBarUIManager {
             if peakHoursStatusItem == nil, let target = peakHoursTarget, let action = peakHoursAction {
                 let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
                 statusItem.autosaveName = Self.peakHoursAutosaveName
+                // Override any persisted false from a prior cmd-drag.
+                statusItem.isVisible = true
                 if let button = statusItem.button {
                     button.action = action
                     button.target = target
@@ -291,6 +299,8 @@ final class StatusBarUIManager {
             // No profiles selected - show default logo
             let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
             statusItem.autosaveName = Self.defaultLogoAutosaveName
+            // Override any persisted false from a prior cmd-drag.
+            statusItem.isVisible = true
             if let button = statusItem.button {
                 button.action = action
                 button.target = target
@@ -307,6 +317,8 @@ final class StatusBarUIManager {
             for profile in selectedProfiles {
                 let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
                 statusItem.autosaveName = Self.autosaveName(forProfileId: profile.id)
+                // Override any persisted false from a prior cmd-drag.
+                statusItem.isVisible = true
 
                 if let button = statusItem.button {
                     button.action = action
@@ -362,6 +374,8 @@ final class StatusBarUIManager {
             // Need to add default logo
             let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
             statusItem.autosaveName = Self.defaultLogoAutosaveName
+            // Override any persisted false from a prior cmd-drag.
+            statusItem.isVisible = true
             if let button = statusItem.button {
                 button.action = action
                 button.target = target
@@ -374,6 +388,8 @@ final class StatusBarUIManager {
             for profile in selectedProfiles where idsToAdd.contains(profile.id) {
                 let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
                 statusItem.autosaveName = Self.autosaveName(forProfileId: profile.id)
+                // Override any persisted false from a prior cmd-drag.
+                statusItem.isVisible = true
                 if let button = statusItem.button {
                     button.action = action
                     button.target = target


### PR DESCRIPTION
NSStatusItem persists isVisible across launches via NSUserDefaults, keyed by autosaveName. When a user cmd-drags an item out of the menu bar, macOS writes false to that key, and on the next launch NSStatusBar reads it back as the item's initial visibility — leaving the item created but hidden with no in-app affordance to restore.

After assigning the autosaveName at each of the eight NSStatusItem creation sites in StatusBarUIManager, explicitly set isVisible = true so the persisted value cannot suppress the item. The autosaveName- driven position persistence is unaffected.

## Description

<!-- Briefly describe what this PR does and why -->

## Changes

-

## Screenshots / Screen Recordings

<!-- REQUIRED for any visual/UI changes. Please attach screenshots or screen recordings of the running app showing your changes. PRs with visual changes that don't include screenshots will not be reviewed. -->

<!-- If your change is not visual (e.g., logic-only, refactoring), write "N/A - no visual changes" -->

## Important Guidelines

- **Do NOT use App Groups Keychain with app group identifiers.** This app is distributed outside the App Store via a Developer ID certificate. App Group entitlements require Keychain access prompts on every launch, which breaks the user experience. Use standard `UserDefaults` and standard Keychain access (without group identifiers) instead.
- Follow existing code patterns and architecture (MVVM, protocol-oriented)
- Add localization keys for any new user-facing strings (9 languages supported)
- Test on macOS 14.0+ (Sonoma)

## Checklist

- [x] I have tested these changes on a running build
- [ ] I have attached screenshots/recordings for any visual changes
- [x] I have not introduced App Group or grouped Keychain usage
- [ ] I have added localization keys for any new user-facing strings
