### PR TITLE
fix(popover): Show popover over full-screen apps

### DIFF
--- a/Claude Usage/MenuBar/MenuBarManager.swift
+++ b/Claude Usage/MenuBar/MenuBarManager.swift
@@ -564,6 +564,10 @@ class MenuBarManager: NSObject, ObservableObject {
                     // the @Published profile properties set earlier in this method
                     popover.close()
                     stopMonitoringForOutsideClicks()
+                    // Activate first so the popover appears over a full-screen Space.
+                    // An .accessory app that isn't active renders the popover on the
+                    // desktop Space, hidden behind any frontmost full-screen app.
+                    NSApp.activate(ignoringOtherApps: true)
                     popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
                     currentPopoverButton = button
                     startMonitoringForOutsideClicks()
@@ -574,6 +578,9 @@ class MenuBarManager: NSObject, ObservableObject {
                 stopMonitoringForOutsideClicks()
                 // Update content view controller for current profile data
                 popover.contentViewController = createContentViewController()
+                // Activate first so the popover appears over a full-screen Space
+                // (otherwise an inactive .accessory app draws it on the desktop Space).
+                NSApp.activate(ignoringOtherApps: true)
                 popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
                 currentPopoverButton = button
                 startMonitoringForOutsideClicks()
@@ -600,6 +607,8 @@ class MenuBarManager: NSObject, ObservableObject {
         popover.behavior = .transient
         popover.animates = true
         popover.contentViewController = NSHostingController(rootView: PeakHoursPopoverView())
+        // Activate first so the popover appears over a full-screen Space.
+        NSApp.activate(ignoringOtherApps: true)
         popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
         peakHoursPopover = popover
     }
@@ -1852,6 +1861,8 @@ extension MenuBarManager: NSPopoverDelegate {
         window.setContentSize(NSSize(width: 280, height: 600))
         window.isReleasedWhenClosed = false
         window.level = .floating
+        // Allow a torn-off popover to stay on a full-screen app's Space.
+        window.collectionBehavior.insert(.fullScreenAuxiliary)
         window.isRestorable = false
         window.delegate = self
         window.backgroundColor = .clear


### PR DESCRIPTION
## Description

The popover when clicking on the menubar item only appeared when the user is on desktop and never over a full-screen app. The app is an accessory/LSUIElement agent so it's never the active app, and showing the popover without activating first makes it render on the desktop space, behind any full-screen window.

This activates the app right before showing the popover so it lands on the current space, over the full-screen app. Fixes #256.

## Changes

- Activate the app with `NSApp.activate(ignoringOtherApps:)` before each `popover.show()` (main popover and peak hours popover)
- Set `.fullScreenAuxiliary` on the detached popover panel so it stays on the full-screen space when popped out

Note: activating the app means clicking the icon takes focus from the frontmost app. That's required to draw over a full-screen space and matches how most menu bar apps behave, just flagging it.

## Screenshots / Screen Recordings
Here you can see the fixed version, with the popover showing over a fullscreen app. 
<img width="1575" height="367" alt="Screenshot 2026-06-03 at 14 26 52" src="https://github.com/user-attachments/assets/cb815345-85a6-4e12-8a83-3428bc044df0" />



## Checklist

- [x] I have tested these changes on a running build
- [x] I have attached screenshots/recordings for any visual changes
- [x] I have not introduced App Group or grouped Keychain usage
- [x] I have added localization keys for any new user-facing strings — N/A, no new strings