### PR TITLE
fix(ui): macOS 26 crash in multi-profile mode — pin NSStatusItem length

### DIFF
--- a/Claude Usage/MenuBar/StatusBarUIManager.swift
+++ b/Claude Usage/MenuBar/StatusBarUIManager.swift
@@ -568,14 +568,33 @@ final class StatusBarUIManager {
                 )
             }
 
+            let finalImage: NSImage
             if profile.id == activeProfileId && config.showActiveProfileIndicator {
                 let underlinedImage = addGreenUnderline(to: image)
                 underlinedImage.isTemplate = false
-                button.image = underlinedImage
+                finalImage = underlinedImage
             } else {
                 image.isTemplate = useMonochrome && !config.showPaceMarker
-                button.image = image
+                finalImage = image
             }
+
+            // macOS 26 (Tahoe) crash fix: with NSStatusItem.variableLength, AppKit
+            // recomputes each item's width from its image inside a shared status-bar
+            // NSISEngine layout pass. With 2+ profile items this recurses without
+            // termination — a stack overflow (___chkstk_darwin in NSISEngine
+            // _coreReplaceMarker:withMarkerPlusDelta:). We pin an explicit length so
+            // AppKit skips the recursive variable-width solve.
+            //
+            // Crucially the length must stay CONSTANT across refreshes: *changing* a
+            // status item's length is itself the recursing op (the "PlusDelta"), so a
+            // per-pixel width jitter between updates (e.g. "5%" vs "45%") would still
+            // crash. Round the width up to a coarse grid so ordinary data changes never
+            // move the length, and only assign when it genuinely changes.
+            let stableLength = ceil(finalImage.size.width / 32.0) * 32.0
+            if abs(statusItem.length - stableLength) > 0.5 {
+                statusItem.length = stableLength
+            }
+            button.image = finalImage
         }
     }
 


### PR DESCRIPTION
## Summary

In **multi-profile mode** on **macOS 26 (Tahoe)**, the app crashes (`EXC_BAD_ACCESS` / stack overflow) as soon as **2 or more** profiles are selected for display. Single-profile mode is fine.

## Repro (deterministic)

Set N profiles' `isSelectedForDisplay = true`, launch, wait ~8s (first icon update):

| profiles visible | result |
|---|---|
| 1 | ✅ stable |
| 2 | ❌ crash |
| 3 | ❌ crash |
| 7 | ❌ crash |

## Faulting stack

```
libsystem_pthread   ___chkstk_darwin              ← stack guard = stack overflow
CoreAutoLayout      -[NSISEngine _flushPendingRemovals]
CoreAutoLayout      -[NSISEngine _coreReplaceMarker:withMarkerPlusDelta:]   (recursing)
CoreAutoLayout      -[NSISEngine constraintDidChangeSuchThatMarker:shouldBeReplacedByMarkerPlusDelta:]
CoreAutoLayout      -[NSLayoutConstraint setConstant:]
AppKit              -[NSView _updateSimpleAutoresizingConstraintsInPlace:forAutoresizingMask:]
AppKit              -[NSView setFrameOrigin:]
SwiftUICore         CoreViewSetGeometry / DisplayList.ViewUpdater.updateGeometry
```

## Cause

`setupMultiProfile` creates one `NSStatusItem.variableLength` per profile. On macOS 26, when `updateMultiProfileButtons` assigns `button.image` to several of these items, AppKit recomputes each item's width from its image inside a **shared status-bar `NSISEngine` layout pass**. With 2+ items the width-marker replacement (`_coreReplaceMarker:withMarkerPlusDelta:`) recurses without termination and overflows the stack. One item never triggers the cross-item cascade, so single-profile mode is unaffected.

## Fix

Pin an explicit `statusItem.length` from the rendered image width right before assigning `button.image`, so AppKit skips the recursive variable-width solve:

```swift
statusItem.length = ceil(finalImage.size.width) + 2
button.image = finalImage
```

## Testing

- Before: crash within ~8s at 2/3/7 visible profiles, every launch.
- After: **3+ minutes with all 7 profiles visible, zero crashes**; icons render and update normally. Single-profile mode unchanged.

+14 / −2, only `StatusBarUIManager.updateMultiProfileButtons`.