### PR TITLE
feat(cli): Allow pasting a long-lived OAuth setup token

### DIFF
--- a/Claude Usage/Resources/de.lproj/Localizable.strings
+++ b/Claude Usage/Resources/de.lproj/Localizable.strings
@@ -730,6 +730,13 @@
 "cli.benefit_1" = "Automatischer Wechsel der Claude Code-Anmeldung mit Profilen";
 "cli.benefit_2" = "CLI- und App-Konten synchron halten";
 "cli.benefit_3" = "Automatische Aktualisierung der Anmeldedaten beim Profilwechsel";
+"cli.manual_token_title" = "OAuth-Setup-Token einfügen";
+"cli.manual_token_subtitle" = "Verwenden Sie ein langlebiges Token von `claude setup-token` statt einer erneuten Synchronisierung";
+"cli.manual_token_disclosure" = "Token manuell eingeben";
+"cli.manual_token_help" = "Führen Sie `claude setup-token` in Ihrem Terminal aus, um ein langlebiges OAuth-Token zu erzeugen, und fügen Sie es hier ein. Nutzen Sie dies, wenn Ihre Web-Sitzung abgelaufen ist oder die Synchronisierung von Claude Code nicht funktioniert.";
+"cli.manual_token_placeholder" = "sk-ant-oat01-...";
+"cli.manual_token_save" = "Token Speichern";
+"cli.manual_token_empty_error" = "Bitte fügen Sie ein Token ein, bevor Sie speichern";
 
 /* ==================== */
 /* MARK: - Additional Keys */

--- a/Claude Usage/Resources/en.lproj/Localizable.strings
+++ b/Claude Usage/Resources/en.lproj/Localizable.strings
@@ -705,6 +705,13 @@
 "cli.benefit_1" = "Auto-switch Claude Code login with profiles";
 "cli.benefit_2" = "Keep CLI and app accounts in sync";
 "cli.benefit_3" = "Auto-refresh credentials on profile switch";
+"cli.manual_token_title" = "Paste an OAuth Setup Token";
+"cli.manual_token_subtitle" = "Use a long-lived token from `claude setup-token` instead of re-syncing";
+"cli.manual_token_disclosure" = "Enter token manually";
+"cli.manual_token_help" = "Run `claude setup-token` in your terminal to generate a long-lived OAuth token, then paste it here. Use this when your web session has expired or syncing from Claude Code is not working.";
+"cli.manual_token_placeholder" = "sk-ant-oat01-...";
+"cli.manual_token_save" = "Save Token";
+"cli.manual_token_empty_error" = "Please paste a token before saving";
 
 /* ==================== */
 /* MARK: - Additional Keys */

--- a/Claude Usage/Resources/es.lproj/Localizable.strings
+++ b/Claude Usage/Resources/es.lproj/Localizable.strings
@@ -711,6 +711,13 @@
 "cli.benefit_1" = "Cambio automático de inicio de sesión de Claude Code con perfiles";
 "cli.benefit_2" = "Mantener la aplicación CLI y las cuentas sincronizadas";
 "cli.benefit_3" = "Actualizar credenciales automáticamente al cambiar de perfil";
+"cli.manual_token_title" = "Pegar un token OAuth de configuración";
+"cli.manual_token_subtitle" = "Use un token de larga duración de `claude setup-token` en lugar de volver a sincronizar";
+"cli.manual_token_disclosure" = "Introducir token manualmente";
+"cli.manual_token_help" = "Ejecute `claude setup-token` en su terminal para generar un token OAuth de larga duración y péguelo aquí. Úselo cuando su sesión web haya expirado o la sincronización desde Claude Code no funcione.";
+"cli.manual_token_placeholder" = "sk-ant-oat01-...";
+"cli.manual_token_save" = "Guardar Token";
+"cli.manual_token_empty_error" = "Pegue un token antes de guardar";
 
 /* ==================== */
 /* MARK: - Additional Keys */

--- a/Claude Usage/Resources/fr.lproj/Localizable.strings
+++ b/Claude Usage/Resources/fr.lproj/Localizable.strings
@@ -708,6 +708,13 @@
 "cli.benefit_1" = "Changement automatique de connexion Claude Code avec les profils";
 "cli.benefit_2" = "Garder CLI et comptes d'application synchronisés";
 "cli.benefit_3" = "Rafraîchir automatiquement les identifiants lors du changement de profil";
+"cli.manual_token_title" = "Coller un jeton OAuth de configuration";
+"cli.manual_token_subtitle" = "Utilisez un jeton longue durée de `claude setup-token` au lieu de resynchroniser";
+"cli.manual_token_disclosure" = "Saisir le jeton manuellement";
+"cli.manual_token_help" = "Exécutez `claude setup-token` dans votre terminal pour générer un jeton OAuth longue durée, puis collez-le ici. Utilisez ceci lorsque votre session web a expiré ou que la synchronisation depuis Claude Code ne fonctionne pas.";
+"cli.manual_token_placeholder" = "sk-ant-oat01-...";
+"cli.manual_token_save" = "Enregistrer le Jeton";
+"cli.manual_token_empty_error" = "Veuillez coller un jeton avant d'enregistrer";
 
 /* ==================== */
 /* MARK: - Additional Keys */

--- a/Claude Usage/Resources/it.lproj/Localizable.strings
+++ b/Claude Usage/Resources/it.lproj/Localizable.strings
@@ -728,6 +728,13 @@
 "cli.benefit_1" = "Cambio automatico login Claude Code con i profili";
 "cli.benefit_2" = "Mantieni sincronizzati CLI e account app";
 "cli.benefit_3" = "Aggiornamento automatico credenziali al cambio profilo";
+"cli.manual_token_title" = "Incolla un token OAuth di configurazione";
+"cli.manual_token_subtitle" = "Usa un token a lunga durata da `claude setup-token` invece di sincronizzare di nuovo";
+"cli.manual_token_disclosure" = "Inserisci token manualmente";
+"cli.manual_token_help" = "Esegui `claude setup-token` nel terminale per generare un token OAuth a lunga durata, quindi incollalo qui. Utile quando la sessione web è scaduta o la sincronizzazione da Claude Code non funziona.";
+"cli.manual_token_placeholder" = "sk-ant-oat01-...";
+"cli.manual_token_save" = "Salva Token";
+"cli.manual_token_empty_error" = "Incolla un token prima di salvare";
 
 /* ==================== */
 /* MARK: - Additional Keys */

--- a/Claude Usage/Resources/ja.lproj/Localizable.strings
+++ b/Claude Usage/Resources/ja.lproj/Localizable.strings
@@ -730,6 +730,13 @@
 "cli.benefit_1" = "プロファイルでClaude Codeログインを自動切り替え";
 "cli.benefit_2" = "CLIとアプリアカウントを同期状態に保つ";
 "cli.benefit_3" = "プロファイル切り替え時に認証情報を自動更新";
+"cli.manual_token_title" = "OAuthセットアップトークンを貼り付け";
+"cli.manual_token_subtitle" = "再同期の代わりに `claude setup-token` で取得した長期トークンを使用";
+"cli.manual_token_disclosure" = "トークンを手動で入力";
+"cli.manual_token_help" = "ターミナルで `claude setup-token` を実行して長期OAuthトークンを生成し、ここに貼り付けてください。Webセッションが切れている場合やClaude Codeからの同期が機能しない場合に使用します。";
+"cli.manual_token_placeholder" = "sk-ant-oat01-...";
+"cli.manual_token_save" = "トークンを保存";
+"cli.manual_token_empty_error" = "保存する前にトークンを貼り付けてください";
 
 /* ==================== */
 /* MARK: - Additional Keys */

--- a/Claude Usage/Resources/ko.lproj/Localizable.strings
+++ b/Claude Usage/Resources/ko.lproj/Localizable.strings
@@ -790,6 +790,13 @@
 "cli.benefit_1" = "프로필로 Claude Code 로그인 자동 전환";
 "cli.benefit_2" = "CLI 및 앱 계정 동기화 유지";
 "cli.benefit_3" = "프로필 전환 시 자격 증명 자동 새로 고침";
+"cli.manual_token_title" = "OAuth 설정 토큰 붙여넣기";
+"cli.manual_token_subtitle" = "다시 동기화하는 대신 `claude setup-token`의 장기 토큰 사용";
+"cli.manual_token_disclosure" = "토큰을 수동으로 입력";
+"cli.manual_token_help" = "터미널에서 `claude setup-token`을 실행하여 장기 OAuth 토큰을 생성한 후 여기에 붙여넣으세요. 웹 세션이 만료되었거나 Claude Code 동기화가 작동하지 않을 때 사용합니다.";
+"cli.manual_token_placeholder" = "sk-ant-oat01-...";
+"cli.manual_token_save" = "토큰 저장";
+"cli.manual_token_empty_error" = "저장하기 전에 토큰을 붙여넣으세요";
 
 /* ==================== */
 /* MARK: - Additional Keys */

--- a/Claude Usage/Resources/pt-BR.lproj/Localizable.strings
+++ b/Claude Usage/Resources/pt-BR.lproj/Localizable.strings
@@ -724,6 +724,13 @@
 "cli.benefit_1" = "Troca automática de login do Claude Code com perfis";
 "cli.benefit_2" = "Manter CLI e contas do aplicativo sincronizadas";
 "cli.benefit_3" = "Atualizar credenciais automaticamente ao trocar de perfil";
+"cli.manual_token_title" = "Cole um token OAuth de configuração";
+"cli.manual_token_subtitle" = "Use um token de longa duração de `claude setup-token` em vez de sincronizar novamente";
+"cli.manual_token_disclosure" = "Inserir token manualmente";
+"cli.manual_token_help" = "Execute `claude setup-token` no seu terminal para gerar um token OAuth de longa duração e cole-o aqui. Use isto quando sua sessão web tiver expirado ou a sincronização com Claude Code não estiver funcionando.";
+"cli.manual_token_placeholder" = "sk-ant-oat01-...";
+"cli.manual_token_save" = "Salvar Token";
+"cli.manual_token_empty_error" = "Cole um token antes de salvar";
 
 /* ==================== */
 /* MARK: - Additional Keys */

--- a/Claude Usage/Resources/pt.lproj/Localizable.strings
+++ b/Claude Usage/Resources/pt.lproj/Localizable.strings
@@ -728,6 +728,13 @@
 "cli.benefit_1" = "Troca automática de login do Claude Code com perfis";
 "cli.benefit_2" = "Manter CLI e contas do aplicativo sincronizadas";
 "cli.benefit_3" = "Atualizar credenciais automaticamente ao trocar de perfil";
+"cli.manual_token_title" = "Cole um token OAuth de configuração";
+"cli.manual_token_subtitle" = "Utilize um token de longa duração de `claude setup-token` em vez de sincronizar novamente";
+"cli.manual_token_disclosure" = "Introduzir token manualmente";
+"cli.manual_token_help" = "Execute `claude setup-token` no seu terminal para gerar um token OAuth de longa duração e cole-o aqui. Utilize isto quando a sua sessão web tiver expirado ou a sincronização a partir do Claude Code não estiver a funcionar.";
+"cli.manual_token_placeholder" = "sk-ant-oat01-...";
+"cli.manual_token_save" = "Guardar Token";
+"cli.manual_token_empty_error" = "Cole um token antes de guardar";
 
 /* ==================== */
 /* MARK: - Additional Keys */

--- a/Claude Usage/Resources/tr.lproj/Localizable.strings
+++ b/Claude Usage/Resources/tr.lproj/Localizable.strings
@@ -704,6 +704,13 @@
 "cli.benefit_1" = "Profil değişikliğinde Claude Code girişini otomatik değiştir";
 "cli.benefit_2" = "CLI ve uygulama hesaplarını senkronize tut";
 "cli.benefit_3" = "Profil değişikliğinde kimlik bilgilerini otomatik yenile";
+"cli.manual_token_title" = "OAuth Kurulum Belirteci Yapıştır";
+"cli.manual_token_subtitle" = "Yeniden senkronize etmek yerine `claude setup-token` ile alınan uzun ömürlü belirteci kullanın";
+"cli.manual_token_disclosure" = "Belirteci manuel olarak gir";
+"cli.manual_token_help" = "Uzun ömürlü bir OAuth belirteci oluşturmak için terminalde `claude setup-token` komutunu çalıştırın ve buraya yapıştırın. Web oturumunuz sona erdiyse veya Claude Code'dan senkronizasyon çalışmıyorsa bunu kullanın.";
+"cli.manual_token_placeholder" = "sk-ant-oat01-...";
+"cli.manual_token_save" = "Belirteci Kaydet";
+"cli.manual_token_empty_error" = "Kaydetmeden önce bir belirteç yapıştırın";
 
 /* ==================== */
 /* MARK: - Additional Keys */

--- a/Claude Usage/Resources/uk.lproj/Localizable.strings
+++ b/Claude Usage/Resources/uk.lproj/Localizable.strings
@@ -705,6 +705,13 @@
 "cli.benefit_1" = "Автоматичне перемикання входу Claude Code разом з профілями";
 "cli.benefit_2" = "Синхронізація акаунтів CLI та програми";
 "cli.benefit_3" = "Автоматичне оновлення облікових даних при перемиканні профілю";
+"cli.manual_token_title" = "Вставте OAuth-токен налаштування";
+"cli.manual_token_subtitle" = "Використовуйте довготривалий токен з `claude setup-token` замість повторної синхронізації";
+"cli.manual_token_disclosure" = "Ввести токен вручну";
+"cli.manual_token_help" = "Запустіть `claude setup-token` у терміналі, щоб згенерувати довготривалий OAuth-токен, і вставте його сюди. Використовуйте це, коли ваша вебсесія завершилася або синхронізація з Claude Code не працює.";
+"cli.manual_token_placeholder" = "sk-ant-oat01-...";
+"cli.manual_token_save" = "Зберегти Токен";
+"cli.manual_token_empty_error" = "Будь ласка, вставте токен перед збереженням";
 
 /* ==================== */
 /* MARK: - Additional Keys */

--- a/Claude Usage/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Claude Usage/Resources/zh-Hant.lproj/Localizable.strings
@@ -711,6 +711,13 @@
 "cli.benefit_1" = "使用設定檔自動切換 Claude Code 登入";
 "cli.benefit_2" = "保持 CLI 和軟體帳戶同步";
 "cli.benefit_3" = "設定檔切換時自動重新整理憑證";
+"cli.manual_token_title" = "貼上 OAuth 設定權杖";
+"cli.manual_token_subtitle" = "使用 `claude setup-token` 產生的長效權杖，無需重新同步";
+"cli.manual_token_disclosure" = "手動輸入權杖";
+"cli.manual_token_help" = "在終端機中執行 `claude setup-token` 以產生長效 OAuth 權杖，然後貼到此處。當您的網頁工作階段已過期或無法從 Claude Code 同步時可使用。";
+"cli.manual_token_placeholder" = "sk-ant-oat01-...";
+"cli.manual_token_save" = "儲存權杖";
+"cli.manual_token_empty_error" = "請先貼上權杖再儲存";
 
 /* ==================== */
 /* MARK: - Additional Keys */

--- a/Claude Usage/Resources/zh-ch.lproj/Localizable.strings
+++ b/Claude Usage/Resources/zh-ch.lproj/Localizable.strings
@@ -711,6 +711,13 @@
 "cli.benefit_1" = "使用配置文件自动切换 Claude Code 登录";
 "cli.benefit_2" = "保持 CLI 和应用账户同步";
 "cli.benefit_3" = "配置文件切换时自动刷新凭据";
+"cli.manual_token_title" = "粘贴 OAuth 设置令牌";
+"cli.manual_token_subtitle" = "使用 `claude setup-token` 生成的长效令牌，而不是重新同步";
+"cli.manual_token_disclosure" = "手动输入令牌";
+"cli.manual_token_help" = "在终端中运行 `claude setup-token` 以生成长效 OAuth 令牌，然后粘贴到此处。当您的网页会话已过期或无法从 Claude Code 同步时使用。";
+"cli.manual_token_placeholder" = "sk-ant-oat01-...";
+"cli.manual_token_save" = "保存令牌";
+"cli.manual_token_empty_error" = "请先粘贴令牌再保存";
 
 /* ==================== */
 /* MARK: - Additional Keys */

--- a/Claude Usage/Shared/Services/ClaudeCodeSyncService.swift
+++ b/Claude Usage/Shared/Services/ClaudeCodeSyncService.swift
@@ -528,6 +528,46 @@ class ClaudeCodeSyncService {
         LoggingService.shared.log("✅ Applied profile CLI credentials to system: \(profileId)")
     }
 
+    /// Saves a manually-pasted long-lived OAuth token (from `claude setup-token`)
+    /// to the given profile. Wraps the bare token in a minimal `claudeAiOauth`
+    /// JSON envelope so the rest of the app can consume it through the same
+    /// extraction helpers used for synced credentials.
+    ///
+    /// Long-lived setup tokens have no `expiresAt` field, which intentionally
+    /// causes `isTokenExpired` to return `false` ("no expiry info = assume valid"),
+    /// which is the desired behavior — these tokens don't expire on a short cycle.
+    func saveManualOAuthToken(_ token: String, profileId: UUID) throws {
+        let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            throw ClaudeCodeError.invalidToken
+        }
+
+        let payload: [String: Any] = [
+            "claudeAiOauth": [
+                "accessToken": trimmed,
+                "subscriptionType": "manual",
+                "scopes": ["user:inference", "user:profile"]
+            ]
+        ]
+
+        guard let data = try? JSONSerialization.data(withJSONObject: payload),
+              let jsonString = String(data: data, encoding: .utf8) else {
+            throw ClaudeCodeError.invalidJSON
+        }
+
+        var profiles = ProfileStore.shared.loadProfiles()
+        guard let index = profiles.firstIndex(where: { $0.id == profileId }) else {
+            throw ClaudeCodeError.noProfileCredentials
+        }
+
+        profiles[index].cliCredentialsJSON = jsonString
+        profiles[index].hasCliAccount = true
+        profiles[index].cliAccountSyncedAt = Date()
+        ProfileStore.shared.saveProfiles(profiles)
+
+        LoggingService.shared.log("Saved manual OAuth setup token to profile: \(profileId)")
+    }
+
     /// Removes CLI credentials from profile (doesn't affect system)
     func removeFromProfile(_ profileId: UUID) throws {
         var profiles = ProfileStore.shared.loadProfiles()
@@ -661,6 +701,7 @@ class ClaudeCodeSyncService {
 enum ClaudeCodeError: LocalizedError {
     case noCredentialsFound
     case invalidJSON
+    case invalidToken
     case keychainReadFailed(status: OSStatus)
     case keychainWriteFailed(status: OSStatus)
     case noProfileCredentials
@@ -671,6 +712,8 @@ enum ClaudeCodeError: LocalizedError {
             return "No Claude Code credentials found in system Keychain. Please log in to Claude Code first."
         case .invalidJSON:
             return "Claude Code credentials are corrupted or invalid."
+        case .invalidToken:
+            return "OAuth token is empty or invalid. Run `claude setup-token` and paste the full token."
         case .keychainReadFailed(let status):
             return "Failed to read credentials from system Keychain (status: \(status))."
         case .keychainWriteFailed(let status):

--- a/Claude Usage/Views/Settings/Credentials/CLIAccountView.swift
+++ b/Claude Usage/Views/Settings/Credentials/CLIAccountView.swift
@@ -12,6 +12,9 @@ struct CLIAccountView: View {
     @State private var isSyncing = false
     @State private var syncError: String?
     @State private var cliAccountInfo: CLIAccountInfo?
+    @State private var manualToken: String = ""
+    @State private var manualTokenExpanded: Bool = false
+    @State private var manualTokenError: String?
 
     var body: some View {
         ScrollView {
@@ -189,6 +192,75 @@ struct CLIAccountView: View {
                         }
                     }
 
+                    // Manual OAuth Token Entry (for `claude setup-token`)
+                    SettingsSectionCard(
+                        title: "cli.manual_token_title".localized,
+                        subtitle: "cli.manual_token_subtitle".localized
+                    ) {
+                        VStack(alignment: .leading, spacing: DesignTokens.Spacing.medium) {
+                            DisclosureGroup(
+                                isExpanded: $manualTokenExpanded,
+                                content: {
+                                    VStack(alignment: .leading, spacing: DesignTokens.Spacing.medium) {
+                                        Text("cli.manual_token_help".localized)
+                                            .font(DesignTokens.Typography.caption)
+                                            .foregroundColor(.secondary)
+                                            .fixedSize(horizontal: false, vertical: true)
+                                            .padding(.top, DesignTokens.Spacing.extraSmall)
+
+                                        TextField("cli.manual_token_placeholder".localized, text: $manualToken)
+                                            .textFieldStyle(.plain)
+                                            .font(DesignTokens.Typography.monospaced)
+                                            .padding(10)
+                                            .background(DesignTokens.Colors.inputBackground)
+                                            .cornerRadius(DesignTokens.Radius.small)
+                                            .overlay(
+                                                RoundedRectangle(cornerRadius: DesignTokens.Radius.small)
+                                                    .strokeBorder(DesignTokens.Colors.cardBorder, lineWidth: 1)
+                                            )
+                                            .onSubmit { saveManualToken() }
+
+                                        if let error = manualTokenError {
+                                            HStack(spacing: DesignTokens.Spacing.small) {
+                                                Image(systemName: "exclamationmark.triangle.fill")
+                                                    .foregroundColor(.red)
+                                                    .font(.system(size: DesignTokens.Icons.standard))
+                                                Text(error)
+                                                    .font(DesignTokens.Typography.body)
+                                                    .foregroundColor(.red)
+                                                    .fixedSize(horizontal: false, vertical: true)
+                                            }
+                                            .padding(DesignTokens.Spacing.iconText)
+                                            .frame(maxWidth: .infinity, alignment: .leading)
+                                            .background(Color.red.opacity(0.08))
+                                            .cornerRadius(DesignTokens.Radius.small)
+                                        }
+
+                                        HStack {
+                                            Spacer()
+                                            Button(action: saveManualToken) {
+                                                HStack(spacing: DesignTokens.Spacing.extraSmall) {
+                                                    Image(systemName: "key.fill")
+                                                        .font(.system(size: DesignTokens.Icons.small))
+                                                    Text("cli.manual_token_save".localized)
+                                                        .font(DesignTokens.Typography.body)
+                                                }
+                                            }
+                                            .buttonStyle(.borderedProminent)
+                                            .controlSize(.regular)
+                                            .disabled(manualToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                                        }
+                                    }
+                                },
+                                label: {
+                                    Text("cli.manual_token_disclosure".localized)
+                                        .font(DesignTokens.Typography.body)
+                                        .fontWeight(.medium)
+                                }
+                            )
+                        }
+                    }
+
                     // Info Card
                     SettingsContentCard {
                         VStack(alignment: .leading, spacing: DesignTokens.Spacing.medium) {
@@ -261,6 +333,40 @@ struct CLIAccountView: View {
         }
 
         isSyncing = false
+    }
+
+    private func saveManualToken() {
+        guard let profileId = profileManager.activeProfile?.id else { return }
+
+        let trimmed = manualToken.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            manualTokenError = "cli.manual_token_empty_error".localized
+            return
+        }
+
+        manualTokenError = nil
+        syncError = nil
+
+        do {
+            try ClaudeCodeSyncService.shared.saveManualOAuthToken(trimmed, profileId: profileId)
+
+            profileManager.loadProfiles()
+
+            if var updated = profileManager.activeProfile {
+                updated.hasCliAccount = true
+                updated.cliAccountSyncedAt = Date()
+                profileManager.updateProfile(updated)
+            }
+
+            loadCLIAccountInfo()
+            manualToken = ""
+            manualTokenExpanded = false
+
+            LoggingService.shared.log("CLIAccountView: Manual OAuth token saved to profile")
+        } catch {
+            manualTokenError = error.localizedDescription
+            LoggingService.shared.logError("CLIAccountView: Failed to save manual OAuth token - \(error.localizedDescription)")
+        }
     }
 
     private func removeSync() {


### PR DESCRIPTION
## Description

Adds a "Paste an OAuth Setup Token" section to the CLI Account settings view so users can configure their profile with a long-lived token generated by `claude setup-token` instead of relying on a potentially-expired web sync flow from Claude Code's keychain. This is useful when a user's Claude Code session is dead/expired and re-running the OAuth web flow isn't viable (CI environments, remote machines, stale sessions).

The token is wrapped in a minimal `claudeAiOauth` JSON envelope and stored in the active profile's `cliCredentialsJSON`; downstream usage extraction (`ClaudeAPIService.getAuthentication`, `Profile.hasValidCLIOAuth`) consumes it through the existing helpers — no new code paths in the request layer. Long-lived setup tokens have no `expiresAt` field, which intentionally makes `isTokenExpired` return `false` ("no expiry info = assume valid"), matching the lifecycle of `claude setup-token` output.

## Changes

- `ClaudeCodeSyncService.saveManualOAuthToken(_:profileId:)` — wraps a trimmed token in `{"claudeAiOauth":{"accessToken":"…","subscriptionType":"manual","scopes":["user:inference","user:profile"]}}`, writes it to the profile, and sets `hasCliAccount`/`cliAccountSyncedAt`. Adds a new `ClaudeCodeError.invalidToken` case for empty input.
- `CLIAccountView` — new `SettingsSectionCard` containing a collapsible `DisclosureGroup` with a monospaced `TextField` (`sk-ant-oat01-…` placeholder), inline error display, and a Save button. Reuses existing `DesignTokens` (`inputBackground`, `cardBorder`, `Radius.small`, etc.) for visual consistency with the manual session-key entry in `PersonalUsageView`.
- Localization — 7 new keys (`cli.manual_token_title`, `cli.manual_token_subtitle`, `cli.manual_token_disclosure`, `cli.manual_token_help`, `cli.manual_token_placeholder`, `cli.manual_token_save`, `cli.manual_token_empty_error`) translated into all 13 `.lproj` files (en, de, es, fr, it, ja, ko, pt-BR, pt, tr, uk, zh-Hant, zh-ch).

No changes to `ClaudeAPIService`, `Profile` model, or the storage layer — the new token flows through the existing CLI OAuth fallback path in `getAuthentication()` (priority 2, ahead of system Keychain lookup).

## Screenshots / Screen Recordings

> ⚠️ I wasn't able to run the app from this environment — please attach a screenshot of the new "Paste an OAuth Setup Token" card on the CLI Account settings page (both collapsed and expanded states) before requesting review.

## Checklist

- [ ] I have tested these changes on a running build *(needs verification on macOS)*
- [ ] I have attached screenshots/recordings for any visual changes *(see note above)*
- [x] I have not introduced App Group or grouped Keychain usage — token is stored in the profile via the existing `ProfileStore` (standard `UserDefaults`), no new Keychain access
- [x] I have added localization keys for any new user-facing strings — 7 keys added to all 13 supported languages; `scripts/validate_localizations.sh` confirms no new mismatches were introduced