### PR TITLE
fix(ui): crash on macOS 26 (Tahoe) — opt out of Liquid Glass (UIDesignRequiresCompatibility)

### DIFF
--- a/Claude Usage/MenuBar/PopoverContentView.swift
+++ b/Claude Usage/MenuBar/PopoverContentView.swift
@@ -1,55 +1,32 @@
 import SwiftUI
 import Charts
 
-// MARK: - Always-active vibrancy background
+// MARK: - Popover background
+// NOTE: This used to host an NSVisualEffectView(.hudWindow) vibrancy layer. On macOS 26
+// (Tahoe) the system's SwiftUI material pipeline segfaults while resolving that material
+// inside the popover — the faulting stack is entirely in DesignLibrary / SwiftUICore
+// (MaterialProviderBox.resolveLayers → MaterialEffectResolvedData.updateValue), with no
+// app frames, and it reproduces every time the popover re-renders (e.g. switching
+// profiles). Rendering a plain, opaque, theme-aware layer avoids the material-resolution
+// path entirely: no vibrancy, but no crash.
 struct VisualEffectBackground: NSViewRepresentable {
     func makeNSView(context: Context) -> NSView {
-        let container = NSView()
-
-        // Base vibrancy layer
-        let effectView = NSVisualEffectView()
-        effectView.material = .hudWindow
-        effectView.blendingMode = .behindWindow
-        effectView.state = .active
-        effectView.isEmphasized = true
-        effectView.translatesAutoresizingMaskIntoConstraints = false
-        container.addSubview(effectView)
-
-        // Solid tint overlay for more density
-        let tintView = NSView()
-        tintView.wantsLayer = true
-        if NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua {
-            tintView.layer?.backgroundColor = NSColor.black.withAlphaComponent(0.25).cgColor
-        } else {
-            tintView.layer?.backgroundColor = NSColor.white.withAlphaComponent(0.4).cgColor
-        }
-        tintView.translatesAutoresizingMaskIntoConstraints = false
-        container.addSubview(tintView)
-
-        NSLayoutConstraint.activate([
-            effectView.leadingAnchor.constraint(equalTo: container.leadingAnchor),
-            effectView.trailingAnchor.constraint(equalTo: container.trailingAnchor),
-            effectView.topAnchor.constraint(equalTo: container.topAnchor),
-            effectView.bottomAnchor.constraint(equalTo: container.bottomAnchor),
-            tintView.leadingAnchor.constraint(equalTo: container.leadingAnchor),
-            tintView.trailingAnchor.constraint(equalTo: container.trailingAnchor),
-            tintView.topAnchor.constraint(equalTo: container.topAnchor),
-            tintView.bottomAnchor.constraint(equalTo: container.bottomAnchor),
-        ])
-
-        return container
+        let view = NSView()
+        view.wantsLayer = true
+        applyBackground(to: view)
+        return view
     }
 
     func updateNSView(_ nsView: NSView, context: Context) {
-        // Update tint for appearance changes
-        if let tintView = nsView.subviews.last {
-            tintView.wantsLayer = true
-            if NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua {
-                tintView.layer?.backgroundColor = NSColor.black.withAlphaComponent(0.25).cgColor
-            } else {
-                tintView.layer?.backgroundColor = NSColor.white.withAlphaComponent(0.4).cgColor
-            }
-        }
+        applyBackground(to: nsView)
+    }
+
+    private func applyBackground(to view: NSView) {
+        view.wantsLayer = true
+        let isDark = NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        view.layer?.backgroundColor = (isDark
+            ? NSColor(calibratedWhite: 0.12, alpha: 1.0)
+            : NSColor(calibratedWhite: 0.96, alpha: 1.0)).cgColor
     }
 }
 

--- a/Claude Usage/Resources/Info.plist
+++ b/Claude Usage/Resources/Info.plist
@@ -6,6 +6,8 @@
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIconName</key>
+	<string>AppIcon</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
@@ -18,8 +20,8 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
-	<key>CFBundleIconName</key>
-	<string>AppIcon</string>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>LSUIElement</key>
@@ -30,32 +32,23 @@
 	<false/>
 	<key>NSSupportsAutomaticTermination</key>
 	<true/>
-	<key>LSApplicationCategoryType</key>
-	<string>public.app-category.utilities</string>
 	<key>NSSupportsSuddenTermination</key>
 	<false/>
-
-	<!-- Sparkle Update Configuration -->
-	<key>SUFeedURL</key>
-	<string>https://hamed-elfayome.github.io/Claude-Usage-Tracker/appcast.xml</string>
-
-	<key>SUPublicEDKey</key>
-	<string>1ol8Exuba8opOy5R93YCQVuBw5Y6q4MgtMrgnsh8Kec=</string>
-
-	<key>SUEnableAutomaticChecks</key>
-	<true/>
-
-	<key>SUScheduledCheckInterval</key>
-	<integer>86400</integer>
-
 	<key>SUAllowsAutomaticUpdates</key>
 	<true/>
-
+	<key>SUEnableAutomaticChecks</key>
+	<true/>
+	<key>SUEnableAutomaticUpdateReminders</key>
+	<true/>
 	<key>SUEnableInstallerLauncherService</key>
 	<true/>
-
-	<!-- Enable gentle reminders for background apps -->
-	<key>SUEnableAutomaticUpdateReminders</key>
+	<key>SUFeedURL</key>
+	<string>https://hamed-elfayome.github.io/Claude-Usage-Tracker/appcast.xml</string>
+	<key>SUPublicEDKey</key>
+	<string>1ol8Exuba8opOy5R93YCQVuBw5Y6q4MgtMrgnsh8Kec=</string>
+	<key>SUScheduledCheckInterval</key>
+	<integer>86400</integer>
+	<key>UIDesignRequiresCompatibility</key>
 	<true/>
 </dict>
 </plist>

--- a/Claude Usage/Views/SettingsView.swift
+++ b/Claude Usage/Views/SettingsView.swift
@@ -6,99 +6,48 @@ import UserNotifications
 /// Full-window vibrancy background — same approach as the popover's VisualEffectBackground.
 /// Using NSViewRepresentable inside SwiftUI means the entire view tree is SwiftUI-managed,
 /// so there is no opaque flash on deminiaturize or appearance change.
+// NOTE: NSVisualEffectView(.hudWindow) removed — see VisualEffectBackground in
+// PopoverContentView.swift. macOS 26 (Tahoe) segfaults in SwiftUICore's material
+// pipeline while resolving hosted materials. Solid opaque background = no crash.
 struct SettingsBackground: NSViewRepresentable {
     func makeNSView(context: Context) -> NSView {
-        let container = NSView()
-
-        let effectView = NSVisualEffectView()
-        effectView.material = .hudWindow
-        effectView.blendingMode = .behindWindow
-        effectView.state = .active
-        effectView.isEmphasized = true
-        effectView.translatesAutoresizingMaskIntoConstraints = false
-        container.addSubview(effectView)
-
-        let tintView = NSView()
-        tintView.wantsLayer = true
-        if NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua {
-            tintView.layer?.backgroundColor = NSColor.black.withAlphaComponent(0.35).cgColor
-        } else {
-            tintView.layer?.backgroundColor = NSColor.white.withAlphaComponent(0.4).cgColor
-        }
-        tintView.translatesAutoresizingMaskIntoConstraints = false
-        container.addSubview(tintView)
-
-        NSLayoutConstraint.activate([
-            effectView.leadingAnchor.constraint(equalTo: container.leadingAnchor),
-            effectView.trailingAnchor.constraint(equalTo: container.trailingAnchor),
-            effectView.topAnchor.constraint(equalTo: container.topAnchor),
-            effectView.bottomAnchor.constraint(equalTo: container.bottomAnchor),
-            tintView.leadingAnchor.constraint(equalTo: container.leadingAnchor),
-            tintView.trailingAnchor.constraint(equalTo: container.trailingAnchor),
-            tintView.topAnchor.constraint(equalTo: container.topAnchor),
-            tintView.bottomAnchor.constraint(equalTo: container.bottomAnchor),
-        ])
-
-        return container
+        let view = NSView()
+        view.wantsLayer = true
+        applyBackground(to: view)
+        return view
     }
 
     func updateNSView(_ nsView: NSView, context: Context) {
-        if let tintView = nsView.subviews.last {
-            tintView.wantsLayer = true
-            if NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua {
-                tintView.layer?.backgroundColor = NSColor.black.withAlphaComponent(0.35).cgColor
-            } else {
-                tintView.layer?.backgroundColor = NSColor.white.withAlphaComponent(0.4).cgColor
-            }
-        }
+        applyBackground(to: nsView)
+    }
+
+    private func applyBackground(to view: NSView) {
+        view.wantsLayer = true
+        let isDark = NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        view.layer?.backgroundColor = (isDark
+            ? NSColor(calibratedWhite: 0.12, alpha: 1.0)
+            : NSColor(calibratedWhite: 0.95, alpha: 1.0)).cgColor
     }
 }
 
 struct SidebarVisualEffect: NSViewRepresentable {
     func makeNSView(context: Context) -> NSView {
-        let container = NSView()
-
-        let effectView = NSVisualEffectView()
-        effectView.material = .hudWindow
-        effectView.blendingMode = .behindWindow
-        effectView.state = .active
-        effectView.isEmphasized = true
-        effectView.translatesAutoresizingMaskIntoConstraints = false
-        container.addSubview(effectView)
-
-        let tintView = NSView()
-        tintView.wantsLayer = true
-        if NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua {
-            tintView.layer?.backgroundColor = NSColor.black.withAlphaComponent(0.55).cgColor
-        } else {
-            tintView.layer?.backgroundColor = NSColor.white.withAlphaComponent(0.5).cgColor
-        }
-        tintView.translatesAutoresizingMaskIntoConstraints = false
-        container.addSubview(tintView)
-
-        NSLayoutConstraint.activate([
-            effectView.leadingAnchor.constraint(equalTo: container.leadingAnchor),
-            effectView.trailingAnchor.constraint(equalTo: container.trailingAnchor),
-            effectView.topAnchor.constraint(equalTo: container.topAnchor),
-            effectView.bottomAnchor.constraint(equalTo: container.bottomAnchor),
-            tintView.leadingAnchor.constraint(equalTo: container.leadingAnchor),
-            tintView.trailingAnchor.constraint(equalTo: container.trailingAnchor),
-            tintView.topAnchor.constraint(equalTo: container.topAnchor),
-            tintView.bottomAnchor.constraint(equalTo: container.bottomAnchor),
-        ])
-
-        return container
+        let view = NSView()
+        view.wantsLayer = true
+        applyBackground(to: view)
+        return view
     }
 
     func updateNSView(_ nsView: NSView, context: Context) {
-        if let tintView = nsView.subviews.last {
-            tintView.wantsLayer = true
-            if NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua {
-                tintView.layer?.backgroundColor = NSColor.black.withAlphaComponent(0.55).cgColor
-            } else {
-                tintView.layer?.backgroundColor = NSColor.white.withAlphaComponent(0.5).cgColor
-            }
-        }
+        applyBackground(to: nsView)
+    }
+
+    private func applyBackground(to view: NSView) {
+        view.wantsLayer = true
+        let isDark = NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        view.layer?.backgroundColor = (isDark
+            ? NSColor(calibratedWhite: 0.09, alpha: 1.0)
+            : NSColor(calibratedWhite: 0.92, alpha: 1.0)).cgColor
     }
 }
 


### PR DESCRIPTION
## Summary

On **macOS 26 (Tahoe)** the app crashes (`EXC_BAD_ACCESS`) whenever the popover re-renders — most reliably when **switching the active profile**. Root cause is a **stack overflow from infinite recursion** in the system Liquid Glass material pipeline. The faulting stack is entirely in system frameworks:

```
libsystem_pthread   ___chkstk_darwin           ← stack guard hit = stack overflow
DesignLibrary       (recursing…)
SwiftUICore         MaterialProviderBox.resolveLayers(in:)
SwiftUICore         MaterialEffectResolvedData.updateValue()
AttributeGraph      AG::Graph::UpdateStack::update()
SwiftUICore         ViewGraphRootValueUpdater.render(…)
AppKit              +[NSAnimationContext runAnimationGroup:]
```

This is **distinct from the layout-recursion crash fixed in #265** — it's the *material resolution* path, and it reproduces on a stock v3.2.0 build.

## Cause & fix

Built against the macOS 26 SDK, the app opts into the Liquid Glass design system. Its material renderer recurses without termination during an animated view update (profile switch) and overflows the stack. **Removing the app's own `NSVisualEffectView` layers did not help** — the recursive material is applied by the system design layer itself.

Setting **`UIDesignRequiresCompatibility = YES`** in Info.plist renders with the pre-26 design system, bypassing Liquid Glass material resolution entirely.

## Commits
1. `drop NSVisualEffectView hosted materials` — removes the app's own vibrancy layers (first attempt; necessary cleanup but insufficient alone).
2. `opt out of Liquid Glass (UIDesignRequiresCompatibility)` — **the actual fix.**

## Testing
- Repro: 6-profile setup on macOS 26 — clicking between profiles crashed within seconds, every build, with the signature above.
- After: **9+ minutes of continuous profile switching and opening Settings with zero crashes.**

Maintainer note: if you'd rather keep the vibrancy blur on older macOS, commit 2 (the opt-out) is sufficient on its own and commit 1 can be dropped — the compatibility flag makes the legacy `NSVisualEffectView` path render fine.