### PR TITLE
fix(menubar): honor system Keychain CLI token in icon render gate (#250)

### DIFF
--- a/Claude Usage/MenuBar/MenuBarManager.swift
+++ b/Claude Usage/MenuBar/MenuBarManager.swift
@@ -395,7 +395,7 @@ class MenuBarManager: NSObject, ObservableObject {
         recreatePopover()
 
         // 5. Trigger immediate refresh ONLY if profile has usage credentials
-        if profile.hasUsageCredentials {
+        if profile.hasUsageCredentialsForDisplay {
             self.lastRefreshTriggerTime = Date()
             refreshUsage()
         } else {
@@ -430,7 +430,7 @@ class MenuBarManager: NSObject, ObservableObject {
         }
 
         // Check if active profile has usage credentials (not just CLI)
-        let hasUsageCredentials = profileManager.activeProfile?.hasUsageCredentials ?? false
+        let hasUsageCredentials = profileManager.activeProfile?.hasUsageCredentialsForDisplay ?? false
 
         // If no usage credentials, use an empty config (will show default logo)
         let displayConfig: MenuBarIconConfiguration
@@ -790,7 +790,7 @@ class MenuBarManager: NSObject, ObservableObject {
 
             Task { @MainActor in
                 // Check if active profile has usage credentials
-                guard let profile = self.profileManager.activeProfile, profile.hasUsageCredentials else {
+                guard let profile = self.profileManager.activeProfile, profile.hasUsageCredentialsForDisplay else {
                     LoggingService.shared.logInfo("Credentials changed but no usage credentials - showing default logo")
 
                     // Reconfigure menu bar to show default logo
@@ -938,23 +938,8 @@ class MenuBarManager: NSObject, ObservableObject {
     /// `ClaudeAPIService.getAuthentication()` so the refresh path isn't gated off
     /// before the API service has a chance to discover system-level credentials.
     private func hasAnyAvailableCredentials() -> Bool {
-        guard let profile = profileManager.activeProfile else { return false }
-
-        // Profile-local credentials (Claude.ai, API Console, saved CLI OAuth)
-        if profile.hasUsageCredentials { return true }
-
-        // Fall back to system Keychain CLI credentials
-        do {
-            if let systemCreds = try ClaudeCodeSyncService.shared.readSystemCredentials(),
-               !ClaudeCodeSyncService.shared.isTokenExpired(systemCreds),
-               ClaudeCodeSyncService.shared.extractAccessToken(from: systemCreds) != nil {
-                return true
-            }
-        } catch {
-            LoggingService.shared.log("MenuBarManager.hasAnyAvailableCredentials: system keychain check failed: \(error.localizedDescription)")
-        }
-
-        return false
+        // Single source of truth: profile-local creds OR system Keychain CLI token.
+        return profileManager.activeProfile?.hasUsageCredentialsForDisplay ?? false
     }
 
     private func setupMultiProfileMode() {
@@ -1170,7 +1155,7 @@ class MenuBarManager: NSObject, ObservableObject {
     private func setupSingleProfileMode() {
         guard let profile = profileManager.activeProfile else { return }
 
-        let hasUsageCredentials = profile.hasUsageCredentials
+        let hasUsageCredentials = profile.hasUsageCredentialsForDisplay
         let config = profile.iconConfig
 
         // If no usage credentials, create empty config to show default logo

--- a/Claude Usage/MenuBar/StatusBarUIManager.swift
+++ b/Claude Usage/MenuBar/StatusBarUIManager.swift
@@ -614,7 +614,7 @@ final class StatusBarUIManager {
         let config = profile?.iconConfig ?? .default
 
         // Check if we should show default logo (no usage credentials OR no enabled metrics)
-        let hasUsageCredentials = profile?.hasUsageCredentials ?? false
+        let hasUsageCredentials = profile?.hasUsageCredentialsForDisplay ?? false
         if !hasUsageCredentials || config.enabledMetrics.isEmpty {
             // Show default app logo
             if let statusItem = statusItems[.session],  // We use .session as placeholder key

--- a/Claude Usage/Shared/Models/Profile.swift
+++ b/Claude Usage/Shared/Models/Profile.swift
@@ -121,6 +121,20 @@ struct Profile: Codable, Identifiable, Equatable {
         return !ClaudeCodeSyncService.shared.isTokenExpired(cliJSON)
     }
 
+    /// Ako `hasUsageCredentials`, ale pre zobrazenie (menu bar) zohľadňuje aj
+    /// systémový Keychain CLI token (Claude Code). Inak ikona spadne na default
+    /// logo po expirácii profile-cached CLI tokenu, hoci refresh stále beží cez
+    /// systémový token (bug #250).
+    var hasUsageCredentialsForDisplay: Bool {
+        if hasUsageCredentials { return true }
+        if let systemCreds = try? ClaudeCodeSyncService.shared.readSystemCredentials(),
+           !ClaudeCodeSyncService.shared.isTokenExpired(systemCreds),
+           ClaudeCodeSyncService.shared.extractAccessToken(from: systemCreds) != nil {
+            return true
+        }
+        return false
+    }
+
     var hasAnyCredentials: Bool {
         hasClaudeAI || hasAPIConsole || cliCredentialsJSON != nil
     }


### PR DESCRIPTION
## Problem

Fixes #250 (and likely dupes #226, #230, #244).

The menu bar icon drops to the default app logo while usage data is still collected correctly (the popover shows live %). Toggling **Icon Style** or **Session Usage** in settings has no visible effect.

## Root cause

There are two credential checks:
- **Refresh/data path** uses `MenuBarManager.hasAnyAvailableCredentials()`, which falls back to the **system Keychain CLI token** (Claude Code) — so data keeps flowing.
- **Render path** uses the narrow `Profile.hasUsageCredentials`, which only looks at profile-local credentials.

Once a profile's cached CLI OAuth token expires (Claude Code rotates the system token every few hours, but the profile-cached copy isn't refreshed for rendering), every redraw hits `!hasUsageCredentials`, disables all metrics and draws the default logo — even though the system Keychain token is still valid. Hence: live data, dead icon, settings that appear to do nothing.

## Fix

- Add `Profile.hasUsageCredentialsForDisplay`, mirroring the existing system-Keychain fallback in `hasAnyAvailableCredentials()`.
- Use it on the single-profile render/refresh gates: `StatusBarUIManager.updateAllButtons`, `MenuBarManager.updateMenuBarDisplay` / `setupSingleProfileMode` / `.credentialsChanged` observer / immediate-refresh trigger.
- `hasAnyAvailableCredentials()` now delegates to it (single source of truth).
- Multi-profile selection is intentionally left unchanged — its Keychain semantics are a separate question noted in #250.

No change to the data-fetch logic.

## Testing

Built locally (Release, build 15) and ran with a profile whose cached CLI token had already expired (~19 h prior) while the system Keychain token was still valid:
- **Before:** menu bar shows the static default logo; Icon Style toggles do nothing.
- **After:** menu bar shows the Battery (Classic) session icon with live data; toggles work again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
