### PR TITLE
fix(menubar): fix popover layout-recursion crash on macOS 26/27

### DIFF
--- a/Claude Usage/MenuBar/MenuBarManager.swift
+++ b/Claude Usage/MenuBar/MenuBarManager.swift
@@ -39,6 +39,12 @@ class MenuBarManager: NSObject, ObservableObject {
     // Event monitor for closing popover on outside click
     private var eventMonitor: Any?
 
+    // Timestamp of the most recent popover close. Used to debounce the
+    // status-item click that dismisses the popover: that same click also fires
+    // togglePopover, which would otherwise immediately re-show the popover
+    // (the "click makes it bounce back instead of closing" race).
+    private var lastPopoverCloseDate: Date = .distantPast
+
     // Detached window reference (when popover is detached)
     private var detachedWindow: NSWindow?
 
@@ -413,7 +419,14 @@ class MenuBarManager: NSObject, ObservableObject {
         let newPopover = NSPopover()
         newPopover.contentSize = Constants.WindowSizes.popoverSize
         newPopover.behavior = .semitransient
-        newPopover.animates = true
+        // Disabled to avoid an infinite layout-recursion crash on macOS 26/27.
+        // The hosting controller's sizingOptions/preferredContentSize (PR #200)
+        // keep the popover sized to its content; with animation on, each animated
+        // resize re-triggers layout (updateAnimatedWindowSize -> setFrame -> layout)
+        // and never converges, overflowing the main-thread stack. Disabling only the
+        // animation breaks the loop while preserving content sizing/positioning.
+        // See Discussion #64.
+        newPopover.animates = false
         newPopover.delegate = self
         newPopover.contentViewController = createContentViewController()
 
@@ -477,7 +490,14 @@ class MenuBarManager: NSObject, ObservableObject {
         let popover = NSPopover()
         popover.contentSize = Constants.WindowSizes.popoverSize
         popover.behavior = .semitransient  // Changed to allow detaching
-        popover.animates = true
+        // Disabled to avoid an infinite layout-recursion crash on macOS 26/27.
+        // The hosting controller's sizingOptions/preferredContentSize (PR #200)
+        // keep the popover sized to its content; with animation on, each animated
+        // resize re-triggers layout (updateAnimatedWindowSize -> setFrame -> layout)
+        // and never converges, overflowing the main-thread stack. Disabling only the
+        // animation breaks the loop while preserving content sizing/positioning.
+        // See Discussion #64.
+        popover.animates = false
         popover.delegate = self
 
         popover.contentViewController = createContentViewController()
@@ -569,7 +589,14 @@ class MenuBarManager: NSObject, ObservableObject {
                     startMonitoringForOutsideClicks()
                 }
             } else {
-                // Popover not shown - show it
+                // Popover not shown - show it.
+                // Guard against the dismiss/re-open race: if the popover was just
+                // closed (e.g. the outside-click monitor handled this same click a
+                // moment before the button action fired), treat this click as the
+                // dismissing click and don't immediately re-open it.
+                if Date().timeIntervalSince(lastPopoverCloseDate) < 0.25 {
+                    return
+                }
                 // Stop any existing monitor first
                 stopMonitoringForOutsideClicks()
                 // Update content view controller for current profile data
@@ -644,6 +671,7 @@ class MenuBarManager: NSObject, ObservableObject {
         popover?.performClose(nil)
         stopMonitoringForOutsideClicks()
         currentPopoverButton = nil
+        lastPopoverCloseDate = Date()
     }
 
     private func startMonitoringForOutsideClicks() {
@@ -1818,6 +1846,13 @@ extension MenuBarManager: NSPopoverDelegate {
     func popoverShouldDetach(_ popover: NSPopover) -> Bool {
         // Allow popover to be detached by dragging
         return true
+    }
+
+    func popoverDidClose(_ notification: Notification) {
+        // Record every close (transient dismiss, outside-click monitor, or
+        // explicit close) so togglePopover can debounce the dismissing click
+        // and avoid the "click bounces the popover back open" race.
+        lastPopoverCloseDate = Date()
     }
 
     func detachableWindow(for popover: NSPopover) -> NSWindow? {

--- a/Claude Usage/MenuBar/PopoverContentView.swift
+++ b/Claude Usage/MenuBar/PopoverContentView.swift
@@ -61,6 +61,12 @@ struct PopoverContentView: View {
 
     @State private var isRefreshing = false
     @State private var showInsights = false
+    // Drives a custom entrance animation. The native NSPopover open animation is
+    // disabled (see MenuBarManager) because its animated window resize recurses
+    // infinitely on macOS 26/27; this fades/scales the content in from the top
+    // instead — a pure SwiftUI transform on a fixed-size view, so it can't trigger
+    // the window-resize loop.
+    @State private var appeared = false
     @StateObject private var profileManager = ProfileManager.shared
 
     private func profileInitials(for name: String) -> String {
@@ -201,6 +207,14 @@ struct PopoverContentView: View {
         .padding(.bottom, 8)
         .frame(width: 280)
         .background(VisualEffectBackground())
+        .opacity(appeared ? 1 : 0)
+        .scaleEffect(appeared ? 1 : 0.96, anchor: .top)
+        .onAppear {
+            appeared = false
+            withAnimation(.spring(response: 0.32, dampingFraction: 0.82)) {
+                appeared = true
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Description

On macOS 26/27, clicking the menu bar icon can crash the app with `EXC_BAD_ACCESS` ("Thread stack size exceeded due to excessive recursion"). The main thread overflows in an unbounded AppKit/SwiftUI layout loop while the popover is being shown.

**Root cause:** the popover's `NSHostingController` uses `sizingOptions = .preferredContentSize` (added in #200 to fix positioning), which continuously re-pushes the SwiftUI content size into the popover window. With `NSPopover.animates = true`, macOS 26/27's updated SwiftUI never converges the animated resize:

```
NSPopover.show
  -> NSHostingView.windowDidLayout
    -> updateAnimatedWindowSize
      -> _NSPopoverWindow.setFrame:display:
        -> layout   (repeats ~6,500x) -> stack overflow
```

This is the layout-recursion fragility flagged in #64, escalated from a warning into a hard crash by the newer SwiftUI. Reproduced on macOS 27.0 (build 26A5353q), Apple Silicon.

## Changes

- **Fix the crash:** disable the native popover animation (`animates = false`) in `setupPopover()` and `recreatePopover()`, so the animated window resize can no longer feed the loop. The `preferredContentSize`/`sizingOptions` sizing from #200 is left intact, so the popover's content-hugging size and position are unchanged.
- **Keep an animated open:** replace the native animation with a custom SwiftUI fade + scale-from-top entrance in `PopoverContentView`. It runs purely as an opacity/transform on the fixed-size view, so it cannot re-trigger the window-resize loop.
- **Fix a dismiss/re-open race:** clicking the status item could occasionally close and immediately re-open the popover (the outside-click monitor and the button action racing). The popover now records its last close time, and `togglePopover` ignores a re-open within 0.25s of a close.

## Screenshots / Screen Recordings

<!-- Drag-and-drop your screen recording here in the GitHub web editor -->
_Screen recording (open animation + click-to-toggle + no crash) attached below._

## Checklist

- [x] I have tested these changes on a running build (Xcode 27 on macOS 27): repeated open/close with no crash, animated open, polished sizing, reliable click-to-toggle

https://github.com/user-attachments/assets/12ca1141-e558-430b-9f6d-baa4183fcff7


- [x] I have attached screenshots/recordings for any visual changes
- [x] I have not introduced App Group or grouped Keychain usage
- [x] N/A — no new user-facing strings
