### PR TITLE
fix(services): identify accounts by accountUuid, not rotating refresh token

### DIFF
--- a/Claude Usage/Shared/Services/ClaudeCodeSyncService.swift
+++ b/Claude Usage/Shared/Services/ClaudeCodeSyncService.swift
@@ -541,6 +541,22 @@ class ClaudeCodeSyncService {
         LoggingService.shared.log("Removed CLI credentials from profile: \(profileId)")
     }
 
+    // MARK: - Account Identity
+
+    /// Extracts the stable `accountUuid` from a serialized `oauthAccount` JSON
+    /// string (as captured per-profile in `oauthAccountJSON`, or returned by
+    /// `readOAuthAccount()` for the live system). Unlike the OAuth `refreshToken`,
+    /// `accountUuid` does NOT change when Claude Code rotates tokens, so it is a
+    /// reliable signal for "is this the same account?".
+    private func accountUUID(fromOAuthAccountJSON json: String?) -> String? {
+        guard let json,
+              let data = json.data(using: .utf8),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        return obj["accountUuid"] as? String
+    }
+
     // MARK: - Access Token Extraction
 
     func extractAccessToken(from jsonData: String) -> String? {
@@ -625,13 +641,33 @@ class ClaudeCodeSyncService {
         // mismatch means the keychain holds another account's data (written by
         // applyProfileCredentials for a different profile). Saving would corrupt this profile.
         var profiles = ProfileStore.shared.loadProfiles()
-        if let profile = profiles.first(where: { $0.id == profileId }),
-           let storedJSON = profile.cliCredentialsJSON {
-            let freshRefreshToken = extractRefreshToken(from: freshJSON)
-            let storedRefreshToken = extractRefreshToken(from: storedJSON)
-            if let fresh = freshRefreshToken, let stored = storedRefreshToken, fresh != stored {
-                LoggingService.shared.log("⚠️ resyncBeforeSwitching: skipping for '\(profile.name)' — system refresh token differs (different account)")
-                return
+        if let profile = profiles.first(where: { $0.id == profileId }) {
+            // Identify accounts by a STABLE id (oauthAccount.accountUuid), NOT the
+            // refreshToken. Claude Code rotates the refreshToken on every token
+            // refresh within the SAME account, so refreshToken inequality does not
+            // imply a different account — it almost always just means "the token
+            // rotated since the last sync". Using the refreshToken as the identity
+            // check caused legitimate same-account re-syncs to be skipped, leaving
+            // the profile's stored credentials frozen at a now-invalidated token
+            // (and discarding the live rotated one), which later broke profile
+            // switching with HTTP 401.
+            let freshAccountId = accountUUID(fromOAuthAccountJSON: readOAuthAccount())
+            let storedAccountId = accountUUID(fromOAuthAccountJSON: profile.oauthAccountJSON)
+
+            if let fresh = freshAccountId, let stored = storedAccountId {
+                if fresh != stored {
+                    LoggingService.shared.log("⚠️ resyncBeforeSwitching: skipping for '\(profile.name)' — system account differs from profile account")
+                    return
+                }
+            } else if let storedJSON = profile.cliCredentialsJSON {
+                // Last-resort fallback only when the stable account id is
+                // unavailable on either side: keep the legacy refreshToken check.
+                let freshRefreshToken = extractRefreshToken(from: freshJSON)
+                let storedRefreshToken = extractRefreshToken(from: storedJSON)
+                if let fresh = freshRefreshToken, let stored = storedRefreshToken, fresh != stored {
+                    LoggingService.shared.log("⚠️ resyncBeforeSwitching: skipping for '\(profile.name)' — no account id and refresh tokens differ")
+                    return
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #263

## Problem

`resyncBeforeSwitching` used the OAuth `refreshToken` as an account-identity check (guard added in #215 to prevent cross-profile contamination). But Claude Code **rotates the `refreshToken` on every token refresh within the same account**, so `fresh != stored` is almost always true even for the same account. The guard therefore skipped the re-sync on essentially every switch, leaving the profile's stored credentials frozen at a now-invalidated token (and discarding the live rotated one). Once the stored access token expired, switching to that profile wrote dead credentials to the keychain → `401 Invalid authentication credentials` → forced `claude /login`.

See #263 for the full root-cause analysis and a controlled A/B experiment reproducing both the failure and this fix.

## Change

Identify accounts by the **stable** `oauthAccount.accountUuid` (already captured per-profile in `oauthAccountJSON` since #175) instead of the rotating refresh token. The re-sync is skipped only when account ids genuinely differ. When an account id is unavailable on either side, it falls back to the legacy refresh-token comparison, so behavior is unchanged for profiles that predate `oauthAccountJSON` capture.

- New helper `accountUUID(fromOAuthAccountJSON:)`.
- `resyncBeforeSwitching` guard reworked to use account identity with a refresh-token fallback.

This is intentionally scoped to the primary fix (bug 1). The defense-in-depth follow-up discussed in #263 (refusing to write already-expired credentials over a working keychain in `applyProfileCredentials`) is left out of this PR to keep it focused.

## Testing

- `xcodebuild ... -scheme "Claude Usage" build` → **BUILD SUCCEEDED** (Xcode 26.5).
- Reproduced the bug deterministically on the released build, then ran the **same** procedure against a local build of this branch:
  - **Before:** after forcing a real token rotation `A → B` and switching profiles, the stored profile token stayed at the dead `A` (rotation discarded).
  - **After:** same procedure rotated `Y → Z`; the stored profile token correctly became `Z` (rotation captured). No re-login required.

## Notes

- Possibly related to #239 (different setup/code path, same underlying trigger of Claude Code rotating refresh tokens). Flagged in #263 in case they can be addressed together.