### PR TITLE
fix(api): per-model weekly quotas (Fable/Opus/Sonnet) stay at 0% for CLI OAuth profiles

### DIFF
--- a/Claude Usage/Shared/Services/ClaudeAPIService.swift
+++ b/Claude Usage/Shared/Services/ClaudeAPIService.swift
@@ -512,10 +512,17 @@ class ClaudeAPIService: APIServiceProtocol {
 
             return claudeUsage
 
-        case .cliOAuth:
-            // The dedicated OAuth usage endpoint (api.anthropic.com/api/oauth/usage) is disabled.
-            // Instead, make a minimal Messages API call and extract usage from response headers.
-            LoggingService.shared.log("ClaudeAPIService: Fetching usage via Messages API headers (OAuth)")
+        case .cliOAuth(let accessToken):
+            // Prefer the dedicated OAuth usage endpoint (api.anthropic.com/api/oauth/usage):
+            // it is the only source of the per-model weekly quotas (Fable/Opus/Sonnet/Design
+            // via the limits[] array). The Messages-API header fallback below cannot see
+            // those, so per-model bars stay at 0 for CLI-credential profiles without this.
+            if let usage = try? await fetchUsageData(oauthAccessToken: accessToken) {
+                return usage
+            }
+
+            // Fallback: make a minimal Messages API call and extract usage from response headers.
+            LoggingService.shared.log("ClaudeAPIService: OAuth usage endpoint unavailable; falling back to Messages API headers")
 
             guard let url = URL(string: "https://api.anthropic.com/v1/messages") else {
                 throw AppError(


### PR DESCRIPTION
## Problem

For profiles authenticated with **Claude Code CLI credentials**, the per-model weekly bars (Fable / Opus / Sonnet / Design) always show **0%**, even when the account has real usage (e.g. Fable at 76-100%).

## Root cause

`fetchUsageData()`'s `.cliOAuth` branch assumes the dedicated OAuth usage endpoint is disabled and instead sends a minimal Messages API call, extracting usage from **rate-limit headers**. Those headers only carry the session/weekly aggregate — never the per-model quotas — so `parseUsageResponse()`'s `limits[]` handling (which correctly maps `kind=weekly_scoped` + `scope.model.display_name`) is never reached with per-model data.

Meanwhile the endpoint actually works. Verified today against a Max 20x account:

```
GET https://api.anthropic.com/api/oauth/usage
Authorization: Bearer <cli-oauth-token>
anthropic-beta: oauth-2025-04-20

"limits": [
  {"kind":"session","percent":2,...},
  {"kind":"weekly_all","percent":62,...},
  {"kind":"weekly_scoped","percent":76,"is_active":true,
   "scope":{"model":{"id":null,"display_name":"Fable"}}}
]
```

## Fix

In the `.cliOAuth` branch, call the existing `fetchUsageData(oauthAccessToken:)` (which hits the dedicated endpoint and already parses `limits[]`) first, and keep the Messages-API header probe as a graceful fallback if the endpoint errors.

Side benefit: when the endpoint is available, the app no longer spends a Haiku token on every refresh cycle.

## Testing

- Queried the endpoint directly with CLI OAuth tokens from 5 different Max accounts — all return the `limits[]` array with the Fable scoped quota.
- Confirmed the header-based path is the reason `fableWeeklyPercentage` stays 0 in `profiles_v3` while the API reports 76-100% for the same accounts.