### PR TITLE
fix(profiles): don't rotate externally-owned OAuth tokens; show cached usage instead of erroring

### DIFF
--- a/Claude Usage/MenuBar/MenuBarManager.swift
+++ b/Claude Usage/MenuBar/MenuBarManager.swift
@@ -1210,6 +1210,17 @@ class MenuBarManager: NSObject, ObservableObject {
             return try await apiService.fetchUsageData(oauthAccessToken: accessToken)
         }
 
+        // No usable live credential (e.g. a non-active profile whose CLI token expired and
+        // must not be refreshed independently — that would rotate a token another tool such as
+        // `cux` owns). Rather than surfacing a blocking "session key not found" dialog on every
+        // profile switch, fall back to the profile's last-known usage snapshot. Per-model weekly
+        // quotas (Fable/Opus/Sonnet) change slowly, so a slightly stale reading is far better UX
+        // than an error popup — and the active profile still refreshes live every cycle.
+        if let cached = profile.claudeUsage {
+            LoggingService.shared.log("fetchUsageForProfile: no live credential for '\(profile.name)'; showing last-known cached usage")
+            return cached
+        }
+
         throw AppError(
             code: .sessionKeyNotFound,
             message: "Missing credentials for profile '\(profile.name)'",

--- a/Claude Usage/Shared/Services/ClaudeCodeSyncService.swift
+++ b/Claude Usage/Shared/Services/ClaudeCodeSyncService.swift
@@ -1091,6 +1091,20 @@ class ClaudeCodeSyncService {
             return cliJSON
         }
 
+        // At this point the profile is EITHER pinned to a keychain entry (customSvc != nil)
+        // OR non-active & unpinned — the active/unpinned case already returned above via the
+        // system-keychain branch. For a non-active, unpinned profile the refresh_token lineage
+        // is owned by an external tool (e.g. the `cux` account switcher, or Claude Code's own
+        // keychain rotation). Refreshing here would consume that refresh token out from under
+        // the other tool, forcing its next use to fail with invalid_grant ("Please run /login").
+        // Never rotate a lineage we don't own: return the cached snapshot (even if expired) and
+        // let the display fall back to last-known usage. Pinned profiles are safe to refresh
+        // because we write the rotated tokens back to the shared keychain entry below.
+        if customSvc == nil {
+            LoggingService.shared.log("ensureFreshCredentials: '\(profile.name)' is non-active & unpinned; skipping refresh to avoid rotating an externally-owned token")
+            return cliJSON
+        }
+
         guard let refreshToken = extractRefreshToken(from: cliJSON) else {
             LoggingService.shared.log("ensureFreshCredentials: profile '\(profile.name)' has no refresh token; cannot auto-refresh")
             return nil


### PR DESCRIPTION
## Summary

Two small, related fixes so multi-account monitoring coexists with external tools that own the OAuth `refresh_token` lineage — e.g. account switchers like [`cux`](https://github.com/inulute/cux), or Claude Code's own keychain rotation.

This is independent of #276 (that one fixes the per-model Fable quota parsing); this PR only touches token-rotation safety and the profile-switch error UX.

## Problem

With several CLI-credential profiles, switching profiles pops a blocking **`E1000 — session key not found`** dialog, and the app can silently break the external switcher.

Root cause is a shared-lineage conflict:

- A tool like `cux` keeps only the **active** account's token fresh in the single `Claude Code-credentials` keychain entry; non-active accounts' `refresh_token`s live in its own store.
- When the Tracker calls `ensureFreshCredentials` for a **non-active, unpinned** profile whose token expired, it performs the `refresh_token` grant itself. That **rotates the token out from under the other tool**, so its next use fails with `invalid_grant` ("Please run /login").
- If the refresh fails (rotated already, or rate-limited), `fetchUsageForProfile` throws `sessionKeyNotFound`, surfacing the E1000 dialog on every switch.

## Changes

**1. `ClaudeCodeSyncService.ensureFreshCredentials`** — never independently refresh a non-active, unpinned profile. By the time we reach the refresh, the active/system-keychain case has already returned, so `customSvc == nil` here means *non-active + unpinned* → return the cached snapshot instead of rotating a lineage we don't own. Active profiles (system-keychain write-back) and pinned profiles (`customKeychainServiceName` write-back) are unchanged and still refresh.

**2. `MenuBarManager.fetchUsageForProfile`** — when no live credential is available, fall back to the profile's last-known `ClaudeUsage` snapshot instead of throwing `sessionKeyNotFound`. Per-model weekly quotas change slowly, so a slightly stale reading is far better UX than a blocking dialog on every profile switch. The active profile still refreshes live each cycle.

## Result

- Active profile → live data every cycle (unchanged).
- Non-active profiles → last-known usage, no popup.
- External switchers (`cux`, CLI) keep working — the Tracker no longer consumes their refresh tokens.

## Notes

- +25 lines, no deletions, no behavior change for single-profile / claude.ai-session-key / pinned-keychain setups.
- Verified against a real 6-account `cux` setup: before, every profile switch either popped E1000 or forced a `cux` re-login within ~8h; after, switching is silent and `cux` stays authorized.