### PR TITLE
feat: Keep Awake — stop the Mac sleeping while Claude Code works

### DIFF
--- a/Claude Usage/App/AppDelegate.swift
+++ b/Claude Usage/App/AppDelegate.swift
@@ -45,13 +45,23 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         // Start 24-hour heartbeat ping to track active app usage
         HeartbeatService.shared.start()
 
+        // Keep Awake: manages the power assertion for manual and auto mode.
+        KeepAwakeService.shared.start()
+
         // Claude Code notch HUD (opt-in): start the hook listener + HUD when
-        // enabled, and react to the settings toggle at runtime.
+        // enabled, and react to the settings toggle at runtime. Keep Awake's
+        // auto mode shares the hook listener, so its toggle re-evaluates too.
         updateNotchHUDServices()
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(handleNotchHUDSettingChanged),
             name: .notchHUDSettingChanged,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleKeepAwakeSettingChanged),
+            name: .keepAwakeSettingChanged,
             object: nil
         )
 
@@ -227,32 +237,50 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
 
     func applicationWillTerminate(_ notification: Notification) {
         // Cleanup
+        KeepAwakeService.shared.stop()
         NotchHookServer.shared.stop()
         NotchHUDController.shared.stop()
         menuBarManager?.cleanup()
     }
 
-    // MARK: - Claude Code Notch HUD
+    // MARK: - Claude Code Notch HUD / Keep Awake hook plumbing
 
     @objc private func handleNotchHUDSettingChanged() {
         updateNotchHUDServices()
     }
 
+    @objc private func handleKeepAwakeSettingChanged() {
+        updateNotchHUDServices()
+        KeepAwakeService.shared.settingsChanged()
+    }
+
+    /// The hook listener (and session store lifecycle) is shared between the
+    /// notch HUD and Keep Awake's auto mode: it runs while EITHER feature
+    /// needs session events. The HUD window itself stays gated on its own toggle.
     private func updateNotchHUDServices() {
-        if SharedDataStore.shared.loadNotchHUDEnabled() {
-            NotchHUDController.shared.start()
+        let hudEnabled = SharedDataStore.shared.loadNotchHUDEnabled()
+        let hooksNeeded = hudEnabled || SharedDataStore.shared.loadKeepAwakeAutoEnabled()
+
+        if hooksNeeded {
             NotchHookServer.shared.start()
+            NotchSessionStore.shared.startStaleSweep()
             // Self-heal hook config drift (e.g. legacy entries from an old build).
             if NotchHookInstaller.shared.checkStatus() != .installed {
                 NotchHookInstaller.shared.install()
             }
+        } else {
+            NotchHookServer.shared.stop()
+            NotchSessionStore.shared.reset()
+        }
+
+        if hudEnabled {
+            NotchHUDController.shared.start()
             #if DEBUG
             if ProcessInfo.processInfo.arguments.contains("--mock-notch") {
                 NotchHUDController.shared.injectMockSessions()
             }
             #endif
         } else {
-            NotchHookServer.shared.stop()
             NotchHUDController.shared.stop()
         }
     }

--- a/Claude Usage/App/AppDelegate.swift
+++ b/Claude Usage/App/AppDelegate.swift
@@ -52,13 +52,23 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         // Start 24-hour heartbeat ping to track active app usage
         HeartbeatService.shared.start()
 
+        // Keep Awake: manages the power assertion for manual and auto mode.
+        KeepAwakeService.shared.start()
+
         // Claude Code notch HUD (opt-in): start the hook listener + HUD when
-        // enabled, and react to the settings toggle at runtime.
+        // enabled, and react to the settings toggle at runtime. Keep Awake's
+        // auto mode shares the hook listener, so its toggle re-evaluates too.
         updateNotchHUDServices()
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(handleNotchHUDSettingChanged),
             name: .notchHUDSettingChanged,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleKeepAwakeSettingChanged),
+            name: .keepAwakeSettingChanged,
             object: nil
         )
 
@@ -236,32 +246,50 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
 
     func applicationWillTerminate(_ notification: Notification) {
         // Cleanup
+        KeepAwakeService.shared.stop()
         NotchHookServer.shared.stop()
         NotchHUDController.shared.stop()
         menuBarManager?.cleanup()
     }
 
-    // MARK: - Claude Code Notch HUD
+    // MARK: - Claude Code Notch HUD / Keep Awake hook plumbing
 
     @objc private func handleNotchHUDSettingChanged() {
         updateNotchHUDServices()
     }
 
+    @objc private func handleKeepAwakeSettingChanged() {
+        updateNotchHUDServices()
+        KeepAwakeService.shared.settingsChanged()
+    }
+
+    /// The hook listener (and session store lifecycle) is shared between the
+    /// notch HUD and Keep Awake's auto mode: it runs while EITHER feature
+    /// needs session events. The HUD window itself stays gated on its own toggle.
     private func updateNotchHUDServices() {
-        if SharedDataStore.shared.loadNotchHUDEnabled() {
-            NotchHUDController.shared.start()
+        let hudEnabled = SharedDataStore.shared.loadNotchHUDEnabled()
+        let hooksNeeded = hudEnabled || SharedDataStore.shared.loadKeepAwakeAutoEnabled()
+
+        if hooksNeeded {
             NotchHookServer.shared.start()
+            NotchSessionStore.shared.startStaleSweep()
             // Self-heal hook config drift (e.g. legacy entries from an old build).
             if NotchHookInstaller.shared.checkStatus() != .installed {
                 NotchHookInstaller.shared.install()
             }
+        } else {
+            NotchHookServer.shared.stop()
+            NotchSessionStore.shared.reset()
+        }
+
+        if hudEnabled {
+            NotchHUDController.shared.start()
             #if DEBUG
             if ProcessInfo.processInfo.arguments.contains("--mock-notch") {
                 NotchHUDController.shared.injectMockSessions()
             }
             #endif
         } else {
-            NotchHookServer.shared.stop()
             NotchHUDController.shared.stop()
         }
     }

--- a/Claude Usage/MenuBar/KeepAwakeAmbientLayerView.swift
+++ b/Claude Usage/MenuBar/KeepAwakeAmbientLayerView.swift
@@ -1,0 +1,194 @@
+//
+//  KeepAwakeAmbientLayerView.swift
+//  Claude Usage
+//
+//  Core Animation-driven ambience for the keep-awake header button: a soft
+//  breathing glow behind the cup and three steam wisps drifting up from it.
+//
+//  These loops were originally SwiftUI `.repeatForever` animations. A looping
+//  SwiftUI animation re-renders the popover's NSHostingView on every display
+//  frame (up to 120 Hz on ProMotion) for as long as the popover is open, and
+//  each pass also re-measures the NSPopover frame — measured at 25–37% of a
+//  core in a Debug build. CAAnimations are committed once and then run on the
+//  render server, so the main thread does no per-frame work at all.
+//
+
+import AppKit
+import SwiftUI
+
+/// SwiftUI wrapper. Sized by the caller (24×24 to match the button).
+struct KeepAwakeAmbientLayerView: NSViewRepresentable {
+    /// When false (Reduce Motion), a static glow is drawn and steam is hidden.
+    var animates: Bool
+
+    func makeNSView(context: Context) -> KeepAwakeAmbientNSView {
+        let view = KeepAwakeAmbientNSView()
+        view.animates = animates
+        return view
+    }
+
+    func updateNSView(_ nsView: KeepAwakeAmbientNSView, context: Context) {
+        nsView.animates = animates
+    }
+}
+
+final class KeepAwakeAmbientNSView: NSView {
+    var animates = true {
+        didSet { if animates != oldValue { rebuildAnimations() } }
+    }
+
+    private let glowLayer = CAGradientLayer()
+    private var steamLayers: [CALayer] = []
+    private var occlusionObserver: NSObjectProtocol?
+
+    // Matches the original SwiftUI steam: 2.5pt dots at x offsets −2.5 / 0.5 / 3,
+    // each rising from y −5 to −12 while fading 0.5 → 0 over 1.7s, staggered.
+    private static let steamSpecs: [(x: CGFloat, delay: CFTimeInterval)] = [
+        (-2.5, 0.0), (0.5, 0.55), (3.0, 1.1),
+    ]
+    private static let steamDuration: CFTimeInterval = 1.7
+    private static let glowDuration: CFTimeInterval = 2.0
+    private static let glowDiameter: CGFloat = 22
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+        layerContentsRedrawPolicy = .never
+        setupLayers()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) is not supported") }
+
+    deinit {
+        if let occlusionObserver {
+            NotificationCenter.default.removeObserver(occlusionObserver)
+        }
+    }
+
+    /// y-down so layer offsets read like the SwiftUI `.offset` values they replace.
+    override var isFlipped: Bool { true }
+
+    /// Purely decorative; never intercept the button's clicks.
+    override func hitTest(_ point: NSPoint) -> NSView? { nil }
+
+    // MARK: - Layers
+
+    private func setupLayers() {
+        guard let layer else { return }
+
+        glowLayer.type = .radial
+        glowLayer.colors = [
+            NSColor.systemOrange.withAlphaComponent(0.5).cgColor,
+            NSColor.systemOrange.withAlphaComponent(0.0).cgColor,
+        ]
+        glowLayer.locations = [0, 1]
+        glowLayer.startPoint = CGPoint(x: 0.5, y: 0.5)
+        glowLayer.endPoint = CGPoint(x: 1.0, y: 1.0)
+        glowLayer.bounds = CGRect(x: 0, y: 0, width: Self.glowDiameter, height: Self.glowDiameter)
+        layer.addSublayer(glowLayer)
+
+        for _ in Self.steamSpecs {
+            let dot = CALayer()
+            dot.bounds = CGRect(x: 0, y: 0, width: 2.5, height: 2.5)
+            dot.cornerRadius = 1.25
+            dot.backgroundColor = NSColor.systemOrange.cgColor
+            dot.opacity = 0 // invisible until its animation begins
+            layer.addSublayer(dot)
+            steamLayers.append(dot)
+        }
+    }
+
+    private func positionLayers() {
+        let center = CGPoint(x: bounds.midX, y: bounds.midY)
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        glowLayer.position = center
+        for (dot, spec) in zip(steamLayers, Self.steamSpecs) {
+            dot.position = CGPoint(x: center.x + spec.x, y: center.y - 5)
+        }
+        CATransaction.commit()
+    }
+
+    override func layout() {
+        super.layout()
+        positionLayers()
+    }
+
+    override func viewDidChangeBackingProperties() {
+        super.viewDidChangeBackingProperties()
+        let scale = window?.backingScaleFactor ?? 2
+        glowLayer.contentsScale = scale
+        steamLayers.forEach { $0.contentsScale = scale }
+    }
+
+    // MARK: - Animations
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        if let occlusionObserver {
+            NotificationCenter.default.removeObserver(occlusionObserver)
+            self.occlusionObserver = nil
+        }
+        if let window {
+            // Don't keep the render server busy for a popover that's off-screen.
+            occlusionObserver = NotificationCenter.default.addObserver(
+                forName: NSWindow.didChangeOcclusionStateNotification,
+                object: window,
+                queue: .main
+            ) { [weak self] _ in
+                self?.rebuildAnimations()
+            }
+        }
+        rebuildAnimations()
+    }
+
+    private func rebuildAnimations() {
+        glowLayer.removeAllAnimations()
+        steamLayers.forEach { $0.removeAllAnimations() }
+
+        guard let window, window.occlusionState.contains(.visible) else {
+            return
+        }
+        positionLayers()
+
+        guard animates else {
+            // Reduce Motion: steady glow, no steam.
+            glowLayer.opacity = 0.7
+            steamLayers.forEach { $0.opacity = 0 }
+            return
+        }
+
+        glowLayer.opacity = 1
+        let pulse = CABasicAnimation(keyPath: "opacity")
+        pulse.fromValue = 0.45
+        pulse.toValue = 1.0
+        pulse.duration = Self.glowDuration
+        pulse.autoreverses = true
+        pulse.repeatCount = .infinity
+        pulse.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+        glowLayer.add(pulse, forKey: "pulse")
+
+        let now = CACurrentMediaTime()
+        let center = CGPoint(x: bounds.midX, y: bounds.midY)
+        for (dot, spec) in zip(steamLayers, Self.steamSpecs) {
+            dot.opacity = 0
+
+            let rise = CABasicAnimation(keyPath: "position.y")
+            rise.fromValue = center.y - 5
+            rise.toValue = center.y - 12
+
+            let fade = CABasicAnimation(keyPath: "opacity")
+            fade.fromValue = 0.5
+            fade.toValue = 0.0
+
+            let group = CAAnimationGroup()
+            group.animations = [rise, fade]
+            group.duration = Self.steamDuration
+            group.beginTime = now + spec.delay
+            group.repeatCount = .infinity
+            group.timingFunction = CAMediaTimingFunction(name: .easeOut)
+            dot.add(group, forKey: "steam")
+        }
+    }
+}

--- a/Claude Usage/MenuBar/NotchHUD/NotchHUDController.swift
+++ b/Claude Usage/MenuBar/NotchHUD/NotchHUDController.swift
@@ -48,7 +48,8 @@ final class NotchHUDController {
             compactTrailing: { NotchCompactTrailingView() }
         )
 
-        NotchSessionStore.shared.startStaleSweep()
+        // Stale-sweep and store reset are owned by AppDelegate: the session
+        // store outlives the HUD when Keep Awake's auto mode still needs it.
         NotchSessionStore.shared.$sessions
             .receive(on: DispatchQueue.main)
             .sink { [weak self] sessions in
@@ -69,7 +70,6 @@ final class NotchHUDController {
         dynamicNotch = nil
         isVisible = false
         isExpanded = false
-        NotchSessionStore.shared.reset()
         Task { await notch?.hide() }
     }
 

--- a/Claude Usage/MenuBar/PopoverContentView.swift
+++ b/Claude Usage/MenuBar/PopoverContentView.swift
@@ -688,9 +688,9 @@ private struct KeepAwakeHoverCard: View {
                     .font(.system(size: 11))
                     .foregroundColor(.primary)
 
-                // Auto mode is armed but not currently the reason we're lit:
+                // A manual hold is showing above, but auto is also armed:
                 // say so, so its behavior is never a surprise.
-                if service.autoEnabled, !service.isAutoHolding {
+                if service.autoEnabled, !service.isAutoHolding, service.isManualOn {
                     Text("keep_awake.state_auto_armed".localized)
                         .font(.system(size: 10))
                         .foregroundColor(.secondary)
@@ -720,14 +720,20 @@ private struct KeepAwakeHoverCard: View {
             return "keep_awake.state_auto_grace".localized(
                 with: KeepAwakeTimeFormat.remaining(until: graceEnd, from: reference))
         }
+        if service.autoEnabled {
+            // Armed but idle: auto will hold as soon as Claude Code works.
+            return "keep_awake.state_auto_armed".localized
+        }
         return "keep_awake.state_off".localized
     }
 
     private var hintText: String {
-        guard service.isAssertionHeld else { return "keep_awake.hint_click_on".localized }
-        return service.isAutoHolding && !service.isManualOn
-            ? "keep_awake.hint_click_pause_auto".localized
-            : "keep_awake.hint_click_off".localized
+        if service.isManualOn {
+            return "keep_awake.hint_click_off".localized
+        }
+        return service.autoEnabled
+            ? "keep_awake.hint_click_auto_off".localized
+            : "keep_awake.hint_click_on".localized
     }
 }
 

--- a/Claude Usage/MenuBar/PopoverContentView.swift
+++ b/Claude Usage/MenuBar/PopoverContentView.swift
@@ -571,12 +571,34 @@ struct KeepAwakeHeaderButton: View {
 
     private var isActive: Bool { service.isAssertionHeld }
 
+    /// State-aware tooltip so hovering explains exactly what the cup is doing.
+    private var tooltip: String {
+        if service.isManualOn {
+            if let expiry = service.manualExpiry {
+                let formatter = DateFormatter()
+                formatter.timeStyle = .short
+                return "keep_awake.tooltip_until".localized(with: formatter.string(from: expiry))
+            }
+            return "keep_awake.tooltip_on".localized
+        }
+        if service.isAutoHolding {
+            return "keep_awake.tooltip_auto".localized
+        }
+        return "keep_awake.tooltip_off".localized
+    }
+
     var body: some View {
         Button(action: { service.toggleManual() }) {
             ZStack {
                 if !reduceMotion, rippleID > 0, isActive {
                     KeepAwakeActivationRipple()
                         .id(rippleID)
+                    KeepAwakeActivationRipple(delay: 0.18)
+                        .id(-rippleID)
+                }
+
+                if isActive, !reduceMotion {
+                    KeepAwakeSteamView()
                 }
 
                 Image(systemName: isActive ? "cup.and.saucer.fill" : "cup.and.saucer")
@@ -602,7 +624,7 @@ struct KeepAwakeHeaderButton: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .help("keep_awake.toggle_tooltip".localized)
+        .help(tooltip)
         .onHover { hovering in
             withAnimation(.easeInOut(duration: 0.15)) {
                 isHovered = hovering
@@ -629,8 +651,10 @@ struct KeepAwakeHeaderButton: View {
 }
 
 /// One-shot expanding ring played on activation; re-created via `.id` so each
-/// activation replays it from the start.
+/// activation replays it from the start. Two staggered rings give the "drop
+/// in water" feel.
 private struct KeepAwakeActivationRipple: View {
+    var delay: Double = 0
     @State private var expanded = false
 
     var body: some View {
@@ -640,10 +664,38 @@ private struct KeepAwakeActivationRipple: View {
             .scaleEffect(expanded ? 1.9 : 0.7)
             .allowsHitTesting(false)
             .onAppear {
-                withAnimation(.easeOut(duration: 0.6)) {
+                withAnimation(.easeOut(duration: 0.6).delay(delay)) {
                     expanded = true
                 }
             }
+    }
+}
+
+/// Three tiny steam wisps drifting up from the cup while keep-awake is active.
+/// Each dot fades out as it rises, then loops; staggered delays keep the
+/// motion organic. Only shown when Reduce Motion is off.
+private struct KeepAwakeSteamView: View {
+    @State private var rising = false
+
+    var body: some View {
+        ZStack {
+            steamDot(x: -2.5, delay: 0.0)
+            steamDot(x: 0.5, delay: 0.55)
+            steamDot(x: 3.0, delay: 1.1)
+        }
+        .allowsHitTesting(false)
+        .onAppear { rising = true }
+    }
+
+    private func steamDot(x: CGFloat, delay: Double) -> some View {
+        Circle()
+            .fill(Color.orange.opacity(rising ? 0 : 0.5))
+            .frame(width: 2.5, height: 2.5)
+            .offset(x: x, y: rising ? -12 : -5)
+            .animation(
+                .easeOut(duration: 1.7).repeatForever(autoreverses: false).delay(delay),
+                value: rising
+            )
     }
 }
 

--- a/Claude Usage/MenuBar/PopoverContentView.swift
+++ b/Claude Usage/MenuBar/PopoverContentView.swift
@@ -575,11 +575,20 @@ struct KeepAwakeHeaderButton: View {
     private static let menuDurations: [TimeInterval] = [15 * 60, 3600, 2 * 3600, 8 * 3600]
 
     private var isActive: Bool { service.isAssertionHeld }
+    /// Auto mode is on but not currently holding: dimmed-orange filled cup so
+    /// the first click (and every armed idle state) has visible feedback.
+    private var isArmed: Bool { service.autoEnabled && !isActive }
+
+    private var iconColor: Color {
+        if isActive { return .orange }
+        if isArmed { return Color.orange.opacity(0.55) }
+        return isHovered ? .primary : .secondary
+    }
 
     var body: some View {
         Button(action: { service.smartToggle() }) {
             ZStack {
-                if !reduceMotion, rippleID > 0, isActive {
+                if !reduceMotion, rippleID > 0, isActive || isArmed {
                     KeepAwakeActivationRipple()
                         .id(rippleID)
                     KeepAwakeActivationRipple(delay: 0.18)
@@ -590,24 +599,27 @@ struct KeepAwakeHeaderButton: View {
                     KeepAwakeSteamView()
                 }
 
-                Image(systemName: isActive ? "cup.and.saucer.fill" : "cup.and.saucer")
+                Image(systemName: isActive || isArmed ? "cup.and.saucer.fill" : "cup.and.saucer")
                     .font(.system(size: 10.5, weight: .medium))
                     .imageScale(.medium)
                     .contentTransition(.symbolEffect(.replace))
                     .symbolEffect(.bounce, options: .speed(1.3), value: isActive)
+                    .symbolEffect(.bounce, options: .speed(1.3), value: service.autoEnabled)
                     .shadow(
                         color: isActive ? Color.orange.opacity(glowPulse ? 0.55 : 0.25) : .clear,
                         radius: glowPulse ? 5 : 3
                     )
             }
-            .foregroundColor(isActive ? .orange : (isHovered ? .primary : .secondary))
+            .foregroundColor(iconColor)
             .frame(width: 24, height: 24, alignment: .center)
             .background(
                 RoundedRectangle(cornerRadius: 5)
                     .fill(
                         isActive
                             ? Color.orange.opacity(isHovered ? 0.16 : 0.10)
-                            : (isHovered ? Color.primary.opacity(0.08) : Color.clear)
+                            : (isArmed
+                                ? Color.orange.opacity(isHovered ? 0.12 : 0.06)
+                                : (isHovered ? Color.primary.opacity(0.08) : Color.clear))
                     )
             )
             .contentShape(Rectangle())
@@ -663,6 +675,13 @@ struct KeepAwakeHeaderButton: View {
                 glowPulse = true
             } else {
                 glowPulse = false
+            }
+        }
+        .onChange(of: service.autoEnabled) { _, enabled in
+            // Arming auto (usually the first-ever click) plays the ripple even
+            // though no assertion is held yet — the click must feel received.
+            if enabled, !isActive {
+                rippleID += 1
             }
         }
     }

--- a/Claude Usage/MenuBar/PopoverContentView.swift
+++ b/Claude Usage/MenuBar/PopoverContentView.swift
@@ -688,6 +688,14 @@ private struct KeepAwakeHoverCard: View {
                     .font(.system(size: 11))
                     .foregroundColor(.primary)
 
+                // Auto mode is armed but not currently the reason we're lit:
+                // say so, so its behavior is never a surprise.
+                if service.autoEnabled, !service.isAutoHolding {
+                    Text("keep_awake.state_auto_armed".localized)
+                        .font(.system(size: 10))
+                        .foregroundColor(.secondary)
+                }
+
                 Text(hintText)
                     .font(.system(size: 10))
                     .foregroundColor(.secondary)

--- a/Claude Usage/MenuBar/PopoverContentView.swift
+++ b/Claude Usage/MenuBar/PopoverContentView.swift
@@ -494,6 +494,9 @@ struct SmartHeader: View {
             Spacer()
 
             HStack(alignment: .center, spacing: 2) {
+                // Keep awake
+                KeepAwakeHeaderButton()
+
                 // Refresh
                 HeaderIconButton(
                     icon: "arrow.clockwise",
@@ -551,6 +554,96 @@ struct HeaderIconButton: View {
                 isHovered = hovering
             }
         }
+    }
+}
+
+// MARK: - Keep Awake Header Button
+
+/// Header toggle for KeepAwakeService. Lights up (with a one-shot ripple and
+/// a soft breathing glow) whenever the assertion is held — including holds
+/// from auto mode — so it doubles as an "is my Mac staying awake?" indicator.
+struct KeepAwakeHeaderButton: View {
+    @ObservedObject private var service = KeepAwakeService.shared
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var isHovered = false
+    @State private var rippleID = 0
+    @State private var glowPulse = false
+
+    private var isActive: Bool { service.isAssertionHeld }
+
+    var body: some View {
+        Button(action: { service.toggleManual() }) {
+            ZStack {
+                if !reduceMotion, rippleID > 0, isActive {
+                    KeepAwakeActivationRipple()
+                        .id(rippleID)
+                }
+
+                Image(systemName: isActive ? "cup.and.saucer.fill" : "cup.and.saucer")
+                    .font(.system(size: 10.5, weight: .medium))
+                    .imageScale(.medium)
+                    .contentTransition(.symbolEffect(.replace))
+                    .symbolEffect(.bounce, options: .speed(1.3), value: isActive)
+                    .shadow(
+                        color: isActive ? Color.orange.opacity(glowPulse ? 0.55 : 0.25) : .clear,
+                        radius: glowPulse ? 5 : 3
+                    )
+            }
+            .foregroundColor(isActive ? .orange : (isHovered ? .primary : .secondary))
+            .frame(width: 24, height: 24, alignment: .center)
+            .background(
+                RoundedRectangle(cornerRadius: 5)
+                    .fill(
+                        isActive
+                            ? Color.orange.opacity(isHovered ? 0.16 : 0.10)
+                            : (isHovered ? Color.primary.opacity(0.08) : Color.clear)
+                    )
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .help("keep_awake.toggle_tooltip".localized)
+        .onHover { hovering in
+            withAnimation(.easeInOut(duration: 0.15)) {
+                isHovered = hovering
+            }
+        }
+        .animation(
+            isActive && !reduceMotion
+                ? .easeInOut(duration: 2.0).repeatForever(autoreverses: true)
+                : .easeOut(duration: 0.3),
+            value: glowPulse
+        )
+        .onAppear {
+            if isActive { glowPulse = true }
+        }
+        .onChange(of: isActive) { _, active in
+            if active {
+                rippleID += 1
+                glowPulse = true
+            } else {
+                glowPulse = false
+            }
+        }
+    }
+}
+
+/// One-shot expanding ring played on activation; re-created via `.id` so each
+/// activation replays it from the start.
+private struct KeepAwakeActivationRipple: View {
+    @State private var expanded = false
+
+    var body: some View {
+        Circle()
+            .stroke(Color.orange.opacity(expanded ? 0 : 0.6), lineWidth: 1.5)
+            .frame(width: 18, height: 18)
+            .scaleEffect(expanded ? 1.9 : 0.7)
+            .allowsHitTesting(false)
+            .onAppear {
+                withAnimation(.easeOut(duration: 0.6)) {
+                    expanded = true
+                }
+            }
     }
 }
 

--- a/Claude Usage/MenuBar/PopoverContentView.swift
+++ b/Claude Usage/MenuBar/PopoverContentView.swift
@@ -562,33 +562,22 @@ struct HeaderIconButton: View {
 /// Header toggle for KeepAwakeService. Lights up (with a one-shot ripple and
 /// a soft breathing glow) whenever the assertion is held — including holds
 /// from auto mode — so it doubles as an "is my Mac staying awake?" indicator.
+/// Hovering shows a live status card; right-click offers durations and auto mode.
 struct KeepAwakeHeaderButton: View {
     @ObservedObject private var service = KeepAwakeService.shared
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var isHovered = false
     @State private var rippleID = 0
     @State private var glowPulse = false
+    @State private var showHoverCard = false
+    @State private var hoverCardTask: DispatchWorkItem?
+
+    private static let menuDurations: [TimeInterval] = [15 * 60, 3600, 2 * 3600, 8 * 3600]
 
     private var isActive: Bool { service.isAssertionHeld }
 
-    /// State-aware tooltip so hovering explains exactly what the cup is doing.
-    private var tooltip: String {
-        if service.isManualOn {
-            if let expiry = service.manualExpiry {
-                let formatter = DateFormatter()
-                formatter.timeStyle = .short
-                return "keep_awake.tooltip_until".localized(with: formatter.string(from: expiry))
-            }
-            return "keep_awake.tooltip_on".localized
-        }
-        if service.isAutoHolding {
-            return "keep_awake.tooltip_auto".localized
-        }
-        return "keep_awake.tooltip_off".localized
-    }
-
     var body: some View {
-        Button(action: { service.toggleManual() }) {
+        Button(action: { service.smartToggle() }) {
             ZStack {
                 if !reduceMotion, rippleID > 0, isActive {
                     KeepAwakeActivationRipple()
@@ -624,10 +613,39 @@ struct KeepAwakeHeaderButton: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .help(tooltip)
+        .contextMenu {
+            if isActive {
+                Button("keep_awake.menu_off".localized) { service.smartToggle() }
+            } else {
+                Button("keep_awake.menu_indefinite".localized) {
+                    service.setManual(on: true, duration: 0)
+                }
+                ForEach(Self.menuDurations, id: \.self) { duration in
+                    Button("keep_awake.menu_for".localized(with: KeepAwakeTimeFormat.interval(duration))) {
+                        service.setManual(on: true, duration: duration)
+                    }
+                }
+            }
+            Divider()
+            Toggle("keep_awake.auto".localized, isOn: Binding(
+                get: { SharedDataStore.shared.loadKeepAwakeAutoEnabled() },
+                set: { service.setAutoEnabled($0) }
+            ))
+        }
+        .popover(isPresented: $showHoverCard, arrowEdge: .bottom) {
+            KeepAwakeHoverCard(service: service)
+        }
         .onHover { hovering in
             withAnimation(.easeInOut(duration: 0.15)) {
                 isHovered = hovering
+            }
+            hoverCardTask?.cancel()
+            if hovering {
+                let task = DispatchWorkItem { showHoverCard = true }
+                hoverCardTask = task
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.4, execute: task)
+            } else {
+                showHoverCard = false
             }
         }
         .animation(
@@ -647,6 +665,79 @@ struct KeepAwakeHeaderButton: View {
                 glowPulse = false
             }
         }
+    }
+}
+
+/// Live status card shown while hovering the keep-awake button: current mode
+/// (off / on / auto), time remaining or ∞, and what a click will do.
+private struct KeepAwakeHoverCard: View {
+    @ObservedObject var service: KeepAwakeService
+
+    var body: some View {
+        TimelineView(.periodic(from: .now, by: 1)) { context in
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 5) {
+                    Image(systemName: service.isAssertionHeld ? "cup.and.saucer.fill" : "cup.and.saucer")
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundColor(service.isAssertionHeld ? .orange : .secondary)
+                    Text("section.keep_awake_title".localized)
+                        .font(.system(size: 11, weight: .semibold))
+                }
+
+                Text(statusText(at: context.date))
+                    .font(.system(size: 11))
+                    .foregroundColor(.primary)
+
+                Text(hintText)
+                    .font(.system(size: 10))
+                    .foregroundColor(.secondary)
+            }
+            .padding(10)
+            .frame(width: 230, alignment: .leading)
+        }
+    }
+
+    private func statusText(at reference: Date) -> String {
+        if service.isManualOn {
+            guard let expiry = service.manualExpiry else {
+                return "keep_awake.state_on_indefinite".localized
+            }
+            return "keep_awake.state_on_remaining".localized(
+                with: KeepAwakeTimeFormat.remaining(until: expiry, from: reference))
+        }
+        if service.isAutoHolding {
+            guard let graceEnd = service.autoGraceExpiry else {
+                return "keep_awake.state_auto_active".localized
+            }
+            return "keep_awake.state_auto_grace".localized(
+                with: KeepAwakeTimeFormat.remaining(until: graceEnd, from: reference))
+        }
+        return "keep_awake.state_off".localized
+    }
+
+    private var hintText: String {
+        guard service.isAssertionHeld else { return "keep_awake.hint_click_on".localized }
+        return service.isAutoHolding && !service.isManualOn
+            ? "keep_awake.hint_click_pause_auto".localized
+            : "keep_awake.hint_click_off".localized
+    }
+}
+
+/// Shared duration formatting for the keep-awake button, menu, and hover card.
+enum KeepAwakeTimeFormat {
+    static func interval(_ interval: TimeInterval) -> String {
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = interval < 3600 ? [.minute] : [.hour]
+        formatter.unitsStyle = .abbreviated
+        return formatter.string(from: interval) ?? ""
+    }
+
+    static func remaining(until deadline: Date, from reference: Date) -> String {
+        let remaining = max(0, deadline.timeIntervalSince(reference))
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = remaining < 3600 ? [.minute, .second] : [.hour, .minute]
+        formatter.unitsStyle = .abbreviated
+        return formatter.string(from: remaining) ?? ""
     }
 }
 

--- a/Claude Usage/MenuBar/PopoverContentView.swift
+++ b/Claude Usage/MenuBar/PopoverContentView.swift
@@ -717,6 +717,14 @@ private struct KeepAwakeHoverCard: View {
                     .font(.system(size: 11))
                     .foregroundColor(.primary)
 
+                // Auto mode is armed but not currently the reason we're lit:
+                // say so, so its behavior is never a surprise.
+                if service.autoEnabled, !service.isAutoHolding {
+                    Text("keep_awake.state_auto_armed".localized)
+                        .font(.system(size: 10))
+                        .foregroundColor(.secondary)
+                }
+
                 Text(hintText)
                     .font(.system(size: 10))
                     .foregroundColor(.secondary)

--- a/Claude Usage/MenuBar/PopoverContentView.swift
+++ b/Claude Usage/MenuBar/PopoverContentView.swift
@@ -591,33 +591,22 @@ struct HeaderIconButton: View {
 /// Header toggle for KeepAwakeService. Lights up (with a one-shot ripple and
 /// a soft breathing glow) whenever the assertion is held — including holds
 /// from auto mode — so it doubles as an "is my Mac staying awake?" indicator.
+/// Hovering shows a live status card; right-click offers durations and auto mode.
 struct KeepAwakeHeaderButton: View {
     @ObservedObject private var service = KeepAwakeService.shared
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var isHovered = false
     @State private var rippleID = 0
     @State private var glowPulse = false
+    @State private var showHoverCard = false
+    @State private var hoverCardTask: DispatchWorkItem?
+
+    private static let menuDurations: [TimeInterval] = [15 * 60, 3600, 2 * 3600, 8 * 3600]
 
     private var isActive: Bool { service.isAssertionHeld }
 
-    /// State-aware tooltip so hovering explains exactly what the cup is doing.
-    private var tooltip: String {
-        if service.isManualOn {
-            if let expiry = service.manualExpiry {
-                let formatter = DateFormatter()
-                formatter.timeStyle = .short
-                return "keep_awake.tooltip_until".localized(with: formatter.string(from: expiry))
-            }
-            return "keep_awake.tooltip_on".localized
-        }
-        if service.isAutoHolding {
-            return "keep_awake.tooltip_auto".localized
-        }
-        return "keep_awake.tooltip_off".localized
-    }
-
     var body: some View {
-        Button(action: { service.toggleManual() }) {
+        Button(action: { service.smartToggle() }) {
             ZStack {
                 if !reduceMotion, rippleID > 0, isActive {
                     KeepAwakeActivationRipple()
@@ -653,10 +642,39 @@ struct KeepAwakeHeaderButton: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .help(tooltip)
+        .contextMenu {
+            if isActive {
+                Button("keep_awake.menu_off".localized) { service.smartToggle() }
+            } else {
+                Button("keep_awake.menu_indefinite".localized) {
+                    service.setManual(on: true, duration: 0)
+                }
+                ForEach(Self.menuDurations, id: \.self) { duration in
+                    Button("keep_awake.menu_for".localized(with: KeepAwakeTimeFormat.interval(duration))) {
+                        service.setManual(on: true, duration: duration)
+                    }
+                }
+            }
+            Divider()
+            Toggle("keep_awake.auto".localized, isOn: Binding(
+                get: { SharedDataStore.shared.loadKeepAwakeAutoEnabled() },
+                set: { service.setAutoEnabled($0) }
+            ))
+        }
+        .popover(isPresented: $showHoverCard, arrowEdge: .bottom) {
+            KeepAwakeHoverCard(service: service)
+        }
         .onHover { hovering in
             withAnimation(.easeInOut(duration: 0.15)) {
                 isHovered = hovering
+            }
+            hoverCardTask?.cancel()
+            if hovering {
+                let task = DispatchWorkItem { showHoverCard = true }
+                hoverCardTask = task
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.4, execute: task)
+            } else {
+                showHoverCard = false
             }
         }
         .animation(
@@ -676,6 +694,79 @@ struct KeepAwakeHeaderButton: View {
                 glowPulse = false
             }
         }
+    }
+}
+
+/// Live status card shown while hovering the keep-awake button: current mode
+/// (off / on / auto), time remaining or ∞, and what a click will do.
+private struct KeepAwakeHoverCard: View {
+    @ObservedObject var service: KeepAwakeService
+
+    var body: some View {
+        TimelineView(.periodic(from: .now, by: 1)) { context in
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 5) {
+                    Image(systemName: service.isAssertionHeld ? "cup.and.saucer.fill" : "cup.and.saucer")
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundColor(service.isAssertionHeld ? .orange : .secondary)
+                    Text("section.keep_awake_title".localized)
+                        .font(.system(size: 11, weight: .semibold))
+                }
+
+                Text(statusText(at: context.date))
+                    .font(.system(size: 11))
+                    .foregroundColor(.primary)
+
+                Text(hintText)
+                    .font(.system(size: 10))
+                    .foregroundColor(.secondary)
+            }
+            .padding(10)
+            .frame(width: 230, alignment: .leading)
+        }
+    }
+
+    private func statusText(at reference: Date) -> String {
+        if service.isManualOn {
+            guard let expiry = service.manualExpiry else {
+                return "keep_awake.state_on_indefinite".localized
+            }
+            return "keep_awake.state_on_remaining".localized(
+                with: KeepAwakeTimeFormat.remaining(until: expiry, from: reference))
+        }
+        if service.isAutoHolding {
+            guard let graceEnd = service.autoGraceExpiry else {
+                return "keep_awake.state_auto_active".localized
+            }
+            return "keep_awake.state_auto_grace".localized(
+                with: KeepAwakeTimeFormat.remaining(until: graceEnd, from: reference))
+        }
+        return "keep_awake.state_off".localized
+    }
+
+    private var hintText: String {
+        guard service.isAssertionHeld else { return "keep_awake.hint_click_on".localized }
+        return service.isAutoHolding && !service.isManualOn
+            ? "keep_awake.hint_click_pause_auto".localized
+            : "keep_awake.hint_click_off".localized
+    }
+}
+
+/// Shared duration formatting for the keep-awake button, menu, and hover card.
+enum KeepAwakeTimeFormat {
+    static func interval(_ interval: TimeInterval) -> String {
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = interval < 3600 ? [.minute] : [.hour]
+        formatter.unitsStyle = .abbreviated
+        return formatter.string(from: interval) ?? ""
+    }
+
+    static func remaining(until deadline: Date, from reference: Date) -> String {
+        let remaining = max(0, deadline.timeIntervalSince(reference))
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = remaining < 3600 ? [.minute, .second] : [.hour, .minute]
+        formatter.unitsStyle = .abbreviated
+        return formatter.string(from: remaining) ?? ""
     }
 }
 

--- a/Claude Usage/MenuBar/PopoverContentView.swift
+++ b/Claude Usage/MenuBar/PopoverContentView.swift
@@ -523,6 +523,9 @@ struct SmartHeader: View {
             Spacer()
 
             HStack(alignment: .center, spacing: 2) {
+                // Keep awake
+                KeepAwakeHeaderButton()
+
                 // Refresh
                 HeaderIconButton(
                     icon: "arrow.clockwise",
@@ -580,6 +583,96 @@ struct HeaderIconButton: View {
                 isHovered = hovering
             }
         }
+    }
+}
+
+// MARK: - Keep Awake Header Button
+
+/// Header toggle for KeepAwakeService. Lights up (with a one-shot ripple and
+/// a soft breathing glow) whenever the assertion is held — including holds
+/// from auto mode — so it doubles as an "is my Mac staying awake?" indicator.
+struct KeepAwakeHeaderButton: View {
+    @ObservedObject private var service = KeepAwakeService.shared
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var isHovered = false
+    @State private var rippleID = 0
+    @State private var glowPulse = false
+
+    private var isActive: Bool { service.isAssertionHeld }
+
+    var body: some View {
+        Button(action: { service.toggleManual() }) {
+            ZStack {
+                if !reduceMotion, rippleID > 0, isActive {
+                    KeepAwakeActivationRipple()
+                        .id(rippleID)
+                }
+
+                Image(systemName: isActive ? "cup.and.saucer.fill" : "cup.and.saucer")
+                    .font(.system(size: 10.5, weight: .medium))
+                    .imageScale(.medium)
+                    .contentTransition(.symbolEffect(.replace))
+                    .symbolEffect(.bounce, options: .speed(1.3), value: isActive)
+                    .shadow(
+                        color: isActive ? Color.orange.opacity(glowPulse ? 0.55 : 0.25) : .clear,
+                        radius: glowPulse ? 5 : 3
+                    )
+            }
+            .foregroundColor(isActive ? .orange : (isHovered ? .primary : .secondary))
+            .frame(width: 24, height: 24, alignment: .center)
+            .background(
+                RoundedRectangle(cornerRadius: 5)
+                    .fill(
+                        isActive
+                            ? Color.orange.opacity(isHovered ? 0.16 : 0.10)
+                            : (isHovered ? Color.primary.opacity(0.08) : Color.clear)
+                    )
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .help("keep_awake.toggle_tooltip".localized)
+        .onHover { hovering in
+            withAnimation(.easeInOut(duration: 0.15)) {
+                isHovered = hovering
+            }
+        }
+        .animation(
+            isActive && !reduceMotion
+                ? .easeInOut(duration: 2.0).repeatForever(autoreverses: true)
+                : .easeOut(duration: 0.3),
+            value: glowPulse
+        )
+        .onAppear {
+            if isActive { glowPulse = true }
+        }
+        .onChange(of: isActive) { _, active in
+            if active {
+                rippleID += 1
+                glowPulse = true
+            } else {
+                glowPulse = false
+            }
+        }
+    }
+}
+
+/// One-shot expanding ring played on activation; re-created via `.id` so each
+/// activation replays it from the start.
+private struct KeepAwakeActivationRipple: View {
+    @State private var expanded = false
+
+    var body: some View {
+        Circle()
+            .stroke(Color.orange.opacity(expanded ? 0 : 0.6), lineWidth: 1.5)
+            .frame(width: 18, height: 18)
+            .scaleEffect(expanded ? 1.9 : 0.7)
+            .allowsHitTesting(false)
+            .onAppear {
+                withAnimation(.easeOut(duration: 0.6)) {
+                    expanded = true
+                }
+            }
     }
 }
 

--- a/Claude Usage/MenuBar/PopoverContentView.swift
+++ b/Claude Usage/MenuBar/PopoverContentView.swift
@@ -604,11 +604,20 @@ struct KeepAwakeHeaderButton: View {
     private static let menuDurations: [TimeInterval] = [15 * 60, 3600, 2 * 3600, 8 * 3600]
 
     private var isActive: Bool { service.isAssertionHeld }
+    /// Auto mode is on but not currently holding: dimmed-orange filled cup so
+    /// the first click (and every armed idle state) has visible feedback.
+    private var isArmed: Bool { service.autoEnabled && !isActive }
+
+    private var iconColor: Color {
+        if isActive { return .orange }
+        if isArmed { return Color.orange.opacity(0.55) }
+        return isHovered ? .primary : .secondary
+    }
 
     var body: some View {
         Button(action: { service.smartToggle() }) {
             ZStack {
-                if !reduceMotion, rippleID > 0, isActive {
+                if !reduceMotion, rippleID > 0, isActive || isArmed {
                     KeepAwakeActivationRipple()
                         .id(rippleID)
                     KeepAwakeActivationRipple(delay: 0.18)
@@ -619,24 +628,27 @@ struct KeepAwakeHeaderButton: View {
                     KeepAwakeSteamView()
                 }
 
-                Image(systemName: isActive ? "cup.and.saucer.fill" : "cup.and.saucer")
+                Image(systemName: isActive || isArmed ? "cup.and.saucer.fill" : "cup.and.saucer")
                     .font(.system(size: 10.5, weight: .medium))
                     .imageScale(.medium)
                     .contentTransition(.symbolEffect(.replace))
                     .symbolEffect(.bounce, options: .speed(1.3), value: isActive)
+                    .symbolEffect(.bounce, options: .speed(1.3), value: service.autoEnabled)
                     .shadow(
                         color: isActive ? Color.orange.opacity(glowPulse ? 0.55 : 0.25) : .clear,
                         radius: glowPulse ? 5 : 3
                     )
             }
-            .foregroundColor(isActive ? .orange : (isHovered ? .primary : .secondary))
+            .foregroundColor(iconColor)
             .frame(width: 24, height: 24, alignment: .center)
             .background(
                 RoundedRectangle(cornerRadius: 5)
                     .fill(
                         isActive
                             ? Color.orange.opacity(isHovered ? 0.16 : 0.10)
-                            : (isHovered ? Color.primary.opacity(0.08) : Color.clear)
+                            : (isArmed
+                                ? Color.orange.opacity(isHovered ? 0.12 : 0.06)
+                                : (isHovered ? Color.primary.opacity(0.08) : Color.clear))
                     )
             )
             .contentShape(Rectangle())
@@ -692,6 +704,13 @@ struct KeepAwakeHeaderButton: View {
                 glowPulse = true
             } else {
                 glowPulse = false
+            }
+        }
+        .onChange(of: service.autoEnabled) { _, enabled in
+            // Arming auto (usually the first-ever click) plays the ripple even
+            // though no assertion is held yet — the click must feel received.
+            if enabled, !isActive {
+                rippleID += 1
             }
         }
     }

--- a/Claude Usage/MenuBar/PopoverContentView.swift
+++ b/Claude Usage/MenuBar/PopoverContentView.swift
@@ -600,12 +600,34 @@ struct KeepAwakeHeaderButton: View {
 
     private var isActive: Bool { service.isAssertionHeld }
 
+    /// State-aware tooltip so hovering explains exactly what the cup is doing.
+    private var tooltip: String {
+        if service.isManualOn {
+            if let expiry = service.manualExpiry {
+                let formatter = DateFormatter()
+                formatter.timeStyle = .short
+                return "keep_awake.tooltip_until".localized(with: formatter.string(from: expiry))
+            }
+            return "keep_awake.tooltip_on".localized
+        }
+        if service.isAutoHolding {
+            return "keep_awake.tooltip_auto".localized
+        }
+        return "keep_awake.tooltip_off".localized
+    }
+
     var body: some View {
         Button(action: { service.toggleManual() }) {
             ZStack {
                 if !reduceMotion, rippleID > 0, isActive {
                     KeepAwakeActivationRipple()
                         .id(rippleID)
+                    KeepAwakeActivationRipple(delay: 0.18)
+                        .id(-rippleID)
+                }
+
+                if isActive, !reduceMotion {
+                    KeepAwakeSteamView()
                 }
 
                 Image(systemName: isActive ? "cup.and.saucer.fill" : "cup.and.saucer")
@@ -631,7 +653,7 @@ struct KeepAwakeHeaderButton: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .help("keep_awake.toggle_tooltip".localized)
+        .help(tooltip)
         .onHover { hovering in
             withAnimation(.easeInOut(duration: 0.15)) {
                 isHovered = hovering
@@ -658,8 +680,10 @@ struct KeepAwakeHeaderButton: View {
 }
 
 /// One-shot expanding ring played on activation; re-created via `.id` so each
-/// activation replays it from the start.
+/// activation replays it from the start. Two staggered rings give the "drop
+/// in water" feel.
 private struct KeepAwakeActivationRipple: View {
+    var delay: Double = 0
     @State private var expanded = false
 
     var body: some View {
@@ -669,10 +693,38 @@ private struct KeepAwakeActivationRipple: View {
             .scaleEffect(expanded ? 1.9 : 0.7)
             .allowsHitTesting(false)
             .onAppear {
-                withAnimation(.easeOut(duration: 0.6)) {
+                withAnimation(.easeOut(duration: 0.6).delay(delay)) {
                     expanded = true
                 }
             }
+    }
+}
+
+/// Three tiny steam wisps drifting up from the cup while keep-awake is active.
+/// Each dot fades out as it rises, then loops; staggered delays keep the
+/// motion organic. Only shown when Reduce Motion is off.
+private struct KeepAwakeSteamView: View {
+    @State private var rising = false
+
+    var body: some View {
+        ZStack {
+            steamDot(x: -2.5, delay: 0.0)
+            steamDot(x: 0.5, delay: 0.55)
+            steamDot(x: 3.0, delay: 1.1)
+        }
+        .allowsHitTesting(false)
+        .onAppear { rising = true }
+    }
+
+    private func steamDot(x: CGFloat, delay: Double) -> some View {
+        Circle()
+            .fill(Color.orange.opacity(rising ? 0 : 0.5))
+            .frame(width: 2.5, height: 2.5)
+            .offset(x: x, y: rising ? -12 : -5)
+            .animation(
+                .easeOut(duration: 1.7).repeatForever(autoreverses: false).delay(delay),
+                value: rising
+            )
     }
 }
 

--- a/Claude Usage/MenuBar/PopoverContentView.swift
+++ b/Claude Usage/MenuBar/PopoverContentView.swift
@@ -717,9 +717,9 @@ private struct KeepAwakeHoverCard: View {
                     .font(.system(size: 11))
                     .foregroundColor(.primary)
 
-                // Auto mode is armed but not currently the reason we're lit:
+                // A manual hold is showing above, but auto is also armed:
                 // say so, so its behavior is never a surprise.
-                if service.autoEnabled, !service.isAutoHolding {
+                if service.autoEnabled, !service.isAutoHolding, service.isManualOn {
                     Text("keep_awake.state_auto_armed".localized)
                         .font(.system(size: 10))
                         .foregroundColor(.secondary)
@@ -749,14 +749,20 @@ private struct KeepAwakeHoverCard: View {
             return "keep_awake.state_auto_grace".localized(
                 with: KeepAwakeTimeFormat.remaining(until: graceEnd, from: reference))
         }
+        if service.autoEnabled {
+            // Armed but idle: auto will hold as soon as Claude Code works.
+            return "keep_awake.state_auto_armed".localized
+        }
         return "keep_awake.state_off".localized
     }
 
     private var hintText: String {
-        guard service.isAssertionHeld else { return "keep_awake.hint_click_on".localized }
-        return service.isAutoHolding && !service.isManualOn
-            ? "keep_awake.hint_click_pause_auto".localized
-            : "keep_awake.hint_click_off".localized
+        if service.isManualOn {
+            return "keep_awake.hint_click_off".localized
+        }
+        return service.autoEnabled
+            ? "keep_awake.hint_click_auto_off".localized
+            : "keep_awake.hint_click_on".localized
     }
 }
 

--- a/Claude Usage/MenuBar/PopoverContentView.swift
+++ b/Claude Usage/MenuBar/PopoverContentView.swift
@@ -592,12 +592,16 @@ struct HeaderIconButton: View {
 /// a soft breathing glow) whenever the assertion is held — including holds
 /// from auto mode — so it doubles as an "is my Mac staying awake?" indicator.
 /// Hovering shows a live status card; right-click offers durations and auto mode.
+///
+/// The looping glow and steam live in `KeepAwakeAmbientLayerView` (Core
+/// Animation), not SwiftUI: a `.repeatForever` animation here re-renders the
+/// whole popover every frame while it's open. Only one-shot effects stay in
+/// SwiftUI.
 struct KeepAwakeHeaderButton: View {
     @ObservedObject private var service = KeepAwakeService.shared
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var isHovered = false
     @State private var rippleID = 0
-    @State private var glowPulse = false
     @State private var showHoverCard = false
     @State private var hoverCardTask: DispatchWorkItem?
 
@@ -624,8 +628,10 @@ struct KeepAwakeHeaderButton: View {
                         .id(-rippleID)
                 }
 
-                if isActive, !reduceMotion {
-                    KeepAwakeSteamView()
+                if isActive {
+                    KeepAwakeAmbientLayerView(animates: !reduceMotion)
+                        .frame(width: 24, height: 24)
+                        .allowsHitTesting(false)
                 }
 
                 Image(systemName: isActive || isArmed ? "cup.and.saucer.fill" : "cup.and.saucer")
@@ -634,10 +640,7 @@ struct KeepAwakeHeaderButton: View {
                     .contentTransition(.symbolEffect(.replace))
                     .symbolEffect(.bounce, options: .speed(1.3), value: isActive)
                     .symbolEffect(.bounce, options: .speed(1.3), value: service.autoEnabled)
-                    .shadow(
-                        color: isActive ? Color.orange.opacity(glowPulse ? 0.55 : 0.25) : .clear,
-                        radius: glowPulse ? 5 : 3
-                    )
+                    .shadow(color: isActive ? Color.orange.opacity(0.3) : .clear, radius: 3)
             }
             .foregroundColor(iconColor)
             .frame(width: 24, height: 24, alignment: .center)
@@ -689,22 +692,8 @@ struct KeepAwakeHeaderButton: View {
                 showHoverCard = false
             }
         }
-        .animation(
-            isActive && !reduceMotion
-                ? .easeInOut(duration: 2.0).repeatForever(autoreverses: true)
-                : .easeOut(duration: 0.3),
-            value: glowPulse
-        )
-        .onAppear {
-            if isActive { glowPulse = true }
-        }
         .onChange(of: isActive) { _, active in
-            if active {
-                rippleID += 1
-                glowPulse = true
-            } else {
-                glowPulse = false
-            }
+            if active { rippleID += 1 }
         }
         .onChange(of: service.autoEnabled) { _, enabled in
             // Arming auto (usually the first-ever click) plays the ripple even
@@ -821,34 +810,6 @@ private struct KeepAwakeActivationRipple: View {
                     expanded = true
                 }
             }
-    }
-}
-
-/// Three tiny steam wisps drifting up from the cup while keep-awake is active.
-/// Each dot fades out as it rises, then loops; staggered delays keep the
-/// motion organic. Only shown when Reduce Motion is off.
-private struct KeepAwakeSteamView: View {
-    @State private var rising = false
-
-    var body: some View {
-        ZStack {
-            steamDot(x: -2.5, delay: 0.0)
-            steamDot(x: 0.5, delay: 0.55)
-            steamDot(x: 3.0, delay: 1.1)
-        }
-        .allowsHitTesting(false)
-        .onAppear { rising = true }
-    }
-
-    private func steamDot(x: CGFloat, delay: Double) -> some View {
-        Circle()
-            .fill(Color.orange.opacity(rising ? 0 : 0.5))
-            .frame(width: 2.5, height: 2.5)
-            .offset(x: x, y: rising ? -12 : -5)
-            .animation(
-                .easeOut(duration: 1.7).repeatForever(autoreverses: false).delay(delay),
-                value: rising
-            )
     }
 }
 

--- a/Claude Usage/Resources/de.lproj/Localizable.strings
+++ b/Claude Usage/Resources/de.lproj/Localizable.strings
@@ -1027,6 +1027,33 @@
 "menubar.this_month" = "Diesen Monat";
 "menubar.total" = "Gesamt";
 
+/* Keep Awake */
+"section.keep_awake_title" = "Wachhalten";
+"section.keep_awake_desc" = "Verhindert, dass der Mac in den Ruhezustand wechselt";
+"keep_awake.manual_title" = "Manuelle Steuerung";
+"keep_awake.manual_desc" = "Hält den Mac auf Wunsch wach, optional mit Timer";
+"keep_awake.enable" = "Mac wachhalten";
+"keep_awake.enable_desc" = "Verhindert vorübergehend, dass der Mac in den Ruhezustand wechselt";
+"keep_awake.status_active" = "Der Mac wird derzeit wachgehalten";
+"keep_awake.remaining" = "Wird in %@ deaktiviert";
+"keep_awake.duration" = "Dauer";
+"keep_awake.duration.indefinite" = "Bis zum Ausschalten";
+"keep_awake.duration.custom" = "Eigene…";
+"keep_awake.custom_hours" = "%d Stunden";
+"keep_awake.auto_title" = "Automatisch";
+"keep_awake.auto_card_desc" = "Claude-Code-Aktivität steuert das Wachhalten";
+"keep_awake.auto" = "Wachhalten, während Claude Code arbeitet";
+"keep_awake.auto_desc" = "Hält den Mac automatisch wach, solange eine Claude-Code-Sitzung aktiv ist. Installiert Claude-Code-Hooks";
+"keep_awake.grace" = "Ruhezustand erlauben nach Inaktivität";
+"keep_awake.grace.immediately" = "Sofort";
+"keep_awake.hooks_note" = "Aktivität wird über Claude-Code-Hooks in ~/.claude/settings.json erkannt";
+"keep_awake.sleep_type" = "Ruhezustand-Verhinderung";
+"keep_awake.sleep_type_desc" = "Legt fest, ob der Bildschirm eingeschaltet bleibt, während der Mac wachgehalten wird";
+"keep_awake.sleep_type.system" = "Bildschirm darf ausgehen";
+"keep_awake.sleep_type.display" = "Bildschirm anlassen";
+"keep_awake.lid_note" = "Verhindert nicht den Ruhezustand bei geschlossenem Deckel";
+"keep_awake.toggle_tooltip" = "Mac wachhalten";
+
 /* Sponsor slot */
 "sponsor.slot_title" = "Dieser Platz ist für Sponsoren verfügbar";
 "sponsor.slot_cta" = "Kontakt aufnehmen";

--- a/Claude Usage/Resources/de.lproj/Localizable.strings
+++ b/Claude Usage/Resources/de.lproj/Localizable.strings
@@ -1031,7 +1031,7 @@
 "section.keep_awake_title" = "Wachhalten";
 "section.keep_awake_desc" = "Verhindert, dass der Mac in den Ruhezustand wechselt";
 "keep_awake.manual_title" = "Manuelle Steuerung";
-"keep_awake.manual_desc" = "Hält den Mac auf Wunsch wach, optional mit Timer";
+"keep_awake.manual_desc" = "Schalte das Wachhalten selbst ein, optional mit Timer";
 "keep_awake.enable" = "Mac wachhalten";
 "keep_awake.enable_desc" = "Verhindert vorübergehend, dass der Mac in den Ruhezustand wechselt";
 "keep_awake.status_active" = "Der Mac wird derzeit wachgehalten";
@@ -1041,18 +1041,21 @@
 "keep_awake.duration.custom" = "Eigene…";
 "keep_awake.custom_hours" = "%d Stunden";
 "keep_awake.auto_title" = "Automatisch";
-"keep_awake.auto_card_desc" = "Claude-Code-Aktivität steuert das Wachhalten";
+"keep_awake.auto_card_desc" = "Empfohlen: hält den Mac nur wach, während Claude Code tatsächlich arbeitet";
 "keep_awake.auto" = "Wachhalten, während Claude Code arbeitet";
-"keep_awake.auto_desc" = "Hält den Mac automatisch wach, solange eine Claude-Code-Sitzung aktiv ist. Installiert Claude-Code-Hooks";
-"keep_awake.grace" = "Ruhezustand erlauben nach Inaktivität";
-"keep_awake.grace.immediately" = "Sofort";
+"keep_awake.auto_desc" = "Bleibt während aktiver Claude-Code-Sitzungen wach und erlaubt danach wieder den Ruhezustand. Installiert Claude-Code-Hooks";
+"keep_awake.grace" = "Nach Claudes Arbeit wach bleiben für";
+"keep_awake.grace.immediately" = "Keine zusätzliche Zeit";
 "keep_awake.hooks_note" = "Aktivität wird über Claude-Code-Hooks in ~/.claude/settings.json erkannt";
 "keep_awake.sleep_type" = "Ruhezustand-Verhinderung";
 "keep_awake.sleep_type_desc" = "Legt fest, ob der Bildschirm eingeschaltet bleibt, während der Mac wachgehalten wird";
 "keep_awake.sleep_type.system" = "Bildschirm darf ausgehen";
 "keep_awake.sleep_type.display" = "Bildschirm anlassen";
-"keep_awake.lid_note" = "Verhindert nicht den Ruhezustand bei geschlossenem Deckel";
-"keep_awake.toggle_tooltip" = "Mac wachhalten";
+"keep_awake.lid_note" = "Bei geschlossenem Deckel wechselt der Mac trotzdem in den Ruhezustand, außer er ist am Strom und nutzt ein externes Display";
+"keep_awake.tooltip_off" = "Mac wachhalten — zum Einschalten klicken";
+"keep_awake.tooltip_on" = "Der Mac wird wachgehalten — zum Ausschalten klicken";
+"keep_awake.tooltip_until" = "Der Mac wird bis %@ wachgehalten — zum Ausschalten klicken";
+"keep_awake.tooltip_auto" = "Der Mac wird wachgehalten — Claude Code arbeitet";
 
 /* Sponsor slot */
 "sponsor.slot_title" = "Dieser Platz ist für Sponsoren verfügbar";

--- a/Claude Usage/Resources/de.lproj/Localizable.strings
+++ b/Claude Usage/Resources/de.lproj/Localizable.strings
@@ -1059,9 +1059,9 @@
 "keep_awake.state_auto_active" = "Auto — Claude Code arbeitet";
 "keep_awake.state_auto_grace" = "Auto — Claude ist fertig, bleibt noch %@ wach";
 "keep_awake.state_auto_armed" = "Auto ist aktiv — hält den Mac wach, während Claude Code arbeitet";
-"keep_awake.hint_click_on" = "Klicken, um den Mac wachzuhalten";
+"keep_awake.hint_click_on" = "Klicken zum Einschalten — hält den Mac wach, während Claude Code arbeitet";
 "keep_awake.hint_click_off" = "Klicken zum Ausschalten";
-"keep_awake.hint_click_pause_auto" = "Klicken zum Stoppen — startet wieder, wenn Claude arbeitet";
+"keep_awake.hint_click_auto_off" = "Klicken, um den Automatikmodus auszuschalten — bleibt aus, bis du ihn wieder einschaltest";
 "keep_awake.menu_for" = "Wachhalten für %@";
 "keep_awake.menu_indefinite" = "Wachhalten bis zum Ausschalten";
 "keep_awake.menu_off" = "Wachhalten ausschalten";

--- a/Claude Usage/Resources/de.lproj/Localizable.strings
+++ b/Claude Usage/Resources/de.lproj/Localizable.strings
@@ -1044,18 +1044,26 @@
 "keep_awake.auto_card_desc" = "Empfohlen: hält den Mac nur wach, während Claude Code tatsächlich arbeitet";
 "keep_awake.auto" = "Wachhalten, während Claude Code arbeitet";
 "keep_awake.auto_desc" = "Bleibt während aktiver Claude-Code-Sitzungen wach und erlaubt danach wieder den Ruhezustand. Installiert Claude-Code-Hooks";
-"keep_awake.grace" = "Nach Claudes Arbeit wach bleiben für";
-"keep_awake.grace.immediately" = "Keine zusätzliche Zeit";
+"keep_awake.grace" = "Wenn Claude Code fertig ist";
+"keep_awake.grace.immediately" = "Sofort schlafen";
+"keep_awake.grace.stay" = "%@ wach bleiben";
 "keep_awake.hooks_note" = "Aktivität wird über Claude-Code-Hooks in ~/.claude/settings.json erkannt";
 "keep_awake.sleep_type" = "Ruhezustand-Verhinderung";
 "keep_awake.sleep_type_desc" = "Legt fest, ob der Bildschirm eingeschaltet bleibt, während der Mac wachgehalten wird";
 "keep_awake.sleep_type.system" = "Bildschirm darf ausgehen";
 "keep_awake.sleep_type.display" = "Bildschirm anlassen";
 "keep_awake.lid_note" = "Bei geschlossenem Deckel wechselt der Mac trotzdem in den Ruhezustand, außer er ist am Strom und nutzt ein externes Display";
-"keep_awake.tooltip_off" = "Mac wachhalten — zum Einschalten klicken";
-"keep_awake.tooltip_on" = "Der Mac wird wachgehalten — zum Ausschalten klicken";
-"keep_awake.tooltip_until" = "Der Mac wird bis %@ wachgehalten — zum Ausschalten klicken";
-"keep_awake.tooltip_auto" = "Der Mac wird wachgehalten — Claude Code arbeitet";
+"keep_awake.state_off" = "Aus";
+"keep_awake.state_on_indefinite" = "Ein — bleibt wach, bis du es ausschaltest (∞)";
+"keep_awake.state_on_remaining" = "Ein — noch %@";
+"keep_awake.state_auto_active" = "Auto — Claude Code arbeitet";
+"keep_awake.state_auto_grace" = "Auto — Claude ist fertig, bleibt noch %@ wach";
+"keep_awake.hint_click_on" = "Klicken, um den Mac wachzuhalten";
+"keep_awake.hint_click_off" = "Klicken zum Ausschalten";
+"keep_awake.hint_click_pause_auto" = "Klicken zum Stoppen — startet wieder, wenn Claude arbeitet";
+"keep_awake.menu_for" = "Wachhalten für %@";
+"keep_awake.menu_indefinite" = "Wachhalten bis zum Ausschalten";
+"keep_awake.menu_off" = "Wachhalten ausschalten";
 
 /* Sponsor slot */
 "sponsor.slot_title" = "Dieser Platz ist für Sponsoren verfügbar";

--- a/Claude Usage/Resources/de.lproj/Localizable.strings
+++ b/Claude Usage/Resources/de.lproj/Localizable.strings
@@ -1058,6 +1058,7 @@
 "keep_awake.state_on_remaining" = "Ein — noch %@";
 "keep_awake.state_auto_active" = "Auto — Claude Code arbeitet";
 "keep_awake.state_auto_grace" = "Auto — Claude ist fertig, bleibt noch %@ wach";
+"keep_awake.state_auto_armed" = "Auto ist aktiv — hält den Mac wach, während Claude Code arbeitet";
 "keep_awake.hint_click_on" = "Klicken, um den Mac wachzuhalten";
 "keep_awake.hint_click_off" = "Klicken zum Ausschalten";
 "keep_awake.hint_click_pause_auto" = "Klicken zum Stoppen — startet wieder, wenn Claude arbeitet";

--- a/Claude Usage/Resources/de.lproj/Localizable.strings
+++ b/Claude Usage/Resources/de.lproj/Localizable.strings
@@ -1052,6 +1052,7 @@
 "keep_awake.state_on_remaining" = "Ein — noch %@";
 "keep_awake.state_auto_active" = "Auto — Claude Code arbeitet";
 "keep_awake.state_auto_grace" = "Auto — Claude ist fertig, bleibt noch %@ wach";
+"keep_awake.state_auto_armed" = "Auto ist aktiv — hält den Mac wach, während Claude Code arbeitet";
 "keep_awake.hint_click_on" = "Klicken, um den Mac wachzuhalten";
 "keep_awake.hint_click_off" = "Klicken zum Ausschalten";
 "keep_awake.hint_click_pause_auto" = "Klicken zum Stoppen — startet wieder, wenn Claude arbeitet";

--- a/Claude Usage/Resources/de.lproj/Localizable.strings
+++ b/Claude Usage/Resources/de.lproj/Localizable.strings
@@ -1053,9 +1053,9 @@
 "keep_awake.state_auto_active" = "Auto — Claude Code arbeitet";
 "keep_awake.state_auto_grace" = "Auto — Claude ist fertig, bleibt noch %@ wach";
 "keep_awake.state_auto_armed" = "Auto ist aktiv — hält den Mac wach, während Claude Code arbeitet";
-"keep_awake.hint_click_on" = "Klicken, um den Mac wachzuhalten";
+"keep_awake.hint_click_on" = "Klicken zum Einschalten — hält den Mac wach, während Claude Code arbeitet";
 "keep_awake.hint_click_off" = "Klicken zum Ausschalten";
-"keep_awake.hint_click_pause_auto" = "Klicken zum Stoppen — startet wieder, wenn Claude arbeitet";
+"keep_awake.hint_click_auto_off" = "Klicken, um den Automatikmodus auszuschalten — bleibt aus, bis du ihn wieder einschaltest";
 "keep_awake.menu_for" = "Wachhalten für %@";
 "keep_awake.menu_indefinite" = "Wachhalten bis zum Ausschalten";
 "keep_awake.menu_off" = "Wachhalten ausschalten";

--- a/Claude Usage/Resources/de.lproj/Localizable.strings
+++ b/Claude Usage/Resources/de.lproj/Localizable.strings
@@ -1021,6 +1021,33 @@
 "menubar.this_month" = "Diesen Monat";
 "menubar.total" = "Gesamt";
 
+/* Keep Awake */
+"section.keep_awake_title" = "Wachhalten";
+"section.keep_awake_desc" = "Verhindert, dass der Mac in den Ruhezustand wechselt";
+"keep_awake.manual_title" = "Manuelle Steuerung";
+"keep_awake.manual_desc" = "Hält den Mac auf Wunsch wach, optional mit Timer";
+"keep_awake.enable" = "Mac wachhalten";
+"keep_awake.enable_desc" = "Verhindert vorübergehend, dass der Mac in den Ruhezustand wechselt";
+"keep_awake.status_active" = "Der Mac wird derzeit wachgehalten";
+"keep_awake.remaining" = "Wird in %@ deaktiviert";
+"keep_awake.duration" = "Dauer";
+"keep_awake.duration.indefinite" = "Bis zum Ausschalten";
+"keep_awake.duration.custom" = "Eigene…";
+"keep_awake.custom_hours" = "%d Stunden";
+"keep_awake.auto_title" = "Automatisch";
+"keep_awake.auto_card_desc" = "Claude-Code-Aktivität steuert das Wachhalten";
+"keep_awake.auto" = "Wachhalten, während Claude Code arbeitet";
+"keep_awake.auto_desc" = "Hält den Mac automatisch wach, solange eine Claude-Code-Sitzung aktiv ist. Installiert Claude-Code-Hooks";
+"keep_awake.grace" = "Ruhezustand erlauben nach Inaktivität";
+"keep_awake.grace.immediately" = "Sofort";
+"keep_awake.hooks_note" = "Aktivität wird über Claude-Code-Hooks in ~/.claude/settings.json erkannt";
+"keep_awake.sleep_type" = "Ruhezustand-Verhinderung";
+"keep_awake.sleep_type_desc" = "Legt fest, ob der Bildschirm eingeschaltet bleibt, während der Mac wachgehalten wird";
+"keep_awake.sleep_type.system" = "Bildschirm darf ausgehen";
+"keep_awake.sleep_type.display" = "Bildschirm anlassen";
+"keep_awake.lid_note" = "Verhindert nicht den Ruhezustand bei geschlossenem Deckel";
+"keep_awake.toggle_tooltip" = "Mac wachhalten";
+
 /* Sponsor slot */
 "sponsor.slot_title" = "Dieser Platz ist für Sponsoren verfügbar";
 "sponsor.slot_cta" = "Kontakt aufnehmen";

--- a/Claude Usage/Resources/de.lproj/Localizable.strings
+++ b/Claude Usage/Resources/de.lproj/Localizable.strings
@@ -1038,18 +1038,26 @@
 "keep_awake.auto_card_desc" = "Empfohlen: hält den Mac nur wach, während Claude Code tatsächlich arbeitet";
 "keep_awake.auto" = "Wachhalten, während Claude Code arbeitet";
 "keep_awake.auto_desc" = "Bleibt während aktiver Claude-Code-Sitzungen wach und erlaubt danach wieder den Ruhezustand. Installiert Claude-Code-Hooks";
-"keep_awake.grace" = "Nach Claudes Arbeit wach bleiben für";
-"keep_awake.grace.immediately" = "Keine zusätzliche Zeit";
+"keep_awake.grace" = "Wenn Claude Code fertig ist";
+"keep_awake.grace.immediately" = "Sofort schlafen";
+"keep_awake.grace.stay" = "%@ wach bleiben";
 "keep_awake.hooks_note" = "Aktivität wird über Claude-Code-Hooks in ~/.claude/settings.json erkannt";
 "keep_awake.sleep_type" = "Ruhezustand-Verhinderung";
 "keep_awake.sleep_type_desc" = "Legt fest, ob der Bildschirm eingeschaltet bleibt, während der Mac wachgehalten wird";
 "keep_awake.sleep_type.system" = "Bildschirm darf ausgehen";
 "keep_awake.sleep_type.display" = "Bildschirm anlassen";
 "keep_awake.lid_note" = "Bei geschlossenem Deckel wechselt der Mac trotzdem in den Ruhezustand, außer er ist am Strom und nutzt ein externes Display";
-"keep_awake.tooltip_off" = "Mac wachhalten — zum Einschalten klicken";
-"keep_awake.tooltip_on" = "Der Mac wird wachgehalten — zum Ausschalten klicken";
-"keep_awake.tooltip_until" = "Der Mac wird bis %@ wachgehalten — zum Ausschalten klicken";
-"keep_awake.tooltip_auto" = "Der Mac wird wachgehalten — Claude Code arbeitet";
+"keep_awake.state_off" = "Aus";
+"keep_awake.state_on_indefinite" = "Ein — bleibt wach, bis du es ausschaltest (∞)";
+"keep_awake.state_on_remaining" = "Ein — noch %@";
+"keep_awake.state_auto_active" = "Auto — Claude Code arbeitet";
+"keep_awake.state_auto_grace" = "Auto — Claude ist fertig, bleibt noch %@ wach";
+"keep_awake.hint_click_on" = "Klicken, um den Mac wachzuhalten";
+"keep_awake.hint_click_off" = "Klicken zum Ausschalten";
+"keep_awake.hint_click_pause_auto" = "Klicken zum Stoppen — startet wieder, wenn Claude arbeitet";
+"keep_awake.menu_for" = "Wachhalten für %@";
+"keep_awake.menu_indefinite" = "Wachhalten bis zum Ausschalten";
+"keep_awake.menu_off" = "Wachhalten ausschalten";
 
 /* Sponsor slot */
 "sponsor.slot_title" = "Dieser Platz ist für Sponsoren verfügbar";

--- a/Claude Usage/Resources/de.lproj/Localizable.strings
+++ b/Claude Usage/Resources/de.lproj/Localizable.strings
@@ -1025,7 +1025,7 @@
 "section.keep_awake_title" = "Wachhalten";
 "section.keep_awake_desc" = "Verhindert, dass der Mac in den Ruhezustand wechselt";
 "keep_awake.manual_title" = "Manuelle Steuerung";
-"keep_awake.manual_desc" = "Hält den Mac auf Wunsch wach, optional mit Timer";
+"keep_awake.manual_desc" = "Schalte das Wachhalten selbst ein, optional mit Timer";
 "keep_awake.enable" = "Mac wachhalten";
 "keep_awake.enable_desc" = "Verhindert vorübergehend, dass der Mac in den Ruhezustand wechselt";
 "keep_awake.status_active" = "Der Mac wird derzeit wachgehalten";
@@ -1035,18 +1035,21 @@
 "keep_awake.duration.custom" = "Eigene…";
 "keep_awake.custom_hours" = "%d Stunden";
 "keep_awake.auto_title" = "Automatisch";
-"keep_awake.auto_card_desc" = "Claude-Code-Aktivität steuert das Wachhalten";
+"keep_awake.auto_card_desc" = "Empfohlen: hält den Mac nur wach, während Claude Code tatsächlich arbeitet";
 "keep_awake.auto" = "Wachhalten, während Claude Code arbeitet";
-"keep_awake.auto_desc" = "Hält den Mac automatisch wach, solange eine Claude-Code-Sitzung aktiv ist. Installiert Claude-Code-Hooks";
-"keep_awake.grace" = "Ruhezustand erlauben nach Inaktivität";
-"keep_awake.grace.immediately" = "Sofort";
+"keep_awake.auto_desc" = "Bleibt während aktiver Claude-Code-Sitzungen wach und erlaubt danach wieder den Ruhezustand. Installiert Claude-Code-Hooks";
+"keep_awake.grace" = "Nach Claudes Arbeit wach bleiben für";
+"keep_awake.grace.immediately" = "Keine zusätzliche Zeit";
 "keep_awake.hooks_note" = "Aktivität wird über Claude-Code-Hooks in ~/.claude/settings.json erkannt";
 "keep_awake.sleep_type" = "Ruhezustand-Verhinderung";
 "keep_awake.sleep_type_desc" = "Legt fest, ob der Bildschirm eingeschaltet bleibt, während der Mac wachgehalten wird";
 "keep_awake.sleep_type.system" = "Bildschirm darf ausgehen";
 "keep_awake.sleep_type.display" = "Bildschirm anlassen";
-"keep_awake.lid_note" = "Verhindert nicht den Ruhezustand bei geschlossenem Deckel";
-"keep_awake.toggle_tooltip" = "Mac wachhalten";
+"keep_awake.lid_note" = "Bei geschlossenem Deckel wechselt der Mac trotzdem in den Ruhezustand, außer er ist am Strom und nutzt ein externes Display";
+"keep_awake.tooltip_off" = "Mac wachhalten — zum Einschalten klicken";
+"keep_awake.tooltip_on" = "Der Mac wird wachgehalten — zum Ausschalten klicken";
+"keep_awake.tooltip_until" = "Der Mac wird bis %@ wachgehalten — zum Ausschalten klicken";
+"keep_awake.tooltip_auto" = "Der Mac wird wachgehalten — Claude Code arbeitet";
 
 /* Sponsor slot */
 "sponsor.slot_title" = "Dieser Platz ist für Sponsoren verfügbar";

--- a/Claude Usage/Resources/en.lproj/Localizable.strings
+++ b/Claude Usage/Resources/en.lproj/Localizable.strings
@@ -1054,6 +1054,7 @@
 "keep_awake.state_on_remaining" = "On — %@ left";
 "keep_awake.state_auto_active" = "Auto — Claude Code is working";
 "keep_awake.state_auto_grace" = "Auto — Claude finished, staying awake %@ more";
+"keep_awake.state_auto_armed" = "Auto is on — keeps your Mac awake while Claude Code works";
 "keep_awake.hint_click_on" = "Click to keep your Mac awake";
 "keep_awake.hint_click_off" = "Click to turn off";
 "keep_awake.hint_click_pause_auto" = "Click to stop now — resumes when Claude works again";

--- a/Claude Usage/Resources/en.lproj/Localizable.strings
+++ b/Claude Usage/Resources/en.lproj/Localizable.strings
@@ -1040,18 +1040,26 @@
 "keep_awake.auto_card_desc" = "Recommended: only keeps your Mac awake while Claude Code is actually working";
 "keep_awake.auto" = "Keep Awake While Claude Code Works";
 "keep_awake.auto_desc" = "Stays awake during active Claude Code sessions, then allows sleep again. Installs Claude Code hooks";
-"keep_awake.grace" = "After Claude finishes, stay awake for";
-"keep_awake.grace.immediately" = "No extra time";
+"keep_awake.grace" = "After Claude Code stops working";
+"keep_awake.grace.immediately" = "Sleep right away";
+"keep_awake.grace.stay" = "Stay awake %@";
 "keep_awake.hooks_note" = "Activity is detected through Claude Code hooks in ~/.claude/settings.json";
 "keep_awake.sleep_type" = "Sleep Prevention";
 "keep_awake.sleep_type_desc" = "Choose whether the display stays on while keeping the Mac awake";
 "keep_awake.sleep_type.system" = "Screen may sleep";
 "keep_awake.sleep_type.display" = "Keep screen on";
 "keep_awake.lid_note" = "With the lid closed, your Mac will still sleep unless it's plugged in and using an external display";
-"keep_awake.tooltip_off" = "Keep your Mac awake — click to turn on";
-"keep_awake.tooltip_on" = "Keeping your Mac awake — click to turn off";
-"keep_awake.tooltip_until" = "Keeping your Mac awake until %@ — click to turn off";
-"keep_awake.tooltip_auto" = "Keeping your Mac awake — Claude Code is working";
+"keep_awake.state_off" = "Off";
+"keep_awake.state_on_indefinite" = "On — stays awake until you turn it off (∞)";
+"keep_awake.state_on_remaining" = "On — %@ left";
+"keep_awake.state_auto_active" = "Auto — Claude Code is working";
+"keep_awake.state_auto_grace" = "Auto — Claude finished, staying awake %@ more";
+"keep_awake.hint_click_on" = "Click to keep your Mac awake";
+"keep_awake.hint_click_off" = "Click to turn off";
+"keep_awake.hint_click_pause_auto" = "Click to stop now — resumes when Claude works again";
+"keep_awake.menu_for" = "Keep awake for %@";
+"keep_awake.menu_indefinite" = "Keep awake until turned off";
+"keep_awake.menu_off" = "Turn off keep awake";
 
 /* Sponsor slot */
 "sponsor.slot_title" = "This spot is available for sponsors";

--- a/Claude Usage/Resources/en.lproj/Localizable.strings
+++ b/Claude Usage/Resources/en.lproj/Localizable.strings
@@ -1055,9 +1055,9 @@
 "keep_awake.state_auto_active" = "Auto — Claude Code is working";
 "keep_awake.state_auto_grace" = "Auto — Claude finished, staying awake %@ more";
 "keep_awake.state_auto_armed" = "Auto is on — keeps your Mac awake while Claude Code works";
-"keep_awake.hint_click_on" = "Click to keep your Mac awake";
+"keep_awake.hint_click_on" = "Click to turn on — keeps your Mac awake while Claude Code works";
 "keep_awake.hint_click_off" = "Click to turn off";
-"keep_awake.hint_click_pause_auto" = "Click to stop now — resumes when Claude works again";
+"keep_awake.hint_click_auto_off" = "Click to turn auto mode off — stays off until you turn it back on";
 "keep_awake.menu_for" = "Keep awake for %@";
 "keep_awake.menu_indefinite" = "Keep awake until turned off";
 "keep_awake.menu_off" = "Turn off keep awake";

--- a/Claude Usage/Resources/en.lproj/Localizable.strings
+++ b/Claude Usage/Resources/en.lproj/Localizable.strings
@@ -1027,7 +1027,7 @@
 "section.keep_awake_title" = "Keep Awake";
 "section.keep_awake_desc" = "Prevent your Mac from sleeping";
 "keep_awake.manual_title" = "Manual Control";
-"keep_awake.manual_desc" = "Keep your Mac awake on demand, with an optional timer";
+"keep_awake.manual_desc" = "Turn keep-awake on yourself, with an optional timer";
 "keep_awake.enable" = "Keep Mac Awake";
 "keep_awake.enable_desc" = "Temporarily prevent your Mac from going to sleep";
 "keep_awake.status_active" = "Currently keeping your Mac awake";
@@ -1037,18 +1037,21 @@
 "keep_awake.duration.custom" = "Custom…";
 "keep_awake.custom_hours" = "%d hours";
 "keep_awake.auto_title" = "Automatic";
-"keep_awake.auto_card_desc" = "Let Claude Code activity control sleep prevention";
+"keep_awake.auto_card_desc" = "Recommended: only keeps your Mac awake while Claude Code is actually working";
 "keep_awake.auto" = "Keep Awake While Claude Code Works";
-"keep_awake.auto_desc" = "Automatically keeps your Mac awake while a Claude Code session is active. Installs Claude Code hooks";
-"keep_awake.grace" = "Allow sleep after inactivity";
-"keep_awake.grace.immediately" = "Immediately";
+"keep_awake.auto_desc" = "Stays awake during active Claude Code sessions, then allows sleep again. Installs Claude Code hooks";
+"keep_awake.grace" = "After Claude finishes, stay awake for";
+"keep_awake.grace.immediately" = "No extra time";
 "keep_awake.hooks_note" = "Activity is detected through Claude Code hooks in ~/.claude/settings.json";
 "keep_awake.sleep_type" = "Sleep Prevention";
 "keep_awake.sleep_type_desc" = "Choose whether the display stays on while keeping the Mac awake";
 "keep_awake.sleep_type.system" = "Screen may sleep";
 "keep_awake.sleep_type.display" = "Keep screen on";
-"keep_awake.lid_note" = "Does not prevent sleep when the lid is closed";
-"keep_awake.toggle_tooltip" = "Keep Mac awake";
+"keep_awake.lid_note" = "With the lid closed, your Mac will still sleep unless it's plugged in and using an external display";
+"keep_awake.tooltip_off" = "Keep your Mac awake — click to turn on";
+"keep_awake.tooltip_on" = "Keeping your Mac awake — click to turn off";
+"keep_awake.tooltip_until" = "Keeping your Mac awake until %@ — click to turn off";
+"keep_awake.tooltip_auto" = "Keeping your Mac awake — Claude Code is working";
 
 /* Sponsor slot */
 "sponsor.slot_title" = "This spot is available for sponsors";

--- a/Claude Usage/Resources/en.lproj/Localizable.strings
+++ b/Claude Usage/Resources/en.lproj/Localizable.strings
@@ -1023,6 +1023,33 @@
 "notch.server.port_busy" = "Port %@ is in use — is another copy of the app running?";
 "notch.server.retry" = "Retry";
 
+/* Keep Awake */
+"section.keep_awake_title" = "Keep Awake";
+"section.keep_awake_desc" = "Prevent your Mac from sleeping";
+"keep_awake.manual_title" = "Manual Control";
+"keep_awake.manual_desc" = "Keep your Mac awake on demand, with an optional timer";
+"keep_awake.enable" = "Keep Mac Awake";
+"keep_awake.enable_desc" = "Temporarily prevent your Mac from going to sleep";
+"keep_awake.status_active" = "Currently keeping your Mac awake";
+"keep_awake.remaining" = "Turns off in %@";
+"keep_awake.duration" = "Duration";
+"keep_awake.duration.indefinite" = "Until turned off";
+"keep_awake.duration.custom" = "Custom…";
+"keep_awake.custom_hours" = "%d hours";
+"keep_awake.auto_title" = "Automatic";
+"keep_awake.auto_card_desc" = "Let Claude Code activity control sleep prevention";
+"keep_awake.auto" = "Keep Awake While Claude Code Works";
+"keep_awake.auto_desc" = "Automatically keeps your Mac awake while a Claude Code session is active. Installs Claude Code hooks";
+"keep_awake.grace" = "Allow sleep after inactivity";
+"keep_awake.grace.immediately" = "Immediately";
+"keep_awake.hooks_note" = "Activity is detected through Claude Code hooks in ~/.claude/settings.json";
+"keep_awake.sleep_type" = "Sleep Prevention";
+"keep_awake.sleep_type_desc" = "Choose whether the display stays on while keeping the Mac awake";
+"keep_awake.sleep_type.system" = "Screen may sleep";
+"keep_awake.sleep_type.display" = "Keep screen on";
+"keep_awake.lid_note" = "Does not prevent sleep when the lid is closed";
+"keep_awake.toggle_tooltip" = "Keep Mac awake";
+
 /* Sponsor slot */
 "sponsor.slot_title" = "This spot is available for sponsors";
 "sponsor.slot_cta" = "Get in touch";

--- a/Claude Usage/Resources/en.lproj/Localizable.strings
+++ b/Claude Usage/Resources/en.lproj/Localizable.strings
@@ -1017,6 +1017,33 @@
 "notch.server.port_busy" = "Port %@ is in use — is another copy of the app running?";
 "notch.server.retry" = "Retry";
 
+/* Keep Awake */
+"section.keep_awake_title" = "Keep Awake";
+"section.keep_awake_desc" = "Prevent your Mac from sleeping";
+"keep_awake.manual_title" = "Manual Control";
+"keep_awake.manual_desc" = "Keep your Mac awake on demand, with an optional timer";
+"keep_awake.enable" = "Keep Mac Awake";
+"keep_awake.enable_desc" = "Temporarily prevent your Mac from going to sleep";
+"keep_awake.status_active" = "Currently keeping your Mac awake";
+"keep_awake.remaining" = "Turns off in %@";
+"keep_awake.duration" = "Duration";
+"keep_awake.duration.indefinite" = "Until turned off";
+"keep_awake.duration.custom" = "Custom…";
+"keep_awake.custom_hours" = "%d hours";
+"keep_awake.auto_title" = "Automatic";
+"keep_awake.auto_card_desc" = "Let Claude Code activity control sleep prevention";
+"keep_awake.auto" = "Keep Awake While Claude Code Works";
+"keep_awake.auto_desc" = "Automatically keeps your Mac awake while a Claude Code session is active. Installs Claude Code hooks";
+"keep_awake.grace" = "Allow sleep after inactivity";
+"keep_awake.grace.immediately" = "Immediately";
+"keep_awake.hooks_note" = "Activity is detected through Claude Code hooks in ~/.claude/settings.json";
+"keep_awake.sleep_type" = "Sleep Prevention";
+"keep_awake.sleep_type_desc" = "Choose whether the display stays on while keeping the Mac awake";
+"keep_awake.sleep_type.system" = "Screen may sleep";
+"keep_awake.sleep_type.display" = "Keep screen on";
+"keep_awake.lid_note" = "Does not prevent sleep when the lid is closed";
+"keep_awake.toggle_tooltip" = "Keep Mac awake";
+
 /* Sponsor slot */
 "sponsor.slot_title" = "This spot is available for sponsors";
 "sponsor.slot_cta" = "Get in touch";

--- a/Claude Usage/Resources/en.lproj/Localizable.strings
+++ b/Claude Usage/Resources/en.lproj/Localizable.strings
@@ -1048,6 +1048,7 @@
 "keep_awake.state_on_remaining" = "On — %@ left";
 "keep_awake.state_auto_active" = "Auto — Claude Code is working";
 "keep_awake.state_auto_grace" = "Auto — Claude finished, staying awake %@ more";
+"keep_awake.state_auto_armed" = "Auto is on — keeps your Mac awake while Claude Code works";
 "keep_awake.hint_click_on" = "Click to keep your Mac awake";
 "keep_awake.hint_click_off" = "Click to turn off";
 "keep_awake.hint_click_pause_auto" = "Click to stop now — resumes when Claude works again";

--- a/Claude Usage/Resources/en.lproj/Localizable.strings
+++ b/Claude Usage/Resources/en.lproj/Localizable.strings
@@ -1021,7 +1021,7 @@
 "section.keep_awake_title" = "Keep Awake";
 "section.keep_awake_desc" = "Prevent your Mac from sleeping";
 "keep_awake.manual_title" = "Manual Control";
-"keep_awake.manual_desc" = "Keep your Mac awake on demand, with an optional timer";
+"keep_awake.manual_desc" = "Turn keep-awake on yourself, with an optional timer";
 "keep_awake.enable" = "Keep Mac Awake";
 "keep_awake.enable_desc" = "Temporarily prevent your Mac from going to sleep";
 "keep_awake.status_active" = "Currently keeping your Mac awake";
@@ -1031,18 +1031,21 @@
 "keep_awake.duration.custom" = "Custom…";
 "keep_awake.custom_hours" = "%d hours";
 "keep_awake.auto_title" = "Automatic";
-"keep_awake.auto_card_desc" = "Let Claude Code activity control sleep prevention";
+"keep_awake.auto_card_desc" = "Recommended: only keeps your Mac awake while Claude Code is actually working";
 "keep_awake.auto" = "Keep Awake While Claude Code Works";
-"keep_awake.auto_desc" = "Automatically keeps your Mac awake while a Claude Code session is active. Installs Claude Code hooks";
-"keep_awake.grace" = "Allow sleep after inactivity";
-"keep_awake.grace.immediately" = "Immediately";
+"keep_awake.auto_desc" = "Stays awake during active Claude Code sessions, then allows sleep again. Installs Claude Code hooks";
+"keep_awake.grace" = "After Claude finishes, stay awake for";
+"keep_awake.grace.immediately" = "No extra time";
 "keep_awake.hooks_note" = "Activity is detected through Claude Code hooks in ~/.claude/settings.json";
 "keep_awake.sleep_type" = "Sleep Prevention";
 "keep_awake.sleep_type_desc" = "Choose whether the display stays on while keeping the Mac awake";
 "keep_awake.sleep_type.system" = "Screen may sleep";
 "keep_awake.sleep_type.display" = "Keep screen on";
-"keep_awake.lid_note" = "Does not prevent sleep when the lid is closed";
-"keep_awake.toggle_tooltip" = "Keep Mac awake";
+"keep_awake.lid_note" = "With the lid closed, your Mac will still sleep unless it's plugged in and using an external display";
+"keep_awake.tooltip_off" = "Keep your Mac awake — click to turn on";
+"keep_awake.tooltip_on" = "Keeping your Mac awake — click to turn off";
+"keep_awake.tooltip_until" = "Keeping your Mac awake until %@ — click to turn off";
+"keep_awake.tooltip_auto" = "Keeping your Mac awake — Claude Code is working";
 
 /* Sponsor slot */
 "sponsor.slot_title" = "This spot is available for sponsors";

--- a/Claude Usage/Resources/en.lproj/Localizable.strings
+++ b/Claude Usage/Resources/en.lproj/Localizable.strings
@@ -1049,9 +1049,9 @@
 "keep_awake.state_auto_active" = "Auto — Claude Code is working";
 "keep_awake.state_auto_grace" = "Auto — Claude finished, staying awake %@ more";
 "keep_awake.state_auto_armed" = "Auto is on — keeps your Mac awake while Claude Code works";
-"keep_awake.hint_click_on" = "Click to keep your Mac awake";
+"keep_awake.hint_click_on" = "Click to turn on — keeps your Mac awake while Claude Code works";
 "keep_awake.hint_click_off" = "Click to turn off";
-"keep_awake.hint_click_pause_auto" = "Click to stop now — resumes when Claude works again";
+"keep_awake.hint_click_auto_off" = "Click to turn auto mode off — stays off until you turn it back on";
 "keep_awake.menu_for" = "Keep awake for %@";
 "keep_awake.menu_indefinite" = "Keep awake until turned off";
 "keep_awake.menu_off" = "Turn off keep awake";

--- a/Claude Usage/Resources/en.lproj/Localizable.strings
+++ b/Claude Usage/Resources/en.lproj/Localizable.strings
@@ -1034,18 +1034,26 @@
 "keep_awake.auto_card_desc" = "Recommended: only keeps your Mac awake while Claude Code is actually working";
 "keep_awake.auto" = "Keep Awake While Claude Code Works";
 "keep_awake.auto_desc" = "Stays awake during active Claude Code sessions, then allows sleep again. Installs Claude Code hooks";
-"keep_awake.grace" = "After Claude finishes, stay awake for";
-"keep_awake.grace.immediately" = "No extra time";
+"keep_awake.grace" = "After Claude Code stops working";
+"keep_awake.grace.immediately" = "Sleep right away";
+"keep_awake.grace.stay" = "Stay awake %@";
 "keep_awake.hooks_note" = "Activity is detected through Claude Code hooks in ~/.claude/settings.json";
 "keep_awake.sleep_type" = "Sleep Prevention";
 "keep_awake.sleep_type_desc" = "Choose whether the display stays on while keeping the Mac awake";
 "keep_awake.sleep_type.system" = "Screen may sleep";
 "keep_awake.sleep_type.display" = "Keep screen on";
 "keep_awake.lid_note" = "With the lid closed, your Mac will still sleep unless it's plugged in and using an external display";
-"keep_awake.tooltip_off" = "Keep your Mac awake — click to turn on";
-"keep_awake.tooltip_on" = "Keeping your Mac awake — click to turn off";
-"keep_awake.tooltip_until" = "Keeping your Mac awake until %@ — click to turn off";
-"keep_awake.tooltip_auto" = "Keeping your Mac awake — Claude Code is working";
+"keep_awake.state_off" = "Off";
+"keep_awake.state_on_indefinite" = "On — stays awake until you turn it off (∞)";
+"keep_awake.state_on_remaining" = "On — %@ left";
+"keep_awake.state_auto_active" = "Auto — Claude Code is working";
+"keep_awake.state_auto_grace" = "Auto — Claude finished, staying awake %@ more";
+"keep_awake.hint_click_on" = "Click to keep your Mac awake";
+"keep_awake.hint_click_off" = "Click to turn off";
+"keep_awake.hint_click_pause_auto" = "Click to stop now — resumes when Claude works again";
+"keep_awake.menu_for" = "Keep awake for %@";
+"keep_awake.menu_indefinite" = "Keep awake until turned off";
+"keep_awake.menu_off" = "Turn off keep awake";
 
 /* Sponsor slot */
 "sponsor.slot_title" = "This spot is available for sponsors";

--- a/Claude Usage/Resources/es.lproj/Localizable.strings
+++ b/Claude Usage/Resources/es.lproj/Localizable.strings
@@ -1025,18 +1025,26 @@
 "keep_awake.auto_card_desc" = "Recomendado: solo mantiene el Mac despierto mientras Claude Code está trabajando";
 "keep_awake.auto" = "Mantener despierto mientras Claude Code trabaja";
 "keep_awake.auto_desc" = "Se mantiene despierto durante las sesiones activas de Claude Code y luego vuelve a permitir el reposo. Instala hooks de Claude Code";
-"keep_awake.grace" = "Cuando Claude termine, seguir despierto durante";
-"keep_awake.grace.immediately" = "Sin tiempo extra";
+"keep_awake.grace" = "Cuando Claude Code deje de trabajar";
+"keep_awake.grace.immediately" = "Dormir enseguida";
+"keep_awake.grace.stay" = "Seguir despierto %@";
 "keep_awake.hooks_note" = "La actividad se detecta mediante hooks de Claude Code en ~/.claude/settings.json";
 "keep_awake.sleep_type" = "Prevención de reposo";
 "keep_awake.sleep_type_desc" = "Elige si la pantalla permanece encendida mientras el Mac se mantiene despierto";
 "keep_awake.sleep_type.system" = "La pantalla puede apagarse";
 "keep_awake.sleep_type.display" = "Mantener pantalla encendida";
 "keep_awake.lid_note" = "Con la tapa cerrada, el Mac entrará en reposo igualmente salvo que esté enchufado y use una pantalla externa";
-"keep_awake.tooltip_off" = "Mantener el Mac despierto — haz clic para activar";
-"keep_awake.tooltip_on" = "Manteniendo el Mac despierto — haz clic para desactivar";
-"keep_awake.tooltip_until" = "Manteniendo el Mac despierto hasta las %@ — haz clic para desactivar";
-"keep_awake.tooltip_auto" = "Manteniendo el Mac despierto — Claude Code está trabajando";
+"keep_awake.state_off" = "Desactivado";
+"keep_awake.state_on_indefinite" = "Activado — despierto hasta que lo desactives (∞)";
+"keep_awake.state_on_remaining" = "Activado — quedan %@";
+"keep_awake.state_auto_active" = "Auto — Claude Code está trabajando";
+"keep_awake.state_auto_grace" = "Auto — Claude terminó, despierto %@ más";
+"keep_awake.hint_click_on" = "Haz clic para mantener el Mac despierto";
+"keep_awake.hint_click_off" = "Haz clic para desactivar";
+"keep_awake.hint_click_pause_auto" = "Haz clic para parar — se reanuda cuando Claude vuelva a trabajar";
+"keep_awake.menu_for" = "Mantener despierto %@";
+"keep_awake.menu_indefinite" = "Mantener despierto hasta desactivar";
+"keep_awake.menu_off" = "Desactivar mantener despierto";
 
 /* Sponsor slot */
 "sponsor.slot_title" = "Este espacio está disponible para patrocinadores";

--- a/Claude Usage/Resources/es.lproj/Localizable.strings
+++ b/Claude Usage/Resources/es.lproj/Localizable.strings
@@ -1012,7 +1012,7 @@
 "section.keep_awake_title" = "Mantener despierto";
 "section.keep_awake_desc" = "Evita que el Mac entre en reposo";
 "keep_awake.manual_title" = "Control manual";
-"keep_awake.manual_desc" = "Mantén el Mac despierto cuando quieras, con temporizador opcional";
+"keep_awake.manual_desc" = "Activa tú mismo el mantener despierto, con temporizador opcional";
 "keep_awake.enable" = "Mantener el Mac despierto";
 "keep_awake.enable_desc" = "Evita temporalmente que el Mac entre en reposo";
 "keep_awake.status_active" = "Manteniendo el Mac despierto";
@@ -1022,18 +1022,21 @@
 "keep_awake.duration.custom" = "Personalizada…";
 "keep_awake.custom_hours" = "%d horas";
 "keep_awake.auto_title" = "Automático";
-"keep_awake.auto_card_desc" = "La actividad de Claude Code controla el reposo";
+"keep_awake.auto_card_desc" = "Recomendado: solo mantiene el Mac despierto mientras Claude Code está trabajando";
 "keep_awake.auto" = "Mantener despierto mientras Claude Code trabaja";
-"keep_awake.auto_desc" = "Mantiene el Mac despierto automáticamente mientras hay una sesión de Claude Code activa. Instala hooks de Claude Code";
-"keep_awake.grace" = "Permitir reposo tras inactividad";
-"keep_awake.grace.immediately" = "Inmediatamente";
+"keep_awake.auto_desc" = "Se mantiene despierto durante las sesiones activas de Claude Code y luego vuelve a permitir el reposo. Instala hooks de Claude Code";
+"keep_awake.grace" = "Cuando Claude termine, seguir despierto durante";
+"keep_awake.grace.immediately" = "Sin tiempo extra";
 "keep_awake.hooks_note" = "La actividad se detecta mediante hooks de Claude Code en ~/.claude/settings.json";
 "keep_awake.sleep_type" = "Prevención de reposo";
 "keep_awake.sleep_type_desc" = "Elige si la pantalla permanece encendida mientras el Mac se mantiene despierto";
 "keep_awake.sleep_type.system" = "La pantalla puede apagarse";
 "keep_awake.sleep_type.display" = "Mantener pantalla encendida";
-"keep_awake.lid_note" = "No evita el reposo con la tapa cerrada";
-"keep_awake.toggle_tooltip" = "Mantener el Mac despierto";
+"keep_awake.lid_note" = "Con la tapa cerrada, el Mac entrará en reposo igualmente salvo que esté enchufado y use una pantalla externa";
+"keep_awake.tooltip_off" = "Mantener el Mac despierto — haz clic para activar";
+"keep_awake.tooltip_on" = "Manteniendo el Mac despierto — haz clic para desactivar";
+"keep_awake.tooltip_until" = "Manteniendo el Mac despierto hasta las %@ — haz clic para desactivar";
+"keep_awake.tooltip_auto" = "Manteniendo el Mac despierto — Claude Code está trabajando";
 
 /* Sponsor slot */
 "sponsor.slot_title" = "Este espacio está disponible para patrocinadores";

--- a/Claude Usage/Resources/es.lproj/Localizable.strings
+++ b/Claude Usage/Resources/es.lproj/Localizable.strings
@@ -1039,6 +1039,7 @@
 "keep_awake.state_on_remaining" = "Activado — quedan %@";
 "keep_awake.state_auto_active" = "Auto — Claude Code está trabajando";
 "keep_awake.state_auto_grace" = "Auto — Claude terminó, despierto %@ más";
+"keep_awake.state_auto_armed" = "Auto activado — mantiene el Mac despierto mientras Claude Code trabaja";
 "keep_awake.hint_click_on" = "Haz clic para mantener el Mac despierto";
 "keep_awake.hint_click_off" = "Haz clic para desactivar";
 "keep_awake.hint_click_pause_auto" = "Haz clic para parar — se reanuda cuando Claude vuelva a trabajar";

--- a/Claude Usage/Resources/es.lproj/Localizable.strings
+++ b/Claude Usage/Resources/es.lproj/Localizable.strings
@@ -1040,9 +1040,9 @@
 "keep_awake.state_auto_active" = "Auto — Claude Code está trabajando";
 "keep_awake.state_auto_grace" = "Auto — Claude terminó, despierto %@ más";
 "keep_awake.state_auto_armed" = "Auto activado — mantiene el Mac despierto mientras Claude Code trabaja";
-"keep_awake.hint_click_on" = "Haz clic para mantener el Mac despierto";
+"keep_awake.hint_click_on" = "Haz clic para activar — mantiene el Mac despierto mientras Claude Code trabaja";
 "keep_awake.hint_click_off" = "Haz clic para desactivar";
-"keep_awake.hint_click_pause_auto" = "Haz clic para parar — se reanuda cuando Claude vuelva a trabajar";
+"keep_awake.hint_click_auto_off" = "Haz clic para desactivar el modo automático — permanece desactivado hasta que lo actives de nuevo";
 "keep_awake.menu_for" = "Mantener despierto %@";
 "keep_awake.menu_indefinite" = "Mantener despierto hasta desactivar";
 "keep_awake.menu_off" = "Desactivar mantener despierto";

--- a/Claude Usage/Resources/es.lproj/Localizable.strings
+++ b/Claude Usage/Resources/es.lproj/Localizable.strings
@@ -1008,6 +1008,33 @@
 "menubar.this_month" = "Este mes";
 "menubar.total" = "Total";
 
+/* Keep Awake */
+"section.keep_awake_title" = "Mantener despierto";
+"section.keep_awake_desc" = "Evita que el Mac entre en reposo";
+"keep_awake.manual_title" = "Control manual";
+"keep_awake.manual_desc" = "Mantén el Mac despierto cuando quieras, con temporizador opcional";
+"keep_awake.enable" = "Mantener el Mac despierto";
+"keep_awake.enable_desc" = "Evita temporalmente que el Mac entre en reposo";
+"keep_awake.status_active" = "Manteniendo el Mac despierto";
+"keep_awake.remaining" = "Se desactiva en %@";
+"keep_awake.duration" = "Duración";
+"keep_awake.duration.indefinite" = "Hasta desactivarlo";
+"keep_awake.duration.custom" = "Personalizada…";
+"keep_awake.custom_hours" = "%d horas";
+"keep_awake.auto_title" = "Automático";
+"keep_awake.auto_card_desc" = "La actividad de Claude Code controla el reposo";
+"keep_awake.auto" = "Mantener despierto mientras Claude Code trabaja";
+"keep_awake.auto_desc" = "Mantiene el Mac despierto automáticamente mientras hay una sesión de Claude Code activa. Instala hooks de Claude Code";
+"keep_awake.grace" = "Permitir reposo tras inactividad";
+"keep_awake.grace.immediately" = "Inmediatamente";
+"keep_awake.hooks_note" = "La actividad se detecta mediante hooks de Claude Code en ~/.claude/settings.json";
+"keep_awake.sleep_type" = "Prevención de reposo";
+"keep_awake.sleep_type_desc" = "Elige si la pantalla permanece encendida mientras el Mac se mantiene despierto";
+"keep_awake.sleep_type.system" = "La pantalla puede apagarse";
+"keep_awake.sleep_type.display" = "Mantener pantalla encendida";
+"keep_awake.lid_note" = "No evita el reposo con la tapa cerrada";
+"keep_awake.toggle_tooltip" = "Mantener el Mac despierto";
+
 /* Sponsor slot */
 "sponsor.slot_title" = "Este espacio está disponible para patrocinadores";
 "sponsor.slot_cta" = "Contáctame";

--- a/Claude Usage/Resources/es.lproj/Localizable.strings
+++ b/Claude Usage/Resources/es.lproj/Localizable.strings
@@ -1033,6 +1033,7 @@
 "keep_awake.state_on_remaining" = "Activado — quedan %@";
 "keep_awake.state_auto_active" = "Auto — Claude Code está trabajando";
 "keep_awake.state_auto_grace" = "Auto — Claude terminó, despierto %@ más";
+"keep_awake.state_auto_armed" = "Auto activado — mantiene el Mac despierto mientras Claude Code trabaja";
 "keep_awake.hint_click_on" = "Haz clic para mantener el Mac despierto";
 "keep_awake.hint_click_off" = "Haz clic para desactivar";
 "keep_awake.hint_click_pause_auto" = "Haz clic para parar — se reanuda cuando Claude vuelva a trabajar";

--- a/Claude Usage/Resources/es.lproj/Localizable.strings
+++ b/Claude Usage/Resources/es.lproj/Localizable.strings
@@ -1006,7 +1006,7 @@
 "section.keep_awake_title" = "Mantener despierto";
 "section.keep_awake_desc" = "Evita que el Mac entre en reposo";
 "keep_awake.manual_title" = "Control manual";
-"keep_awake.manual_desc" = "Mantén el Mac despierto cuando quieras, con temporizador opcional";
+"keep_awake.manual_desc" = "Activa tú mismo el mantener despierto, con temporizador opcional";
 "keep_awake.enable" = "Mantener el Mac despierto";
 "keep_awake.enable_desc" = "Evita temporalmente que el Mac entre en reposo";
 "keep_awake.status_active" = "Manteniendo el Mac despierto";
@@ -1016,18 +1016,21 @@
 "keep_awake.duration.custom" = "Personalizada…";
 "keep_awake.custom_hours" = "%d horas";
 "keep_awake.auto_title" = "Automático";
-"keep_awake.auto_card_desc" = "La actividad de Claude Code controla el reposo";
+"keep_awake.auto_card_desc" = "Recomendado: solo mantiene el Mac despierto mientras Claude Code está trabajando";
 "keep_awake.auto" = "Mantener despierto mientras Claude Code trabaja";
-"keep_awake.auto_desc" = "Mantiene el Mac despierto automáticamente mientras hay una sesión de Claude Code activa. Instala hooks de Claude Code";
-"keep_awake.grace" = "Permitir reposo tras inactividad";
-"keep_awake.grace.immediately" = "Inmediatamente";
+"keep_awake.auto_desc" = "Se mantiene despierto durante las sesiones activas de Claude Code y luego vuelve a permitir el reposo. Instala hooks de Claude Code";
+"keep_awake.grace" = "Cuando Claude termine, seguir despierto durante";
+"keep_awake.grace.immediately" = "Sin tiempo extra";
 "keep_awake.hooks_note" = "La actividad se detecta mediante hooks de Claude Code en ~/.claude/settings.json";
 "keep_awake.sleep_type" = "Prevención de reposo";
 "keep_awake.sleep_type_desc" = "Elige si la pantalla permanece encendida mientras el Mac se mantiene despierto";
 "keep_awake.sleep_type.system" = "La pantalla puede apagarse";
 "keep_awake.sleep_type.display" = "Mantener pantalla encendida";
-"keep_awake.lid_note" = "No evita el reposo con la tapa cerrada";
-"keep_awake.toggle_tooltip" = "Mantener el Mac despierto";
+"keep_awake.lid_note" = "Con la tapa cerrada, el Mac entrará en reposo igualmente salvo que esté enchufado y use una pantalla externa";
+"keep_awake.tooltip_off" = "Mantener el Mac despierto — haz clic para activar";
+"keep_awake.tooltip_on" = "Manteniendo el Mac despierto — haz clic para desactivar";
+"keep_awake.tooltip_until" = "Manteniendo el Mac despierto hasta las %@ — haz clic para desactivar";
+"keep_awake.tooltip_auto" = "Manteniendo el Mac despierto — Claude Code está trabajando";
 
 /* Sponsor slot */
 "sponsor.slot_title" = "Este espacio está disponible para patrocinadores";

--- a/Claude Usage/Resources/es.lproj/Localizable.strings
+++ b/Claude Usage/Resources/es.lproj/Localizable.strings
@@ -1034,9 +1034,9 @@
 "keep_awake.state_auto_active" = "Auto — Claude Code está trabajando";
 "keep_awake.state_auto_grace" = "Auto — Claude terminó, despierto %@ más";
 "keep_awake.state_auto_armed" = "Auto activado — mantiene el Mac despierto mientras Claude Code trabaja";
-"keep_awake.hint_click_on" = "Haz clic para mantener el Mac despierto";
+"keep_awake.hint_click_on" = "Haz clic para activar — mantiene el Mac despierto mientras Claude Code trabaja";
 "keep_awake.hint_click_off" = "Haz clic para desactivar";
-"keep_awake.hint_click_pause_auto" = "Haz clic para parar — se reanuda cuando Claude vuelva a trabajar";
+"keep_awake.hint_click_auto_off" = "Haz clic para desactivar el modo automático — permanece desactivado hasta que lo actives de nuevo";
 "keep_awake.menu_for" = "Mantener despierto %@";
 "keep_awake.menu_indefinite" = "Mantener despierto hasta desactivar";
 "keep_awake.menu_off" = "Desactivar mantener despierto";

--- a/Claude Usage/Resources/es.lproj/Localizable.strings
+++ b/Claude Usage/Resources/es.lproj/Localizable.strings
@@ -1019,18 +1019,26 @@
 "keep_awake.auto_card_desc" = "Recomendado: solo mantiene el Mac despierto mientras Claude Code está trabajando";
 "keep_awake.auto" = "Mantener despierto mientras Claude Code trabaja";
 "keep_awake.auto_desc" = "Se mantiene despierto durante las sesiones activas de Claude Code y luego vuelve a permitir el reposo. Instala hooks de Claude Code";
-"keep_awake.grace" = "Cuando Claude termine, seguir despierto durante";
-"keep_awake.grace.immediately" = "Sin tiempo extra";
+"keep_awake.grace" = "Cuando Claude Code deje de trabajar";
+"keep_awake.grace.immediately" = "Dormir enseguida";
+"keep_awake.grace.stay" = "Seguir despierto %@";
 "keep_awake.hooks_note" = "La actividad se detecta mediante hooks de Claude Code en ~/.claude/settings.json";
 "keep_awake.sleep_type" = "Prevención de reposo";
 "keep_awake.sleep_type_desc" = "Elige si la pantalla permanece encendida mientras el Mac se mantiene despierto";
 "keep_awake.sleep_type.system" = "La pantalla puede apagarse";
 "keep_awake.sleep_type.display" = "Mantener pantalla encendida";
 "keep_awake.lid_note" = "Con la tapa cerrada, el Mac entrará en reposo igualmente salvo que esté enchufado y use una pantalla externa";
-"keep_awake.tooltip_off" = "Mantener el Mac despierto — haz clic para activar";
-"keep_awake.tooltip_on" = "Manteniendo el Mac despierto — haz clic para desactivar";
-"keep_awake.tooltip_until" = "Manteniendo el Mac despierto hasta las %@ — haz clic para desactivar";
-"keep_awake.tooltip_auto" = "Manteniendo el Mac despierto — Claude Code está trabajando";
+"keep_awake.state_off" = "Desactivado";
+"keep_awake.state_on_indefinite" = "Activado — despierto hasta que lo desactives (∞)";
+"keep_awake.state_on_remaining" = "Activado — quedan %@";
+"keep_awake.state_auto_active" = "Auto — Claude Code está trabajando";
+"keep_awake.state_auto_grace" = "Auto — Claude terminó, despierto %@ más";
+"keep_awake.hint_click_on" = "Haz clic para mantener el Mac despierto";
+"keep_awake.hint_click_off" = "Haz clic para desactivar";
+"keep_awake.hint_click_pause_auto" = "Haz clic para parar — se reanuda cuando Claude vuelva a trabajar";
+"keep_awake.menu_for" = "Mantener despierto %@";
+"keep_awake.menu_indefinite" = "Mantener despierto hasta desactivar";
+"keep_awake.menu_off" = "Desactivar mantener despierto";
 
 /* Sponsor slot */
 "sponsor.slot_title" = "Este espacio está disponible para patrocinadores";

--- a/Claude Usage/Resources/es.lproj/Localizable.strings
+++ b/Claude Usage/Resources/es.lproj/Localizable.strings
@@ -1002,6 +1002,33 @@
 "menubar.this_month" = "Este mes";
 "menubar.total" = "Total";
 
+/* Keep Awake */
+"section.keep_awake_title" = "Mantener despierto";
+"section.keep_awake_desc" = "Evita que el Mac entre en reposo";
+"keep_awake.manual_title" = "Control manual";
+"keep_awake.manual_desc" = "Mantén el Mac despierto cuando quieras, con temporizador opcional";
+"keep_awake.enable" = "Mantener el Mac despierto";
+"keep_awake.enable_desc" = "Evita temporalmente que el Mac entre en reposo";
+"keep_awake.status_active" = "Manteniendo el Mac despierto";
+"keep_awake.remaining" = "Se desactiva en %@";
+"keep_awake.duration" = "Duración";
+"keep_awake.duration.indefinite" = "Hasta desactivarlo";
+"keep_awake.duration.custom" = "Personalizada…";
+"keep_awake.custom_hours" = "%d horas";
+"keep_awake.auto_title" = "Automático";
+"keep_awake.auto_card_desc" = "La actividad de Claude Code controla el reposo";
+"keep_awake.auto" = "Mantener despierto mientras Claude Code trabaja";
+"keep_awake.auto_desc" = "Mantiene el Mac despierto automáticamente mientras hay una sesión de Claude Code activa. Instala hooks de Claude Code";
+"keep_awake.grace" = "Permitir reposo tras inactividad";
+"keep_awake.grace.immediately" = "Inmediatamente";
+"keep_awake.hooks_note" = "La actividad se detecta mediante hooks de Claude Code en ~/.claude/settings.json";
+"keep_awake.sleep_type" = "Prevención de reposo";
+"keep_awake.sleep_type_desc" = "Elige si la pantalla permanece encendida mientras el Mac se mantiene despierto";
+"keep_awake.sleep_type.system" = "La pantalla puede apagarse";
+"keep_awake.sleep_type.display" = "Mantener pantalla encendida";
+"keep_awake.lid_note" = "No evita el reposo con la tapa cerrada";
+"keep_awake.toggle_tooltip" = "Mantener el Mac despierto";
+
 /* Sponsor slot */
 "sponsor.slot_title" = "Este espacio está disponible para patrocinadores";
 "sponsor.slot_cta" = "Contáctame";

--- a/Claude Usage/Resources/fr.lproj/Localizable.strings
+++ b/Claude Usage/Resources/fr.lproj/Localizable.strings
@@ -1022,18 +1022,26 @@
 "keep_awake.auto_card_desc" = "Recommandé : ne maintient le Mac éveillé que lorsque Claude Code travaille réellement";
 "keep_awake.auto" = "Maintenir éveillé pendant que Claude Code travaille";
 "keep_awake.auto_desc" = "Reste éveillé pendant les sessions Claude Code actives, puis autorise à nouveau la veille. Installe les hooks Claude Code";
-"keep_awake.grace" = "Quand Claude a terminé, rester éveillé pendant";
-"keep_awake.grace.immediately" = "Pas de délai supplémentaire";
+"keep_awake.grace" = "Quand Claude Code s'arrête";
+"keep_awake.grace.immediately" = "Dormir aussitôt";
+"keep_awake.grace.stay" = "Rester éveillé %@";
 "keep_awake.hooks_note" = "L'activité est détectée via les hooks Claude Code dans ~/.claude/settings.json";
 "keep_awake.sleep_type" = "Prévention de la veille";
 "keep_awake.sleep_type_desc" = "Choisissez si l'écran reste allumé pendant que le Mac est maintenu éveillé";
 "keep_awake.sleep_type.system" = "L'écran peut s'éteindre";
 "keep_awake.sleep_type.display" = "Garder l'écran allumé";
 "keep_awake.lid_note" = "Capot fermé, le Mac se mettra quand même en veille sauf s'il est branché et relié à un écran externe";
-"keep_awake.tooltip_off" = "Maintenir le Mac éveillé — cliquez pour activer";
-"keep_awake.tooltip_on" = "Mac maintenu éveillé — cliquez pour désactiver";
-"keep_awake.tooltip_until" = "Mac maintenu éveillé jusqu'à %@ — cliquez pour désactiver";
-"keep_awake.tooltip_auto" = "Mac maintenu éveillé — Claude Code travaille";
+"keep_awake.state_off" = "Désactivé";
+"keep_awake.state_on_indefinite" = "Activé — éveillé jusqu'à désactivation (∞)";
+"keep_awake.state_on_remaining" = "Activé — %@ restant";
+"keep_awake.state_auto_active" = "Auto — Claude Code travaille";
+"keep_awake.state_auto_grace" = "Auto — Claude a terminé, éveillé encore %@";
+"keep_awake.hint_click_on" = "Cliquez pour garder le Mac éveillé";
+"keep_awake.hint_click_off" = "Cliquez pour désactiver";
+"keep_awake.hint_click_pause_auto" = "Cliquez pour arrêter — reprend quand Claude retravaille";
+"keep_awake.menu_for" = "Garder éveillé pendant %@";
+"keep_awake.menu_indefinite" = "Garder éveillé jusqu'à désactivation";
+"keep_awake.menu_off" = "Désactiver le maintien éveillé";
 
 /* Sponsor slot */
 "sponsor.slot_title" = "Cet emplacement est disponible pour les sponsors";

--- a/Claude Usage/Resources/fr.lproj/Localizable.strings
+++ b/Claude Usage/Resources/fr.lproj/Localizable.strings
@@ -1009,7 +1009,7 @@
 "section.keep_awake_title" = "Maintien éveillé";
 "section.keep_awake_desc" = "Empêche le Mac de se mettre en veille";
 "keep_awake.manual_title" = "Contrôle manuel";
-"keep_awake.manual_desc" = "Maintient le Mac éveillé à la demande, avec minuteur facultatif";
+"keep_awake.manual_desc" = "Activez vous-même le maintien éveillé, avec minuteur facultatif";
 "keep_awake.enable" = "Maintenir le Mac éveillé";
 "keep_awake.enable_desc" = "Empêche temporairement le Mac de se mettre en veille";
 "keep_awake.status_active" = "Le Mac est actuellement maintenu éveillé";
@@ -1019,18 +1019,21 @@
 "keep_awake.duration.custom" = "Personnalisée…";
 "keep_awake.custom_hours" = "%d heures";
 "keep_awake.auto_title" = "Automatique";
-"keep_awake.auto_card_desc" = "L'activité de Claude Code contrôle la mise en veille";
+"keep_awake.auto_card_desc" = "Recommandé : ne maintient le Mac éveillé que lorsque Claude Code travaille réellement";
 "keep_awake.auto" = "Maintenir éveillé pendant que Claude Code travaille";
-"keep_awake.auto_desc" = "Maintient automatiquement le Mac éveillé tant qu'une session Claude Code est active. Installe les hooks Claude Code";
-"keep_awake.grace" = "Autoriser la veille après inactivité";
-"keep_awake.grace.immediately" = "Immédiatement";
+"keep_awake.auto_desc" = "Reste éveillé pendant les sessions Claude Code actives, puis autorise à nouveau la veille. Installe les hooks Claude Code";
+"keep_awake.grace" = "Quand Claude a terminé, rester éveillé pendant";
+"keep_awake.grace.immediately" = "Pas de délai supplémentaire";
 "keep_awake.hooks_note" = "L'activité est détectée via les hooks Claude Code dans ~/.claude/settings.json";
 "keep_awake.sleep_type" = "Prévention de la veille";
 "keep_awake.sleep_type_desc" = "Choisissez si l'écran reste allumé pendant que le Mac est maintenu éveillé";
 "keep_awake.sleep_type.system" = "L'écran peut s'éteindre";
 "keep_awake.sleep_type.display" = "Garder l'écran allumé";
-"keep_awake.lid_note" = "N'empêche pas la mise en veille lorsque le capot est fermé";
-"keep_awake.toggle_tooltip" = "Maintenir le Mac éveillé";
+"keep_awake.lid_note" = "Capot fermé, le Mac se mettra quand même en veille sauf s'il est branché et relié à un écran externe";
+"keep_awake.tooltip_off" = "Maintenir le Mac éveillé — cliquez pour activer";
+"keep_awake.tooltip_on" = "Mac maintenu éveillé — cliquez pour désactiver";
+"keep_awake.tooltip_until" = "Mac maintenu éveillé jusqu'à %@ — cliquez pour désactiver";
+"keep_awake.tooltip_auto" = "Mac maintenu éveillé — Claude Code travaille";
 
 /* Sponsor slot */
 "sponsor.slot_title" = "Cet emplacement est disponible pour les sponsors";

--- a/Claude Usage/Resources/fr.lproj/Localizable.strings
+++ b/Claude Usage/Resources/fr.lproj/Localizable.strings
@@ -1036,6 +1036,7 @@
 "keep_awake.state_on_remaining" = "Activé — %@ restant";
 "keep_awake.state_auto_active" = "Auto — Claude Code travaille";
 "keep_awake.state_auto_grace" = "Auto — Claude a terminé, éveillé encore %@";
+"keep_awake.state_auto_armed" = "Auto activé — garde le Mac éveillé quand Claude Code travaille";
 "keep_awake.hint_click_on" = "Cliquez pour garder le Mac éveillé";
 "keep_awake.hint_click_off" = "Cliquez pour désactiver";
 "keep_awake.hint_click_pause_auto" = "Cliquez pour arrêter — reprend quand Claude retravaille";

--- a/Claude Usage/Resources/fr.lproj/Localizable.strings
+++ b/Claude Usage/Resources/fr.lproj/Localizable.strings
@@ -1005,6 +1005,33 @@
 "menubar.this_month" = "Ce mois-ci";
 "menubar.total" = "Total";
 
+/* Keep Awake */
+"section.keep_awake_title" = "Maintien éveillé";
+"section.keep_awake_desc" = "Empêche le Mac de se mettre en veille";
+"keep_awake.manual_title" = "Contrôle manuel";
+"keep_awake.manual_desc" = "Maintient le Mac éveillé à la demande, avec minuteur facultatif";
+"keep_awake.enable" = "Maintenir le Mac éveillé";
+"keep_awake.enable_desc" = "Empêche temporairement le Mac de se mettre en veille";
+"keep_awake.status_active" = "Le Mac est actuellement maintenu éveillé";
+"keep_awake.remaining" = "Désactivation dans %@";
+"keep_awake.duration" = "Durée";
+"keep_awake.duration.indefinite" = "Jusqu'à désactivation";
+"keep_awake.duration.custom" = "Personnalisée…";
+"keep_awake.custom_hours" = "%d heures";
+"keep_awake.auto_title" = "Automatique";
+"keep_awake.auto_card_desc" = "L'activité de Claude Code contrôle la mise en veille";
+"keep_awake.auto" = "Maintenir éveillé pendant que Claude Code travaille";
+"keep_awake.auto_desc" = "Maintient automatiquement le Mac éveillé tant qu'une session Claude Code est active. Installe les hooks Claude Code";
+"keep_awake.grace" = "Autoriser la veille après inactivité";
+"keep_awake.grace.immediately" = "Immédiatement";
+"keep_awake.hooks_note" = "L'activité est détectée via les hooks Claude Code dans ~/.claude/settings.json";
+"keep_awake.sleep_type" = "Prévention de la veille";
+"keep_awake.sleep_type_desc" = "Choisissez si l'écran reste allumé pendant que le Mac est maintenu éveillé";
+"keep_awake.sleep_type.system" = "L'écran peut s'éteindre";
+"keep_awake.sleep_type.display" = "Garder l'écran allumé";
+"keep_awake.lid_note" = "N'empêche pas la mise en veille lorsque le capot est fermé";
+"keep_awake.toggle_tooltip" = "Maintenir le Mac éveillé";
+
 /* Sponsor slot */
 "sponsor.slot_title" = "Cet emplacement est disponible pour les sponsors";
 "sponsor.slot_cta" = "Me contacter";

--- a/Claude Usage/Resources/fr.lproj/Localizable.strings
+++ b/Claude Usage/Resources/fr.lproj/Localizable.strings
@@ -1037,9 +1037,9 @@
 "keep_awake.state_auto_active" = "Auto — Claude Code travaille";
 "keep_awake.state_auto_grace" = "Auto — Claude a terminé, éveillé encore %@";
 "keep_awake.state_auto_armed" = "Auto activé — garde le Mac éveillé quand Claude Code travaille";
-"keep_awake.hint_click_on" = "Cliquez pour garder le Mac éveillé";
+"keep_awake.hint_click_on" = "Cliquez pour activer — garde le Mac éveillé quand Claude Code travaille";
 "keep_awake.hint_click_off" = "Cliquez pour désactiver";
-"keep_awake.hint_click_pause_auto" = "Cliquez pour arrêter — reprend quand Claude retravaille";
+"keep_awake.hint_click_auto_off" = "Cliquez pour désactiver le mode auto — reste désactivé jusqu'à réactivation";
 "keep_awake.menu_for" = "Garder éveillé pendant %@";
 "keep_awake.menu_indefinite" = "Garder éveillé jusqu'à désactivation";
 "keep_awake.menu_off" = "Désactiver le maintien éveillé";

--- a/Claude Usage/Resources/fr.lproj/Localizable.strings
+++ b/Claude Usage/Resources/fr.lproj/Localizable.strings
@@ -1031,9 +1031,9 @@
 "keep_awake.state_auto_active" = "Auto — Claude Code travaille";
 "keep_awake.state_auto_grace" = "Auto — Claude a terminé, éveillé encore %@";
 "keep_awake.state_auto_armed" = "Auto activé — garde le Mac éveillé quand Claude Code travaille";
-"keep_awake.hint_click_on" = "Cliquez pour garder le Mac éveillé";
+"keep_awake.hint_click_on" = "Cliquez pour activer — garde le Mac éveillé quand Claude Code travaille";
 "keep_awake.hint_click_off" = "Cliquez pour désactiver";
-"keep_awake.hint_click_pause_auto" = "Cliquez pour arrêter — reprend quand Claude retravaille";
+"keep_awake.hint_click_auto_off" = "Cliquez pour désactiver le mode auto — reste désactivé jusqu'à réactivation";
 "keep_awake.menu_for" = "Garder éveillé pendant %@";
 "keep_awake.menu_indefinite" = "Garder éveillé jusqu'à désactivation";
 "keep_awake.menu_off" = "Désactiver le maintien éveillé";

--- a/Claude Usage/Resources/fr.lproj/Localizable.strings
+++ b/Claude Usage/Resources/fr.lproj/Localizable.strings
@@ -1016,18 +1016,26 @@
 "keep_awake.auto_card_desc" = "Recommandé : ne maintient le Mac éveillé que lorsque Claude Code travaille réellement";
 "keep_awake.auto" = "Maintenir éveillé pendant que Claude Code travaille";
 "keep_awake.auto_desc" = "Reste éveillé pendant les sessions Claude Code actives, puis autorise à nouveau la veille. Installe les hooks Claude Code";
-"keep_awake.grace" = "Quand Claude a terminé, rester éveillé pendant";
-"keep_awake.grace.immediately" = "Pas de délai supplémentaire";
+"keep_awake.grace" = "Quand Claude Code s'arrête";
+"keep_awake.grace.immediately" = "Dormir aussitôt";
+"keep_awake.grace.stay" = "Rester éveillé %@";
 "keep_awake.hooks_note" = "L'activité est détectée via les hooks Claude Code dans ~/.claude/settings.json";
 "keep_awake.sleep_type" = "Prévention de la veille";
 "keep_awake.sleep_type_desc" = "Choisissez si l'écran reste allumé pendant que le Mac est maintenu éveillé";
 "keep_awake.sleep_type.system" = "L'écran peut s'éteindre";
 "keep_awake.sleep_type.display" = "Garder l'écran allumé";
 "keep_awake.lid_note" = "Capot fermé, le Mac se mettra quand même en veille sauf s'il est branché et relié à un écran externe";
-"keep_awake.tooltip_off" = "Maintenir le Mac éveillé — cliquez pour activer";
-"keep_awake.tooltip_on" = "Mac maintenu éveillé — cliquez pour désactiver";
-"keep_awake.tooltip_until" = "Mac maintenu éveillé jusqu'à %@ — cliquez pour désactiver";
-"keep_awake.tooltip_auto" = "Mac maintenu éveillé — Claude Code travaille";
+"keep_awake.state_off" = "Désactivé";
+"keep_awake.state_on_indefinite" = "Activé — éveillé jusqu'à désactivation (∞)";
+"keep_awake.state_on_remaining" = "Activé — %@ restant";
+"keep_awake.state_auto_active" = "Auto — Claude Code travaille";
+"keep_awake.state_auto_grace" = "Auto — Claude a terminé, éveillé encore %@";
+"keep_awake.hint_click_on" = "Cliquez pour garder le Mac éveillé";
+"keep_awake.hint_click_off" = "Cliquez pour désactiver";
+"keep_awake.hint_click_pause_auto" = "Cliquez pour arrêter — reprend quand Claude retravaille";
+"keep_awake.menu_for" = "Garder éveillé pendant %@";
+"keep_awake.menu_indefinite" = "Garder éveillé jusqu'à désactivation";
+"keep_awake.menu_off" = "Désactiver le maintien éveillé";
 
 /* Sponsor slot */
 "sponsor.slot_title" = "Cet emplacement est disponible pour les sponsors";

--- a/Claude Usage/Resources/fr.lproj/Localizable.strings
+++ b/Claude Usage/Resources/fr.lproj/Localizable.strings
@@ -1030,6 +1030,7 @@
 "keep_awake.state_on_remaining" = "Activé — %@ restant";
 "keep_awake.state_auto_active" = "Auto — Claude Code travaille";
 "keep_awake.state_auto_grace" = "Auto — Claude a terminé, éveillé encore %@";
+"keep_awake.state_auto_armed" = "Auto activé — garde le Mac éveillé quand Claude Code travaille";
 "keep_awake.hint_click_on" = "Cliquez pour garder le Mac éveillé";
 "keep_awake.hint_click_off" = "Cliquez pour désactiver";
 "keep_awake.hint_click_pause_auto" = "Cliquez pour arrêter — reprend quand Claude retravaille";

--- a/Claude Usage/Resources/fr.lproj/Localizable.strings
+++ b/Claude Usage/Resources/fr.lproj/Localizable.strings
@@ -999,6 +999,33 @@
 "menubar.this_month" = "Ce mois-ci";
 "menubar.total" = "Total";
 
+/* Keep Awake */
+"section.keep_awake_title" = "Maintien éveillé";
+"section.keep_awake_desc" = "Empêche le Mac de se mettre en veille";
+"keep_awake.manual_title" = "Contrôle manuel";
+"keep_awake.manual_desc" = "Maintient le Mac éveillé à la demande, avec minuteur facultatif";
+"keep_awake.enable" = "Maintenir le Mac éveillé";
+"keep_awake.enable_desc" = "Empêche temporairement le Mac de se mettre en veille";
+"keep_awake.status_active" = "Le Mac est actuellement maintenu éveillé";
+"keep_awake.remaining" = "Désactivation dans %@";
+"keep_awake.duration" = "Durée";
+"keep_awake.duration.indefinite" = "Jusqu'à désactivation";
+"keep_awake.duration.custom" = "Personnalisée…";
+"keep_awake.custom_hours" = "%d heures";
+"keep_awake.auto_title" = "Automatique";
+"keep_awake.auto_card_desc" = "L'activité de Claude Code contrôle la mise en veille";
+"keep_awake.auto" = "Maintenir éveillé pendant que Claude Code travaille";
+"keep_awake.auto_desc" = "Maintient automatiquement le Mac éveillé tant qu'une session Claude Code est active. Installe les hooks Claude Code";
+"keep_awake.grace" = "Autoriser la veille après inactivité";
+"keep_awake.grace.immediately" = "Immédiatement";
+"keep_awake.hooks_note" = "L'activité est détectée via les hooks Claude Code dans ~/.claude/settings.json";
+"keep_awake.sleep_type" = "Prévention de la veille";
+"keep_awake.sleep_type_desc" = "Choisissez si l'écran reste allumé pendant que le Mac est maintenu éveillé";
+"keep_awake.sleep_type.system" = "L'écran peut s'éteindre";
+"keep_awake.sleep_type.display" = "Garder l'écran allumé";
+"keep_awake.lid_note" = "N'empêche pas la mise en veille lorsque le capot est fermé";
+"keep_awake.toggle_tooltip" = "Maintenir le Mac éveillé";
+
 /* Sponsor slot */
 "sponsor.slot_title" = "Cet emplacement est disponible pour les sponsors";
 "sponsor.slot_cta" = "Me contacter";

--- a/Claude Usage/Resources/fr.lproj/Localizable.strings
+++ b/Claude Usage/Resources/fr.lproj/Localizable.strings
@@ -1003,7 +1003,7 @@
 "section.keep_awake_title" = "Maintien éveillé";
 "section.keep_awake_desc" = "Empêche le Mac de se mettre en veille";
 "keep_awake.manual_title" = "Contrôle manuel";
-"keep_awake.manual_desc" = "Maintient le Mac éveillé à la demande, avec minuteur facultatif";
+"keep_awake.manual_desc" = "Activez vous-même le maintien éveillé, avec minuteur facultatif";
 "keep_awake.enable" = "Maintenir le Mac éveillé";
 "keep_awake.enable_desc" = "Empêche temporairement le Mac de se mettre en veille";
 "keep_awake.status_active" = "Le Mac est actuellement maintenu éveillé";
@@ -1013,18 +1013,21 @@
 "keep_awake.duration.custom" = "Personnalisée…";
 "keep_awake.custom_hours" = "%d heures";
 "keep_awake.auto_title" = "Automatique";
-"keep_awake.auto_card_desc" = "L'activité de Claude Code contrôle la mise en veille";
+"keep_awake.auto_card_desc" = "Recommandé : ne maintient le Mac éveillé que lorsque Claude Code travaille réellement";
 "keep_awake.auto" = "Maintenir éveillé pendant que Claude Code travaille";
-"keep_awake.auto_desc" = "Maintient automatiquement le Mac éveillé tant qu'une session Claude Code est active. Installe les hooks Claude Code";
-"keep_awake.grace" = "Autoriser la veille après inactivité";
-"keep_awake.grace.immediately" = "Immédiatement";
+"keep_awake.auto_desc" = "Reste éveillé pendant les sessions Claude Code actives, puis autorise à nouveau la veille. Installe les hooks Claude Code";
+"keep_awake.grace" = "Quand Claude a terminé, rester éveillé pendant";
+"keep_awake.grace.immediately" = "Pas de délai supplémentaire";
 "keep_awake.hooks_note" = "L'activité est détectée via les hooks Claude Code dans ~/.claude/settings.json";
 "keep_awake.sleep_type" = "Prévention de la veille";
 "keep_awake.sleep_type_desc" = "Choisissez si l'écran reste allumé pendant que le Mac est maintenu éveillé";
 "keep_awake.sleep_type.system" = "L'écran peut s'éteindre";
 "keep_awake.sleep_type.display" = "Garder l'écran allumé";
-"keep_awake.lid_note" = "N'empêche pas la mise en veille lorsque le capot est fermé";
-"keep_awake.toggle_tooltip" = "Maintenir le Mac éveillé";
+"keep_awake.lid_note" = "Capot fermé, le Mac se mettra quand même en veille sauf s'il est branché et relié à un écran externe";
+"keep_awake.tooltip_off" = "Maintenir le Mac éveillé — cliquez pour activer";
+"keep_awake.tooltip_on" = "Mac maintenu éveillé — cliquez pour désactiver";
+"keep_awake.tooltip_until" = "Mac maintenu éveillé jusqu'à %@ — cliquez pour désactiver";
+"keep_awake.tooltip_auto" = "Mac maintenu éveillé — Claude Code travaille";
 
 /* Sponsor slot */
 "sponsor.slot_title" = "Cet emplacement est disponible pour les sponsors";

--- a/Claude Usage/Resources/it.lproj/Localizable.strings
+++ b/Claude Usage/Resources/it.lproj/Localizable.strings
@@ -1059,9 +1059,9 @@
 "keep_awake.state_auto_active" = "Auto — Claude Code sta lavorando";
 "keep_awake.state_auto_grace" = "Auto — Claude ha finito, sveglio ancora per %@";
 "keep_awake.state_auto_armed" = "Auto attivo — tiene sveglio il Mac mentre Claude Code lavora";
-"keep_awake.hint_click_on" = "Fai clic per tenere sveglio il Mac";
+"keep_awake.hint_click_on" = "Fai clic per attivare — tiene sveglio il Mac mentre Claude Code lavora";
 "keep_awake.hint_click_off" = "Fai clic per spegnere";
-"keep_awake.hint_click_pause_auto" = "Fai clic per fermare — riprende quando Claude torna a lavorare";
+"keep_awake.hint_click_auto_off" = "Fai clic per disattivare la modalità automatica — resta disattivata finché non la riattivi";
 "keep_awake.menu_for" = "Tieni sveglio per %@";
 "keep_awake.menu_indefinite" = "Tieni sveglio finché non disattivato";
 "keep_awake.menu_off" = "Disattiva mantieni attivo";

--- a/Claude Usage/Resources/it.lproj/Localizable.strings
+++ b/Claude Usage/Resources/it.lproj/Localizable.strings
@@ -1031,7 +1031,7 @@
 "section.keep_awake_title" = "Mantieni attivo";
 "section.keep_awake_desc" = "Impedisce al Mac di andare in stop";
 "keep_awake.manual_title" = "Controllo manuale";
-"keep_awake.manual_desc" = "Mantiene il Mac attivo su richiesta, con timer opzionale";
+"keep_awake.manual_desc" = "Attiva tu stesso il mantenimento, con timer opzionale";
 "keep_awake.enable" = "Mantieni il Mac attivo";
 "keep_awake.enable_desc" = "Impedisce temporaneamente al Mac di andare in stop";
 "keep_awake.status_active" = "Il Mac viene mantenuto attivo";
@@ -1041,18 +1041,21 @@
 "keep_awake.duration.custom" = "Personalizzata…";
 "keep_awake.custom_hours" = "%d ore";
 "keep_awake.auto_title" = "Automatico";
-"keep_awake.auto_card_desc" = "L'attività di Claude Code controlla lo stop";
+"keep_awake.auto_card_desc" = "Consigliato: mantiene il Mac attivo solo mentre Claude Code sta effettivamente lavorando";
 "keep_awake.auto" = "Mantieni attivo mentre Claude Code lavora";
-"keep_awake.auto_desc" = "Mantiene automaticamente il Mac attivo mentre una sessione di Claude Code è in corso. Installa gli hook di Claude Code";
-"keep_awake.grace" = "Consenti lo stop dopo l'inattività";
-"keep_awake.grace.immediately" = "Immediatamente";
+"keep_awake.auto_desc" = "Resta attivo durante le sessioni di Claude Code, poi consente di nuovo lo stop. Installa gli hook di Claude Code";
+"keep_awake.grace" = "Quando Claude finisce, resta attivo per";
+"keep_awake.grace.immediately" = "Nessun tempo extra";
 "keep_awake.hooks_note" = "L'attività viene rilevata tramite gli hook di Claude Code in ~/.claude/settings.json";
 "keep_awake.sleep_type" = "Prevenzione dello stop";
 "keep_awake.sleep_type_desc" = "Scegli se lo schermo resta acceso mentre il Mac viene mantenuto attivo";
 "keep_awake.sleep_type.system" = "Lo schermo può spegnersi";
 "keep_awake.sleep_type.display" = "Mantieni lo schermo acceso";
-"keep_awake.lid_note" = "Non impedisce lo stop quando il coperchio è chiuso";
-"keep_awake.toggle_tooltip" = "Mantieni il Mac attivo";
+"keep_awake.lid_note" = "Con il coperchio chiuso il Mac andrà comunque in stop, a meno che non sia collegato alla corrente con un display esterno";
+"keep_awake.tooltip_off" = "Mantieni il Mac attivo — fai clic per attivare";
+"keep_awake.tooltip_on" = "Mac mantenuto attivo — fai clic per disattivare";
+"keep_awake.tooltip_until" = "Mac mantenuto attivo fino alle %@ — fai clic per disattivare";
+"keep_awake.tooltip_auto" = "Mac mantenuto attivo — Claude Code sta lavorando";
 
 /* Sponsor slot */
 "sponsor.slot_title" = "Questo spazio è disponibile per gli sponsor";

--- a/Claude Usage/Resources/it.lproj/Localizable.strings
+++ b/Claude Usage/Resources/it.lproj/Localizable.strings
@@ -1027,6 +1027,33 @@
 "settings.updates" = "Aggiornamenti";
 "settings.updates.description" = "Mantieni l'app aggiornata";
 
+/* Keep Awake */
+"section.keep_awake_title" = "Mantieni attivo";
+"section.keep_awake_desc" = "Impedisce al Mac di andare in stop";
+"keep_awake.manual_title" = "Controllo manuale";
+"keep_awake.manual_desc" = "Mantiene il Mac attivo su richiesta, con timer opzionale";
+"keep_awake.enable" = "Mantieni il Mac attivo";
+"keep_awake.enable_desc" = "Impedisce temporaneamente al Mac di andare in stop";
+"keep_awake.status_active" = "Il Mac viene mantenuto attivo";
+"keep_awake.remaining" = "Si disattiva tra %@";
+"keep_awake.duration" = "Durata";
+"keep_awake.duration.indefinite" = "Finché non lo disattivi";
+"keep_awake.duration.custom" = "Personalizzata…";
+"keep_awake.custom_hours" = "%d ore";
+"keep_awake.auto_title" = "Automatico";
+"keep_awake.auto_card_desc" = "L'attività di Claude Code controlla lo stop";
+"keep_awake.auto" = "Mantieni attivo mentre Claude Code lavora";
+"keep_awake.auto_desc" = "Mantiene automaticamente il Mac attivo mentre una sessione di Claude Code è in corso. Installa gli hook di Claude Code";
+"keep_awake.grace" = "Consenti lo stop dopo l'inattività";
+"keep_awake.grace.immediately" = "Immediatamente";
+"keep_awake.hooks_note" = "L'attività viene rilevata tramite gli hook di Claude Code in ~/.claude/settings.json";
+"keep_awake.sleep_type" = "Prevenzione dello stop";
+"keep_awake.sleep_type_desc" = "Scegli se lo schermo resta acceso mentre il Mac viene mantenuto attivo";
+"keep_awake.sleep_type.system" = "Lo schermo può spegnersi";
+"keep_awake.sleep_type.display" = "Mantieni lo schermo acceso";
+"keep_awake.lid_note" = "Non impedisce lo stop quando il coperchio è chiuso";
+"keep_awake.toggle_tooltip" = "Mantieni il Mac attivo";
+
 /* Sponsor slot */
 "sponsor.slot_title" = "Questo spazio è disponibile per gli sponsor";
 "sponsor.slot_cta" = "Contattami";

--- a/Claude Usage/Resources/it.lproj/Localizable.strings
+++ b/Claude Usage/Resources/it.lproj/Localizable.strings
@@ -1044,18 +1044,26 @@
 "keep_awake.auto_card_desc" = "Consigliato: mantiene il Mac attivo solo mentre Claude Code sta effettivamente lavorando";
 "keep_awake.auto" = "Mantieni attivo mentre Claude Code lavora";
 "keep_awake.auto_desc" = "Resta attivo durante le sessioni di Claude Code, poi consente di nuovo lo stop. Installa gli hook di Claude Code";
-"keep_awake.grace" = "Quando Claude finisce, resta attivo per";
-"keep_awake.grace.immediately" = "Nessun tempo extra";
+"keep_awake.grace" = "Quando Claude Code smette di lavorare";
+"keep_awake.grace.immediately" = "Dormi subito";
+"keep_awake.grace.stay" = "Resta sveglio %@";
 "keep_awake.hooks_note" = "L'attività viene rilevata tramite gli hook di Claude Code in ~/.claude/settings.json";
 "keep_awake.sleep_type" = "Prevenzione dello stop";
 "keep_awake.sleep_type_desc" = "Scegli se lo schermo resta acceso mentre il Mac viene mantenuto attivo";
 "keep_awake.sleep_type.system" = "Lo schermo può spegnersi";
 "keep_awake.sleep_type.display" = "Mantieni lo schermo acceso";
 "keep_awake.lid_note" = "Con il coperchio chiuso il Mac andrà comunque in stop, a meno che non sia collegato alla corrente con un display esterno";
-"keep_awake.tooltip_off" = "Mantieni il Mac attivo — fai clic per attivare";
-"keep_awake.tooltip_on" = "Mac mantenuto attivo — fai clic per disattivare";
-"keep_awake.tooltip_until" = "Mac mantenuto attivo fino alle %@ — fai clic per disattivare";
-"keep_awake.tooltip_auto" = "Mac mantenuto attivo — Claude Code sta lavorando";
+"keep_awake.state_off" = "Spento";
+"keep_awake.state_on_indefinite" = "Attivo — sveglio finché non lo spegni (∞)";
+"keep_awake.state_on_remaining" = "Attivo — %@ rimanenti";
+"keep_awake.state_auto_active" = "Auto — Claude Code sta lavorando";
+"keep_awake.state_auto_grace" = "Auto — Claude ha finito, sveglio ancora per %@";
+"keep_awake.hint_click_on" = "Fai clic per tenere sveglio il Mac";
+"keep_awake.hint_click_off" = "Fai clic per spegnere";
+"keep_awake.hint_click_pause_auto" = "Fai clic per fermare — riprende quando Claude torna a lavorare";
+"keep_awake.menu_for" = "Tieni sveglio per %@";
+"keep_awake.menu_indefinite" = "Tieni sveglio finché non disattivato";
+"keep_awake.menu_off" = "Disattiva mantieni attivo";
 
 /* Sponsor slot */
 "sponsor.slot_title" = "Questo spazio è disponibile per gli sponsor";

--- a/Claude Usage/Resources/it.lproj/Localizable.strings
+++ b/Claude Usage/Resources/it.lproj/Localizable.strings
@@ -1058,6 +1058,7 @@
 "keep_awake.state_on_remaining" = "Attivo — %@ rimanenti";
 "keep_awake.state_auto_active" = "Auto — Claude Code sta lavorando";
 "keep_awake.state_auto_grace" = "Auto — Claude ha finito, sveglio ancora per %@";
+"keep_awake.state_auto_armed" = "Auto attivo — tiene sveglio il Mac mentre Claude Code lavora";
 "keep_awake.hint_click_on" = "Fai clic per tenere sveglio il Mac";
 "keep_awake.hint_click_off" = "Fai clic per spegnere";
 "keep_awake.hint_click_pause_auto" = "Fai clic per fermare — riprende quando Claude torna a lavorare";

--- a/Claude Usage/Resources/it.lproj/Localizable.strings
+++ b/Claude Usage/Resources/it.lproj/Localizable.strings
@@ -1052,6 +1052,7 @@
 "keep_awake.state_on_remaining" = "Attivo — %@ rimanenti";
 "keep_awake.state_auto_active" = "Auto — Claude Code sta lavorando";
 "keep_awake.state_auto_grace" = "Auto — Claude ha finito, sveglio ancora per %@";
+"keep_awake.state_auto_armed" = "Auto attivo — tiene sveglio il Mac mentre Claude Code lavora";
 "keep_awake.hint_click_on" = "Fai clic per tenere sveglio il Mac";
 "keep_awake.hint_click_off" = "Fai clic per spegnere";
 "keep_awake.hint_click_pause_auto" = "Fai clic per fermare — riprende quando Claude torna a lavorare";

--- a/Claude Usage/Resources/it.lproj/Localizable.strings
+++ b/Claude Usage/Resources/it.lproj/Localizable.strings
@@ -1038,18 +1038,26 @@
 "keep_awake.auto_card_desc" = "Consigliato: mantiene il Mac attivo solo mentre Claude Code sta effettivamente lavorando";
 "keep_awake.auto" = "Mantieni attivo mentre Claude Code lavora";
 "keep_awake.auto_desc" = "Resta attivo durante le sessioni di Claude Code, poi consente di nuovo lo stop. Installa gli hook di Claude Code";
-"keep_awake.grace" = "Quando Claude finisce, resta attivo per";
-"keep_awake.grace.immediately" = "Nessun tempo extra";
+"keep_awake.grace" = "Quando Claude Code smette di lavorare";
+"keep_awake.grace.immediately" = "Dormi subito";
+"keep_awake.grace.stay" = "Resta sveglio %@";
 "keep_awake.hooks_note" = "L'attività viene rilevata tramite gli hook di Claude Code in ~/.claude/settings.json";
 "keep_awake.sleep_type" = "Prevenzione dello stop";
 "keep_awake.sleep_type_desc" = "Scegli se lo schermo resta acceso mentre il Mac viene mantenuto attivo";
 "keep_awake.sleep_type.system" = "Lo schermo può spegnersi";
 "keep_awake.sleep_type.display" = "Mantieni lo schermo acceso";
 "keep_awake.lid_note" = "Con il coperchio chiuso il Mac andrà comunque in stop, a meno che non sia collegato alla corrente con un display esterno";
-"keep_awake.tooltip_off" = "Mantieni il Mac attivo — fai clic per attivare";
-"keep_awake.tooltip_on" = "Mac mantenuto attivo — fai clic per disattivare";
-"keep_awake.tooltip_until" = "Mac mantenuto attivo fino alle %@ — fai clic per disattivare";
-"keep_awake.tooltip_auto" = "Mac mantenuto attivo — Claude Code sta lavorando";
+"keep_awake.state_off" = "Spento";
+"keep_awake.state_on_indefinite" = "Attivo — sveglio finché non lo spegni (∞)";
+"keep_awake.state_on_remaining" = "Attivo — %@ rimanenti";
+"keep_awake.state_auto_active" = "Auto — Claude Code sta lavorando";
+"keep_awake.state_auto_grace" = "Auto — Claude ha finito, sveglio ancora per %@";
+"keep_awake.hint_click_on" = "Fai clic per tenere sveglio il Mac";
+"keep_awake.hint_click_off" = "Fai clic per spegnere";
+"keep_awake.hint_click_pause_auto" = "Fai clic per fermare — riprende quando Claude torna a lavorare";
+"keep_awake.menu_for" = "Tieni sveglio per %@";
+"keep_awake.menu_indefinite" = "Tieni sveglio finché non disattivato";
+"keep_awake.menu_off" = "Disattiva mantieni attivo";
 
 /* Sponsor slot */
 "sponsor.slot_title" = "Questo spazio è disponibile per gli sponsor";

--- a/Claude Usage/Resources/it.lproj/Localizable.strings
+++ b/Claude Usage/Resources/it.lproj/Localizable.strings
@@ -1053,9 +1053,9 @@
 "keep_awake.state_auto_active" = "Auto — Claude Code sta lavorando";
 "keep_awake.state_auto_grace" = "Auto — Claude ha finito, sveglio ancora per %@";
 "keep_awake.state_auto_armed" = "Auto attivo — tiene sveglio il Mac mentre Claude Code lavora";
-"keep_awake.hint_click_on" = "Fai clic per tenere sveglio il Mac";
+"keep_awake.hint_click_on" = "Fai clic per attivare — tiene sveglio il Mac mentre Claude Code lavora";
 "keep_awake.hint_click_off" = "Fai clic per spegnere";
-"keep_awake.hint_click_pause_auto" = "Fai clic per fermare — riprende quando Claude torna a lavorare";
+"keep_awake.hint_click_auto_off" = "Fai clic per disattivare la modalità automatica — resta disattivata finché non la riattivi";
 "keep_awake.menu_for" = "Tieni sveglio per %@";
 "keep_awake.menu_indefinite" = "Tieni sveglio finché non disattivato";
 "keep_awake.menu_off" = "Disattiva mantieni attivo";

--- a/Claude Usage/Resources/it.lproj/Localizable.strings
+++ b/Claude Usage/Resources/it.lproj/Localizable.strings
@@ -1025,7 +1025,7 @@
 "section.keep_awake_title" = "Mantieni attivo";
 "section.keep_awake_desc" = "Impedisce al Mac di andare in stop";
 "keep_awake.manual_title" = "Controllo manuale";
-"keep_awake.manual_desc" = "Mantiene il Mac attivo su richiesta, con timer opzionale";
+"keep_awake.manual_desc" = "Attiva tu stesso il mantenimento, con timer opzionale";
 "keep_awake.enable" = "Mantieni il Mac attivo";
 "keep_awake.enable_desc" = "Impedisce temporaneamente al Mac di andare in stop";
 "keep_awake.status_active" = "Il Mac viene mantenuto attivo";
@@ -1035,18 +1035,21 @@
 "keep_awake.duration.custom" = "Personalizzata…";
 "keep_awake.custom_hours" = "%d ore";
 "keep_awake.auto_title" = "Automatico";
-"keep_awake.auto_card_desc" = "L'attività di Claude Code controlla lo stop";
+"keep_awake.auto_card_desc" = "Consigliato: mantiene il Mac attivo solo mentre Claude Code sta effettivamente lavorando";
 "keep_awake.auto" = "Mantieni attivo mentre Claude Code lavora";
-"keep_awake.auto_desc" = "Mantiene automaticamente il Mac attivo mentre una sessione di Claude Code è in corso. Installa gli hook di Claude Code";
-"keep_awake.grace" = "Consenti lo stop dopo l'inattività";
-"keep_awake.grace.immediately" = "Immediatamente";
+"keep_awake.auto_desc" = "Resta attivo durante le sessioni di Claude Code, poi consente di nuovo lo stop. Installa gli hook di Claude Code";
+"keep_awake.grace" = "Quando Claude finisce, resta attivo per";
+"keep_awake.grace.immediately" = "Nessun tempo extra";
 "keep_awake.hooks_note" = "L'attività viene rilevata tramite gli hook di Claude Code in ~/.claude/settings.json";
 "keep_awake.sleep_type" = "Prevenzione dello stop";
 "keep_awake.sleep_type_desc" = "Scegli se lo schermo resta acceso mentre il Mac viene mantenuto attivo";
 "keep_awake.sleep_type.system" = "Lo schermo può spegnersi";
 "keep_awake.sleep_type.display" = "Mantieni lo schermo acceso";
-"keep_awake.lid_note" = "Non impedisce lo stop quando il coperchio è chiuso";
-"keep_awake.toggle_tooltip" = "Mantieni il Mac attivo";
+"keep_awake.lid_note" = "Con il coperchio chiuso il Mac andrà comunque in stop, a meno che non sia collegato alla corrente con un display esterno";
+"keep_awake.tooltip_off" = "Mantieni il Mac attivo — fai clic per attivare";
+"keep_awake.tooltip_on" = "Mac mantenuto attivo — fai clic per disattivare";
+"keep_awake.tooltip_until" = "Mac mantenuto attivo fino alle %@ — fai clic per disattivare";
+"keep_awake.tooltip_auto" = "Mac mantenuto attivo — Claude Code sta lavorando";
 
 /* Sponsor slot */
 "sponsor.slot_title" = "Questo spazio è disponibile per gli sponsor";

--- a/Claude Usage/Resources/it.lproj/Localizable.strings
+++ b/Claude Usage/Resources/it.lproj/Localizable.strings
@@ -1021,6 +1021,33 @@
 "settings.updates" = "Aggiornamenti";
 "settings.updates.description" = "Mantieni l'app aggiornata";
 
+/* Keep Awake */
+"section.keep_awake_title" = "Mantieni attivo";
+"section.keep_awake_desc" = "Impedisce al Mac di andare in stop";
+"keep_awake.manual_title" = "Controllo manuale";
+"keep_awake.manual_desc" = "Mantiene il Mac attivo su richiesta, con timer opzionale";
+"keep_awake.enable" = "Mantieni il Mac attivo";
+"keep_awake.enable_desc" = "Impedisce temporaneamente al Mac di andare in stop";
+"keep_awake.status_active" = "Il Mac viene mantenuto attivo";
+"keep_awake.remaining" = "Si disattiva tra %@";
+"keep_awake.duration" = "Durata";
+"keep_awake.duration.indefinite" = "Finché non lo disattivi";
+"keep_awake.duration.custom" = "Personalizzata…";
+"keep_awake.custom_hours" = "%d ore";
+"keep_awake.auto_title" = "Automatico";
+"keep_awake.auto_card_desc" = "L'attività di Claude Code controlla lo stop";
+"keep_awake.auto" = "Mantieni attivo mentre Claude Code lavora";
+"keep_awake.auto_desc" = "Mantiene automaticamente il Mac attivo mentre una sessione di Claude Code è in corso. Installa gli hook di Claude Code";
+"keep_awake.grace" = "Consenti lo stop dopo l'inattività";
+"keep_awake.grace.immediately" = "Immediatamente";
+"keep_awake.hooks_note" = "L'attività viene rilevata tramite gli hook di Claude Code in ~/.claude/settings.json";
+"keep_awake.sleep_type" = "Prevenzione dello stop";
+"keep_awake.sleep_type_desc" = "Scegli se lo schermo resta acceso mentre il Mac viene mantenuto attivo";
+"keep_awake.sleep_type.system" = "Lo schermo può spegnersi";
+"keep_awake.sleep_type.display" = "Mantieni lo schermo acceso";
+"keep_awake.lid_note" = "Non impedisce lo stop quando il coperchio è chiuso";
+"keep_awake.toggle_tooltip" = "Mantieni il Mac attivo";
+
 /* Sponsor slot */
 "sponsor.slot_title" = "Questo spazio è disponibile per gli sponsor";
 "sponsor.slot_cta" = "Contattami";

--- a/Claude Usage/Resources/ja.lproj/Localizable.strings
+++ b/Claude Usage/Resources/ja.lproj/Localizable.strings
@@ -1058,6 +1058,7 @@
 "keep_awake.state_on_remaining" = "オン — 残り%@";
 "keep_awake.state_auto_active" = "自動 — Claude Codeが作業中";
 "keep_awake.state_auto_grace" = "自動 — Claudeの作業終了、あと%@スリープしません";
+"keep_awake.state_auto_armed" = "自動オン — Claude Codeの作業中はMacをスリープさせません";
 "keep_awake.hint_click_on" = "クリックでMacをスリープさせない";
 "keep_awake.hint_click_off" = "クリックでオフ";
 "keep_awake.hint_click_pause_auto" = "クリックで停止 — Claudeが再び作業すると再開します";

--- a/Claude Usage/Resources/ja.lproj/Localizable.strings
+++ b/Claude Usage/Resources/ja.lproj/Localizable.strings
@@ -1059,9 +1059,9 @@
 "keep_awake.state_auto_active" = "自動 — Claude Codeが作業中";
 "keep_awake.state_auto_grace" = "自動 — Claudeの作業終了、あと%@スリープしません";
 "keep_awake.state_auto_armed" = "自動オン — Claude Codeの作業中はMacをスリープさせません";
-"keep_awake.hint_click_on" = "クリックでMacをスリープさせない";
+"keep_awake.hint_click_on" = "クリックでオン — Claude Codeの作業中はMacをスリープさせません";
 "keep_awake.hint_click_off" = "クリックでオフ";
-"keep_awake.hint_click_pause_auto" = "クリックで停止 — Claudeが再び作業すると再開します";
+"keep_awake.hint_click_auto_off" = "クリックで自動モードをオフ — 再びオンにするまでオフのままです";
 "keep_awake.menu_for" = "%@スリープさせない";
 "keep_awake.menu_indefinite" = "オフにするまでスリープさせない";
 "keep_awake.menu_off" = "スリープ防止をオフ";

--- a/Claude Usage/Resources/ja.lproj/Localizable.strings
+++ b/Claude Usage/Resources/ja.lproj/Localizable.strings
@@ -1044,18 +1044,26 @@
 "keep_awake.auto_card_desc" = "おすすめ:Claude Codeが実際に作業している間だけMacをスリープさせません";
 "keep_awake.auto" = "Claude Codeの作業中はスリープさせない";
 "keep_awake.auto_desc" = "Claude Codeのセッション中はスリープせず、終了後は再びスリープを許可します。Claude Codeのフックをインストールします";
-"keep_awake.grace" = "Claudeの作業終了後、スリープ防止を続ける時間";
-"keep_awake.grace.immediately" = "延長なし";
+"keep_awake.grace" = "Claude Codeの作業終了後";
+"keep_awake.grace.immediately" = "すぐにスリープ";
+"keep_awake.grace.stay" = "%@スリープしない";
 "keep_awake.hooks_note" = "アクティビティは ~/.claude/settings.json のClaude Codeフックで検出されます";
 "keep_awake.sleep_type" = "スリープ防止の種類";
 "keep_awake.sleep_type_desc" = "スリープ防止中に画面を点けたままにするかを選択します";
 "keep_awake.sleep_type.system" = "画面はスリープ可";
 "keep_awake.sleep_type.display" = "画面を点けたまま";
 "keep_awake.lid_note" = "蓋を閉じると、電源接続中に外部ディスプレイを使用している場合を除き、Macはスリープします";
-"keep_awake.tooltip_off" = "Macをスリープさせない — クリックでオン";
-"keep_awake.tooltip_on" = "Macのスリープを防止中 — クリックでオフ";
-"keep_awake.tooltip_until" = "%@までスリープを防止中 — クリックでオフ";
-"keep_awake.tooltip_auto" = "スリープ防止中 — Claude Codeが作業しています";
+"keep_awake.state_off" = "オフ";
+"keep_awake.state_on_indefinite" = "オン — オフにするまでスリープしません(∞)";
+"keep_awake.state_on_remaining" = "オン — 残り%@";
+"keep_awake.state_auto_active" = "自動 — Claude Codeが作業中";
+"keep_awake.state_auto_grace" = "自動 — Claudeの作業終了、あと%@スリープしません";
+"keep_awake.hint_click_on" = "クリックでMacをスリープさせない";
+"keep_awake.hint_click_off" = "クリックでオフ";
+"keep_awake.hint_click_pause_auto" = "クリックで停止 — Claudeが再び作業すると再開します";
+"keep_awake.menu_for" = "%@スリープさせない";
+"keep_awake.menu_indefinite" = "オフにするまでスリープさせない";
+"keep_awake.menu_off" = "スリープ防止をオフ";
 
 /* Sponsor slot */
 "sponsor.slot_title" = "スポンサー募集中のスペースです";

--- a/Claude Usage/Resources/ja.lproj/Localizable.strings
+++ b/Claude Usage/Resources/ja.lproj/Localizable.strings
@@ -1031,7 +1031,7 @@
 "section.keep_awake_title" = "スリープ防止";
 "section.keep_awake_desc" = "Macがスリープするのを防ぎます";
 "keep_awake.manual_title" = "手動コントロール";
-"keep_awake.manual_desc" = "必要なときにMacをスリープさせないようにします(タイマー設定可)";
+"keep_awake.manual_desc" = "必要なときに自分でオンにできます(タイマー設定可)";
 "keep_awake.enable" = "Macをスリープさせない";
 "keep_awake.enable_desc" = "一時的にMacがスリープするのを防ぎます";
 "keep_awake.status_active" = "現在Macのスリープを防止中です";
@@ -1041,18 +1041,21 @@
 "keep_awake.duration.custom" = "カスタム…";
 "keep_awake.custom_hours" = "%d時間";
 "keep_awake.auto_title" = "自動";
-"keep_awake.auto_card_desc" = "Claude Codeの動作に合わせてスリープを防止します";
+"keep_awake.auto_card_desc" = "おすすめ:Claude Codeが実際に作業している間だけMacをスリープさせません";
 "keep_awake.auto" = "Claude Codeの作業中はスリープさせない";
-"keep_awake.auto_desc" = "Claude Codeのセッションがアクティブな間、自動的にMacをスリープさせません。Claude Codeのフックをインストールします";
-"keep_awake.grace" = "非アクティブ後にスリープを許可";
-"keep_awake.grace.immediately" = "すぐに";
+"keep_awake.auto_desc" = "Claude Codeのセッション中はスリープせず、終了後は再びスリープを許可します。Claude Codeのフックをインストールします";
+"keep_awake.grace" = "Claudeの作業終了後、スリープ防止を続ける時間";
+"keep_awake.grace.immediately" = "延長なし";
 "keep_awake.hooks_note" = "アクティビティは ~/.claude/settings.json のClaude Codeフックで検出されます";
 "keep_awake.sleep_type" = "スリープ防止の種類";
 "keep_awake.sleep_type_desc" = "スリープ防止中に画面を点けたままにするかを選択します";
 "keep_awake.sleep_type.system" = "画面はスリープ可";
 "keep_awake.sleep_type.display" = "画面を点けたまま";
-"keep_awake.lid_note" = "蓋を閉じた場合のスリープは防げません";
-"keep_awake.toggle_tooltip" = "Macをスリープさせない";
+"keep_awake.lid_note" = "蓋を閉じると、電源接続中に外部ディスプレイを使用している場合を除き、Macはスリープします";
+"keep_awake.tooltip_off" = "Macをスリープさせない — クリックでオン";
+"keep_awake.tooltip_on" = "Macのスリープを防止中 — クリックでオフ";
+"keep_awake.tooltip_until" = "%@までスリープを防止中 — クリックでオフ";
+"keep_awake.tooltip_auto" = "スリープ防止中 — Claude Codeが作業しています";
 
 /* Sponsor slot */
 "sponsor.slot_title" = "スポンサー募集中のスペースです";

--- a/Claude Usage/Resources/ja.lproj/Localizable.strings
+++ b/Claude Usage/Resources/ja.lproj/Localizable.strings
@@ -1027,6 +1027,33 @@
 "menubar.this_month" = "今月";
 "menubar.total" = "合計";
 
+/* Keep Awake */
+"section.keep_awake_title" = "スリープ防止";
+"section.keep_awake_desc" = "Macがスリープするのを防ぎます";
+"keep_awake.manual_title" = "手動コントロール";
+"keep_awake.manual_desc" = "必要なときにMacをスリープさせないようにします(タイマー設定可)";
+"keep_awake.enable" = "Macをスリープさせない";
+"keep_awake.enable_desc" = "一時的にMacがスリープするのを防ぎます";
+"keep_awake.status_active" = "現在Macのスリープを防止中です";
+"keep_awake.remaining" = "%@後にオフになります";
+"keep_awake.duration" = "継続時間";
+"keep_awake.duration.indefinite" = "オフにするまで";
+"keep_awake.duration.custom" = "カスタム…";
+"keep_awake.custom_hours" = "%d時間";
+"keep_awake.auto_title" = "自動";
+"keep_awake.auto_card_desc" = "Claude Codeの動作に合わせてスリープを防止します";
+"keep_awake.auto" = "Claude Codeの作業中はスリープさせない";
+"keep_awake.auto_desc" = "Claude Codeのセッションがアクティブな間、自動的にMacをスリープさせません。Claude Codeのフックをインストールします";
+"keep_awake.grace" = "非アクティブ後にスリープを許可";
+"keep_awake.grace.immediately" = "すぐに";
+"keep_awake.hooks_note" = "アクティビティは ~/.claude/settings.json のClaude Codeフックで検出されます";
+"keep_awake.sleep_type" = "スリープ防止の種類";
+"keep_awake.sleep_type_desc" = "スリープ防止中に画面を点けたままにするかを選択します";
+"keep_awake.sleep_type.system" = "画面はスリープ可";
+"keep_awake.sleep_type.display" = "画面を点けたまま";
+"keep_awake.lid_note" = "蓋を閉じた場合のスリープは防げません";
+"keep_awake.toggle_tooltip" = "Macをスリープさせない";
+
 /* Sponsor slot */
 "sponsor.slot_title" = "スポンサー募集中のスペースです";
 "sponsor.slot_cta" = "お問い合わせ";

--- a/Claude Usage/Resources/ja.lproj/Localizable.strings
+++ b/Claude Usage/Resources/ja.lproj/Localizable.strings
@@ -1038,18 +1038,26 @@
 "keep_awake.auto_card_desc" = "おすすめ:Claude Codeが実際に作業している間だけMacをスリープさせません";
 "keep_awake.auto" = "Claude Codeの作業中はスリープさせない";
 "keep_awake.auto_desc" = "Claude Codeのセッション中はスリープせず、終了後は再びスリープを許可します。Claude Codeのフックをインストールします";
-"keep_awake.grace" = "Claudeの作業終了後、スリープ防止を続ける時間";
-"keep_awake.grace.immediately" = "延長なし";
+"keep_awake.grace" = "Claude Codeの作業終了後";
+"keep_awake.grace.immediately" = "すぐにスリープ";
+"keep_awake.grace.stay" = "%@スリープしない";
 "keep_awake.hooks_note" = "アクティビティは ~/.claude/settings.json のClaude Codeフックで検出されます";
 "keep_awake.sleep_type" = "スリープ防止の種類";
 "keep_awake.sleep_type_desc" = "スリープ防止中に画面を点けたままにするかを選択します";
 "keep_awake.sleep_type.system" = "画面はスリープ可";
 "keep_awake.sleep_type.display" = "画面を点けたまま";
 "keep_awake.lid_note" = "蓋を閉じると、電源接続中に外部ディスプレイを使用している場合を除き、Macはスリープします";
-"keep_awake.tooltip_off" = "Macをスリープさせない — クリックでオン";
-"keep_awake.tooltip_on" = "Macのスリープを防止中 — クリックでオフ";
-"keep_awake.tooltip_until" = "%@までスリープを防止中 — クリックでオフ";
-"keep_awake.tooltip_auto" = "スリープ防止中 — Claude Codeが作業しています";
+"keep_awake.state_off" = "オフ";
+"keep_awake.state_on_indefinite" = "オン — オフにするまでスリープしません(∞)";
+"keep_awake.state_on_remaining" = "オン — 残り%@";
+"keep_awake.state_auto_active" = "自動 — Claude Codeが作業中";
+"keep_awake.state_auto_grace" = "自動 — Claudeの作業終了、あと%@スリープしません";
+"keep_awake.hint_click_on" = "クリックでMacをスリープさせない";
+"keep_awake.hint_click_off" = "クリックでオフ";
+"keep_awake.hint_click_pause_auto" = "クリックで停止 — Claudeが再び作業すると再開します";
+"keep_awake.menu_for" = "%@スリープさせない";
+"keep_awake.menu_indefinite" = "オフにするまでスリープさせない";
+"keep_awake.menu_off" = "スリープ防止をオフ";
 
 /* Sponsor slot */
 "sponsor.slot_title" = "スポンサー募集中のスペースです";

--- a/Claude Usage/Resources/ja.lproj/Localizable.strings
+++ b/Claude Usage/Resources/ja.lproj/Localizable.strings
@@ -1053,9 +1053,9 @@
 "keep_awake.state_auto_active" = "自動 — Claude Codeが作業中";
 "keep_awake.state_auto_grace" = "自動 — Claudeの作業終了、あと%@スリープしません";
 "keep_awake.state_auto_armed" = "自動オン — Claude Codeの作業中はMacをスリープさせません";
-"keep_awake.hint_click_on" = "クリックでMacをスリープさせない";
+"keep_awake.hint_click_on" = "クリックでオン — Claude Codeの作業中はMacをスリープさせません";
 "keep_awake.hint_click_off" = "クリックでオフ";
-"keep_awake.hint_click_pause_auto" = "クリックで停止 — Claudeが再び作業すると再開します";
+"keep_awake.hint_click_auto_off" = "クリックで自動モードをオフ — 再びオンにするまでオフのままです";
 "keep_awake.menu_for" = "%@スリープさせない";
 "keep_awake.menu_indefinite" = "オフにするまでスリープさせない";
 "keep_awake.menu_off" = "スリープ防止をオフ";

--- a/Claude Usage/Resources/ja.lproj/Localizable.strings
+++ b/Claude Usage/Resources/ja.lproj/Localizable.strings
@@ -1052,6 +1052,7 @@
 "keep_awake.state_on_remaining" = "オン — 残り%@";
 "keep_awake.state_auto_active" = "自動 — Claude Codeが作業中";
 "keep_awake.state_auto_grace" = "自動 — Claudeの作業終了、あと%@スリープしません";
+"keep_awake.state_auto_armed" = "自動オン — Claude Codeの作業中はMacをスリープさせません";
 "keep_awake.hint_click_on" = "クリックでMacをスリープさせない";
 "keep_awake.hint_click_off" = "クリックでオフ";
 "keep_awake.hint_click_pause_auto" = "クリックで停止 — Claudeが再び作業すると再開します";

--- a/Claude Usage/Resources/ja.lproj/Localizable.strings
+++ b/Claude Usage/Resources/ja.lproj/Localizable.strings
@@ -1021,6 +1021,33 @@
 "menubar.this_month" = "今月";
 "menubar.total" = "合計";
 
+/* Keep Awake */
+"section.keep_awake_title" = "スリープ防止";
+"section.keep_awake_desc" = "Macがスリープするのを防ぎます";
+"keep_awake.manual_title" = "手動コントロール";
+"keep_awake.manual_desc" = "必要なときにMacをスリープさせないようにします(タイマー設定可)";
+"keep_awake.enable" = "Macをスリープさせない";
+"keep_awake.enable_desc" = "一時的にMacがスリープするのを防ぎます";
+"keep_awake.status_active" = "現在Macのスリープを防止中です";
+"keep_awake.remaining" = "%@後にオフになります";
+"keep_awake.duration" = "継続時間";
+"keep_awake.duration.indefinite" = "オフにするまで";
+"keep_awake.duration.custom" = "カスタム…";
+"keep_awake.custom_hours" = "%d時間";
+"keep_awake.auto_title" = "自動";
+"keep_awake.auto_card_desc" = "Claude Codeの動作に合わせてスリープを防止します";
+"keep_awake.auto" = "Claude Codeの作業中はスリープさせない";
+"keep_awake.auto_desc" = "Claude Codeのセッションがアクティブな間、自動的にMacをスリープさせません。Claude Codeのフックをインストールします";
+"keep_awake.grace" = "非アクティブ後にスリープを許可";
+"keep_awake.grace.immediately" = "すぐに";
+"keep_awake.hooks_note" = "アクティビティは ~/.claude/settings.json のClaude Codeフックで検出されます";
+"keep_awake.sleep_type" = "スリープ防止の種類";
+"keep_awake.sleep_type_desc" = "スリープ防止中に画面を点けたままにするかを選択します";
+"keep_awake.sleep_type.system" = "画面はスリープ可";
+"keep_awake.sleep_type.display" = "画面を点けたまま";
+"keep_awake.lid_note" = "蓋を閉じた場合のスリープは防げません";
+"keep_awake.toggle_tooltip" = "Macをスリープさせない";
+
 /* Sponsor slot */
 "sponsor.slot_title" = "スポンサー募集中のスペースです";
 "sponsor.slot_cta" = "お問い合わせ";

--- a/Claude Usage/Resources/ja.lproj/Localizable.strings
+++ b/Claude Usage/Resources/ja.lproj/Localizable.strings
@@ -1025,7 +1025,7 @@
 "section.keep_awake_title" = "スリープ防止";
 "section.keep_awake_desc" = "Macがスリープするのを防ぎます";
 "keep_awake.manual_title" = "手動コントロール";
-"keep_awake.manual_desc" = "必要なときにMacをスリープさせないようにします(タイマー設定可)";
+"keep_awake.manual_desc" = "必要なときに自分でオンにできます(タイマー設定可)";
 "keep_awake.enable" = "Macをスリープさせない";
 "keep_awake.enable_desc" = "一時的にMacがスリープするのを防ぎます";
 "keep_awake.status_active" = "現在Macのスリープを防止中です";
@@ -1035,18 +1035,21 @@
 "keep_awake.duration.custom" = "カスタム…";
 "keep_awake.custom_hours" = "%d時間";
 "keep_awake.auto_title" = "自動";
-"keep_awake.auto_card_desc" = "Claude Codeの動作に合わせてスリープを防止します";
+"keep_awake.auto_card_desc" = "おすすめ:Claude Codeが実際に作業している間だけMacをスリープさせません";
 "keep_awake.auto" = "Claude Codeの作業中はスリープさせない";
-"keep_awake.auto_desc" = "Claude Codeのセッションがアクティブな間、自動的にMacをスリープさせません。Claude Codeのフックをインストールします";
-"keep_awake.grace" = "非アクティブ後にスリープを許可";
-"keep_awake.grace.immediately" = "すぐに";
+"keep_awake.auto_desc" = "Claude Codeのセッション中はスリープせず、終了後は再びスリープを許可します。Claude Codeのフックをインストールします";
+"keep_awake.grace" = "Claudeの作業終了後、スリープ防止を続ける時間";
+"keep_awake.grace.immediately" = "延長なし";
 "keep_awake.hooks_note" = "アクティビティは ~/.claude/settings.json のClaude Codeフックで検出されます";
 "keep_awake.sleep_type" = "スリープ防止の種類";
 "keep_awake.sleep_type_desc" = "スリープ防止中に画面を点けたままにするかを選択します";
 "keep_awake.sleep_type.system" = "画面はスリープ可";
 "keep_awake.sleep_type.display" = "画面を点けたまま";
-"keep_awake.lid_note" = "蓋を閉じた場合のスリープは防げません";
-"keep_awake.toggle_tooltip" = "Macをスリープさせない";
+"keep_awake.lid_note" = "蓋を閉じると、電源接続中に外部ディスプレイを使用している場合を除き、Macはスリープします";
+"keep_awake.tooltip_off" = "Macをスリープさせない — クリックでオン";
+"keep_awake.tooltip_on" = "Macのスリープを防止中 — クリックでオフ";
+"keep_awake.tooltip_until" = "%@までスリープを防止中 — クリックでオフ";
+"keep_awake.tooltip_auto" = "スリープ防止中 — Claude Codeが作業しています";
 
 /* Sponsor slot */
 "sponsor.slot_title" = "スポンサー募集中のスペースです";

--- a/Claude Usage/Resources/ko.lproj/Localizable.strings
+++ b/Claude Usage/Resources/ko.lproj/Localizable.strings
@@ -1036,6 +1036,33 @@
 "menubar.this_month" = "이번 달";
 "menubar.total" = "합계";
 
+/* Keep Awake */
+"section.keep_awake_title" = "깨어 있기";
+"section.keep_awake_desc" = "Mac이 잠자기 상태로 전환되는 것을 방지합니다";
+"keep_awake.manual_title" = "수동 제어";
+"keep_awake.manual_desc" = "필요할 때 Mac을 깨어 있게 유지합니다(타이머 선택 가능)";
+"keep_awake.enable" = "Mac 깨어 있게 유지";
+"keep_awake.enable_desc" = "일시적으로 Mac이 잠자기 상태로 전환되는 것을 방지합니다";
+"keep_awake.status_active" = "현재 Mac을 깨어 있게 유지하는 중입니다";
+"keep_awake.remaining" = "%@ 후 꺼짐";
+"keep_awake.duration" = "지속 시간";
+"keep_awake.duration.indefinite" = "끌 때까지";
+"keep_awake.duration.custom" = "사용자화…";
+"keep_awake.custom_hours" = "%d시간";
+"keep_awake.auto_title" = "자동";
+"keep_awake.auto_card_desc" = "Claude Code 활동에 따라 잠자기를 방지합니다";
+"keep_awake.auto" = "Claude Code 작업 중 깨어 있게 유지";
+"keep_awake.auto_desc" = "Claude Code 세션이 활성화된 동안 자동으로 Mac을 깨어 있게 유지합니다. Claude Code 훅을 설치합니다";
+"keep_awake.grace" = "비활성 후 잠자기 허용";
+"keep_awake.grace.immediately" = "즉시";
+"keep_awake.hooks_note" = "활동은 ~/.claude/settings.json의 Claude Code 훅을 통해 감지됩니다";
+"keep_awake.sleep_type" = "잠자기 방지 방식";
+"keep_awake.sleep_type_desc" = "Mac을 깨어 있게 유지하는 동안 화면을 켜 둘지 선택합니다";
+"keep_awake.sleep_type.system" = "화면은 꺼질 수 있음";
+"keep_awake.sleep_type.display" = "화면 켜 두기";
+"keep_awake.lid_note" = "덮개를 닫으면 잠자기를 방지할 수 없습니다";
+"keep_awake.toggle_tooltip" = "Mac 깨어 있게 유지";
+
 /* Sponsor slot */
 "sponsor.slot_title" = "이 공간은 스폰서에게 제공됩니다";
 "sponsor.slot_cta" = "문의하기";

--- a/Claude Usage/Resources/ko.lproj/Localizable.strings
+++ b/Claude Usage/Resources/ko.lproj/Localizable.strings
@@ -1068,9 +1068,9 @@
 "keep_awake.state_auto_active" = "자동 — Claude Code 작업 중";
 "keep_awake.state_auto_grace" = "자동 — Claude 작업 완료, %@ 더 깨어 있음";
 "keep_awake.state_auto_armed" = "자동 켜짐 — Claude Code 작업 중 Mac을 깨어 있게 유지합니다";
-"keep_awake.hint_click_on" = "클릭하여 Mac을 깨어 있게 유지";
+"keep_awake.hint_click_on" = "클릭하여 켜기 — Claude Code 작업 중 Mac을 깨어 있게 유지합니다";
 "keep_awake.hint_click_off" = "클릭하여 끄기";
-"keep_awake.hint_click_pause_auto" = "클릭하여 지금 중지 — Claude가 다시 작업하면 재개됩니다";
+"keep_awake.hint_click_auto_off" = "클릭하여 자동 모드 끄기 — 다시 켤 때까지 꺼진 상태로 유지됩니다";
 "keep_awake.menu_for" = "%@ 동안 깨어 있기";
 "keep_awake.menu_indefinite" = "끌 때까지 깨어 있기";
 "keep_awake.menu_off" = "깨어 있기 끄기";

--- a/Claude Usage/Resources/ko.lproj/Localizable.strings
+++ b/Claude Usage/Resources/ko.lproj/Localizable.strings
@@ -1067,6 +1067,7 @@
 "keep_awake.state_on_remaining" = "켜짐 — %@ 남음";
 "keep_awake.state_auto_active" = "자동 — Claude Code 작업 중";
 "keep_awake.state_auto_grace" = "자동 — Claude 작업 완료, %@ 더 깨어 있음";
+"keep_awake.state_auto_armed" = "자동 켜짐 — Claude Code 작업 중 Mac을 깨어 있게 유지합니다";
 "keep_awake.hint_click_on" = "클릭하여 Mac을 깨어 있게 유지";
 "keep_awake.hint_click_off" = "클릭하여 끄기";
 "keep_awake.hint_click_pause_auto" = "클릭하여 지금 중지 — Claude가 다시 작업하면 재개됩니다";

--- a/Claude Usage/Resources/ko.lproj/Localizable.strings
+++ b/Claude Usage/Resources/ko.lproj/Localizable.strings
@@ -1040,7 +1040,7 @@
 "section.keep_awake_title" = "깨어 있기";
 "section.keep_awake_desc" = "Mac이 잠자기 상태로 전환되는 것을 방지합니다";
 "keep_awake.manual_title" = "수동 제어";
-"keep_awake.manual_desc" = "필요할 때 Mac을 깨어 있게 유지합니다(타이머 선택 가능)";
+"keep_awake.manual_desc" = "필요할 때 직접 켤 수 있습니다(타이머 선택 가능)";
 "keep_awake.enable" = "Mac 깨어 있게 유지";
 "keep_awake.enable_desc" = "일시적으로 Mac이 잠자기 상태로 전환되는 것을 방지합니다";
 "keep_awake.status_active" = "현재 Mac을 깨어 있게 유지하는 중입니다";
@@ -1050,18 +1050,21 @@
 "keep_awake.duration.custom" = "사용자화…";
 "keep_awake.custom_hours" = "%d시간";
 "keep_awake.auto_title" = "자동";
-"keep_awake.auto_card_desc" = "Claude Code 활동에 따라 잠자기를 방지합니다";
+"keep_awake.auto_card_desc" = "추천: Claude Code가 실제로 작업하는 동안에만 Mac을 깨어 있게 유지합니다";
 "keep_awake.auto" = "Claude Code 작업 중 깨어 있게 유지";
-"keep_awake.auto_desc" = "Claude Code 세션이 활성화된 동안 자동으로 Mac을 깨어 있게 유지합니다. Claude Code 훅을 설치합니다";
-"keep_awake.grace" = "비활성 후 잠자기 허용";
-"keep_awake.grace.immediately" = "즉시";
+"keep_awake.auto_desc" = "Claude Code 세션 중에는 깨어 있고, 끝나면 다시 잠자기를 허용합니다. Claude Code 훅을 설치합니다";
+"keep_awake.grace" = "Claude 작업이 끝난 후 깨어 있는 시간";
+"keep_awake.grace.immediately" = "추가 시간 없음";
 "keep_awake.hooks_note" = "활동은 ~/.claude/settings.json의 Claude Code 훅을 통해 감지됩니다";
 "keep_awake.sleep_type" = "잠자기 방지 방식";
 "keep_awake.sleep_type_desc" = "Mac을 깨어 있게 유지하는 동안 화면을 켜 둘지 선택합니다";
 "keep_awake.sleep_type.system" = "화면은 꺼질 수 있음";
 "keep_awake.sleep_type.display" = "화면 켜 두기";
-"keep_awake.lid_note" = "덮개를 닫으면 잠자기를 방지할 수 없습니다";
-"keep_awake.toggle_tooltip" = "Mac 깨어 있게 유지";
+"keep_awake.lid_note" = "덮개를 닫으면 전원에 연결된 상태로 외장 디스플레이를 사용하지 않는 한 Mac이 잠자기 상태가 됩니다";
+"keep_awake.tooltip_off" = "Mac 깨어 있게 유지 — 클릭하여 켜기";
+"keep_awake.tooltip_on" = "Mac을 깨어 있게 유지하는 중 — 클릭하여 끄기";
+"keep_awake.tooltip_until" = "%@까지 깨어 있게 유지 — 클릭하여 끄기";
+"keep_awake.tooltip_auto" = "Mac을 깨어 있게 유지하는 중 — Claude Code 작업 중";
 
 /* Sponsor slot */
 "sponsor.slot_title" = "이 공간은 스폰서에게 제공됩니다";

--- a/Claude Usage/Resources/ko.lproj/Localizable.strings
+++ b/Claude Usage/Resources/ko.lproj/Localizable.strings
@@ -1053,18 +1053,26 @@
 "keep_awake.auto_card_desc" = "추천: Claude Code가 실제로 작업하는 동안에만 Mac을 깨어 있게 유지합니다";
 "keep_awake.auto" = "Claude Code 작업 중 깨어 있게 유지";
 "keep_awake.auto_desc" = "Claude Code 세션 중에는 깨어 있고, 끝나면 다시 잠자기를 허용합니다. Claude Code 훅을 설치합니다";
-"keep_awake.grace" = "Claude 작업이 끝난 후 깨어 있는 시간";
-"keep_awake.grace.immediately" = "추가 시간 없음";
+"keep_awake.grace" = "Claude Code 작업이 끝나면";
+"keep_awake.grace.immediately" = "바로 잠자기";
+"keep_awake.grace.stay" = "%@ 깨어 있기";
 "keep_awake.hooks_note" = "활동은 ~/.claude/settings.json의 Claude Code 훅을 통해 감지됩니다";
 "keep_awake.sleep_type" = "잠자기 방지 방식";
 "keep_awake.sleep_type_desc" = "Mac을 깨어 있게 유지하는 동안 화면을 켜 둘지 선택합니다";
 "keep_awake.sleep_type.system" = "화면은 꺼질 수 있음";
 "keep_awake.sleep_type.display" = "화면 켜 두기";
 "keep_awake.lid_note" = "덮개를 닫으면 전원에 연결된 상태로 외장 디스플레이를 사용하지 않는 한 Mac이 잠자기 상태가 됩니다";
-"keep_awake.tooltip_off" = "Mac 깨어 있게 유지 — 클릭하여 켜기";
-"keep_awake.tooltip_on" = "Mac을 깨어 있게 유지하는 중 — 클릭하여 끄기";
-"keep_awake.tooltip_until" = "%@까지 깨어 있게 유지 — 클릭하여 끄기";
-"keep_awake.tooltip_auto" = "Mac을 깨어 있게 유지하는 중 — Claude Code 작업 중";
+"keep_awake.state_off" = "꺼짐";
+"keep_awake.state_on_indefinite" = "켜짐 — 끌 때까지 깨어 있음 (∞)";
+"keep_awake.state_on_remaining" = "켜짐 — %@ 남음";
+"keep_awake.state_auto_active" = "자동 — Claude Code 작업 중";
+"keep_awake.state_auto_grace" = "자동 — Claude 작업 완료, %@ 더 깨어 있음";
+"keep_awake.hint_click_on" = "클릭하여 Mac을 깨어 있게 유지";
+"keep_awake.hint_click_off" = "클릭하여 끄기";
+"keep_awake.hint_click_pause_auto" = "클릭하여 지금 중지 — Claude가 다시 작업하면 재개됩니다";
+"keep_awake.menu_for" = "%@ 동안 깨어 있기";
+"keep_awake.menu_indefinite" = "끌 때까지 깨어 있기";
+"keep_awake.menu_off" = "깨어 있기 끄기";
 
 /* Sponsor slot */
 "sponsor.slot_title" = "이 공간은 스폰서에게 제공됩니다";

--- a/Claude Usage/Resources/ko.lproj/Localizable.strings
+++ b/Claude Usage/Resources/ko.lproj/Localizable.strings
@@ -1062,9 +1062,9 @@
 "keep_awake.state_auto_active" = "자동 — Claude Code 작업 중";
 "keep_awake.state_auto_grace" = "자동 — Claude 작업 완료, %@ 더 깨어 있음";
 "keep_awake.state_auto_armed" = "자동 켜짐 — Claude Code 작업 중 Mac을 깨어 있게 유지합니다";
-"keep_awake.hint_click_on" = "클릭하여 Mac을 깨어 있게 유지";
+"keep_awake.hint_click_on" = "클릭하여 켜기 — Claude Code 작업 중 Mac을 깨어 있게 유지합니다";
 "keep_awake.hint_click_off" = "클릭하여 끄기";
-"keep_awake.hint_click_pause_auto" = "클릭하여 지금 중지 — Claude가 다시 작업하면 재개됩니다";
+"keep_awake.hint_click_auto_off" = "클릭하여 자동 모드 끄기 — 다시 켤 때까지 꺼진 상태로 유지됩니다";
 "keep_awake.menu_for" = "%@ 동안 깨어 있기";
 "keep_awake.menu_indefinite" = "끌 때까지 깨어 있기";
 "keep_awake.menu_off" = "깨어 있기 끄기";

--- a/Claude Usage/Resources/ko.lproj/Localizable.strings
+++ b/Claude Usage/Resources/ko.lproj/Localizable.strings
@@ -1061,6 +1061,7 @@
 "keep_awake.state_on_remaining" = "켜짐 — %@ 남음";
 "keep_awake.state_auto_active" = "자동 — Claude Code 작업 중";
 "keep_awake.state_auto_grace" = "자동 — Claude 작업 완료, %@ 더 깨어 있음";
+"keep_awake.state_auto_armed" = "자동 켜짐 — Claude Code 작업 중 Mac을 깨어 있게 유지합니다";
 "keep_awake.hint_click_on" = "클릭하여 Mac을 깨어 있게 유지";
 "keep_awake.hint_click_off" = "클릭하여 끄기";
 "keep_awake.hint_click_pause_auto" = "클릭하여 지금 중지 — Claude가 다시 작업하면 재개됩니다";

--- a/Claude Usage/Resources/ko.lproj/Localizable.strings
+++ b/Claude Usage/Resources/ko.lproj/Localizable.strings
@@ -1047,18 +1047,26 @@
 "keep_awake.auto_card_desc" = "추천: Claude Code가 실제로 작업하는 동안에만 Mac을 깨어 있게 유지합니다";
 "keep_awake.auto" = "Claude Code 작업 중 깨어 있게 유지";
 "keep_awake.auto_desc" = "Claude Code 세션 중에는 깨어 있고, 끝나면 다시 잠자기를 허용합니다. Claude Code 훅을 설치합니다";
-"keep_awake.grace" = "Claude 작업이 끝난 후 깨어 있는 시간";
-"keep_awake.grace.immediately" = "추가 시간 없음";
+"keep_awake.grace" = "Claude Code 작업이 끝나면";
+"keep_awake.grace.immediately" = "바로 잠자기";
+"keep_awake.grace.stay" = "%@ 깨어 있기";
 "keep_awake.hooks_note" = "활동은 ~/.claude/settings.json의 Claude Code 훅을 통해 감지됩니다";
 "keep_awake.sleep_type" = "잠자기 방지 방식";
 "keep_awake.sleep_type_desc" = "Mac을 깨어 있게 유지하는 동안 화면을 켜 둘지 선택합니다";
 "keep_awake.sleep_type.system" = "화면은 꺼질 수 있음";
 "keep_awake.sleep_type.display" = "화면 켜 두기";
 "keep_awake.lid_note" = "덮개를 닫으면 전원에 연결된 상태로 외장 디스플레이를 사용하지 않는 한 Mac이 잠자기 상태가 됩니다";
-"keep_awake.tooltip_off" = "Mac 깨어 있게 유지 — 클릭하여 켜기";
-"keep_awake.tooltip_on" = "Mac을 깨어 있게 유지하는 중 — 클릭하여 끄기";
-"keep_awake.tooltip_until" = "%@까지 깨어 있게 유지 — 클릭하여 끄기";
-"keep_awake.tooltip_auto" = "Mac을 깨어 있게 유지하는 중 — Claude Code 작업 중";
+"keep_awake.state_off" = "꺼짐";
+"keep_awake.state_on_indefinite" = "켜짐 — 끌 때까지 깨어 있음 (∞)";
+"keep_awake.state_on_remaining" = "켜짐 — %@ 남음";
+"keep_awake.state_auto_active" = "자동 — Claude Code 작업 중";
+"keep_awake.state_auto_grace" = "자동 — Claude 작업 완료, %@ 더 깨어 있음";
+"keep_awake.hint_click_on" = "클릭하여 Mac을 깨어 있게 유지";
+"keep_awake.hint_click_off" = "클릭하여 끄기";
+"keep_awake.hint_click_pause_auto" = "클릭하여 지금 중지 — Claude가 다시 작업하면 재개됩니다";
+"keep_awake.menu_for" = "%@ 동안 깨어 있기";
+"keep_awake.menu_indefinite" = "끌 때까지 깨어 있기";
+"keep_awake.menu_off" = "깨어 있기 끄기";
 
 /* Sponsor slot */
 "sponsor.slot_title" = "이 공간은 스폰서에게 제공됩니다";

--- a/Claude Usage/Resources/ko.lproj/Localizable.strings
+++ b/Claude Usage/Resources/ko.lproj/Localizable.strings
@@ -1034,7 +1034,7 @@
 "section.keep_awake_title" = "깨어 있기";
 "section.keep_awake_desc" = "Mac이 잠자기 상태로 전환되는 것을 방지합니다";
 "keep_awake.manual_title" = "수동 제어";
-"keep_awake.manual_desc" = "필요할 때 Mac을 깨어 있게 유지합니다(타이머 선택 가능)";
+"keep_awake.manual_desc" = "필요할 때 직접 켤 수 있습니다(타이머 선택 가능)";
 "keep_awake.enable" = "Mac 깨어 있게 유지";
 "keep_awake.enable_desc" = "일시적으로 Mac이 잠자기 상태로 전환되는 것을 방지합니다";
 "keep_awake.status_active" = "현재 Mac을 깨어 있게 유지하는 중입니다";
@@ -1044,18 +1044,21 @@
 "keep_awake.duration.custom" = "사용자화…";
 "keep_awake.custom_hours" = "%d시간";
 "keep_awake.auto_title" = "자동";
-"keep_awake.auto_card_desc" = "Claude Code 활동에 따라 잠자기를 방지합니다";
+"keep_awake.auto_card_desc" = "추천: Claude Code가 실제로 작업하는 동안에만 Mac을 깨어 있게 유지합니다";
 "keep_awake.auto" = "Claude Code 작업 중 깨어 있게 유지";
-"keep_awake.auto_desc" = "Claude Code 세션이 활성화된 동안 자동으로 Mac을 깨어 있게 유지합니다. Claude Code 훅을 설치합니다";
-"keep_awake.grace" = "비활성 후 잠자기 허용";
-"keep_awake.grace.immediately" = "즉시";
+"keep_awake.auto_desc" = "Claude Code 세션 중에는 깨어 있고, 끝나면 다시 잠자기를 허용합니다. Claude Code 훅을 설치합니다";
+"keep_awake.grace" = "Claude 작업이 끝난 후 깨어 있는 시간";
+"keep_awake.grace.immediately" = "추가 시간 없음";
 "keep_awake.hooks_note" = "활동은 ~/.claude/settings.json의 Claude Code 훅을 통해 감지됩니다";
 "keep_awake.sleep_type" = "잠자기 방지 방식";
 "keep_awake.sleep_type_desc" = "Mac을 깨어 있게 유지하는 동안 화면을 켜 둘지 선택합니다";
 "keep_awake.sleep_type.system" = "화면은 꺼질 수 있음";
 "keep_awake.sleep_type.display" = "화면 켜 두기";
-"keep_awake.lid_note" = "덮개를 닫으면 잠자기를 방지할 수 없습니다";
-"keep_awake.toggle_tooltip" = "Mac 깨어 있게 유지";
+"keep_awake.lid_note" = "덮개를 닫으면 전원에 연결된 상태로 외장 디스플레이를 사용하지 않는 한 Mac이 잠자기 상태가 됩니다";
+"keep_awake.tooltip_off" = "Mac 깨어 있게 유지 — 클릭하여 켜기";
+"keep_awake.tooltip_on" = "Mac을 깨어 있게 유지하는 중 — 클릭하여 끄기";
+"keep_awake.tooltip_until" = "%@까지 깨어 있게 유지 — 클릭하여 끄기";
+"keep_awake.tooltip_auto" = "Mac을 깨어 있게 유지하는 중 — Claude Code 작업 중";
 
 /* Sponsor slot */
 "sponsor.slot_title" = "이 공간은 스폰서에게 제공됩니다";

--- a/Claude Usage/Resources/ko.lproj/Localizable.strings
+++ b/Claude Usage/Resources/ko.lproj/Localizable.strings
@@ -1030,6 +1030,33 @@
 "menubar.this_month" = "이번 달";
 "menubar.total" = "합계";
 
+/* Keep Awake */
+"section.keep_awake_title" = "깨어 있기";
+"section.keep_awake_desc" = "Mac이 잠자기 상태로 전환되는 것을 방지합니다";
+"keep_awake.manual_title" = "수동 제어";
+"keep_awake.manual_desc" = "필요할 때 Mac을 깨어 있게 유지합니다(타이머 선택 가능)";
+"keep_awake.enable" = "Mac 깨어 있게 유지";
+"keep_awake.enable_desc" = "일시적으로 Mac이 잠자기 상태로 전환되는 것을 방지합니다";
+"keep_awake.status_active" = "현재 Mac을 깨어 있게 유지하는 중입니다";
+"keep_awake.remaining" = "%@ 후 꺼짐";
+"keep_awake.duration" = "지속 시간";
+"keep_awake.duration.indefinite" = "끌 때까지";
+"keep_awake.duration.custom" = "사용자화…";
+"keep_awake.custom_hours" = "%d시간";
+"keep_awake.auto_title" = "자동";
+"keep_awake.auto_card_desc" = "Claude Code 활동에 따라 잠자기를 방지합니다";
+"keep_awake.auto" = "Claude Code 작업 중 깨어 있게 유지";
+"keep_awake.auto_desc" = "Claude Code 세션이 활성화된 동안 자동으로 Mac을 깨어 있게 유지합니다. Claude Code 훅을 설치합니다";
+"keep_awake.grace" = "비활성 후 잠자기 허용";
+"keep_awake.grace.immediately" = "즉시";
+"keep_awake.hooks_note" = "활동은 ~/.claude/settings.json의 Claude Code 훅을 통해 감지됩니다";
+"keep_awake.sleep_type" = "잠자기 방지 방식";
+"keep_awake.sleep_type_desc" = "Mac을 깨어 있게 유지하는 동안 화면을 켜 둘지 선택합니다";
+"keep_awake.sleep_type.system" = "화면은 꺼질 수 있음";
+"keep_awake.sleep_type.display" = "화면 켜 두기";
+"keep_awake.lid_note" = "덮개를 닫으면 잠자기를 방지할 수 없습니다";
+"keep_awake.toggle_tooltip" = "Mac 깨어 있게 유지";
+
 /* Sponsor slot */
 "sponsor.slot_title" = "이 공간은 스폰서에게 제공됩니다";
 "sponsor.slot_cta" = "문의하기";

--- a/Claude Usage/Resources/pt-BR.lproj/Localizable.strings
+++ b/Claude Usage/Resources/pt-BR.lproj/Localizable.strings
@@ -1031,7 +1031,7 @@
 "section.keep_awake_title" = "Manter acordado";
 "section.keep_awake_desc" = "Impede que o Mac entre em repouso";
 "keep_awake.manual_title" = "Controle manual";
-"keep_awake.manual_desc" = "Mantém o Mac acordado quando você quiser, com timer opcional";
+"keep_awake.manual_desc" = "Ative você mesmo, com timer opcional";
 "keep_awake.enable" = "Manter o Mac acordado";
 "keep_awake.enable_desc" = "Impede temporariamente que o Mac entre em repouso";
 "keep_awake.status_active" = "Mantendo o Mac acordado";
@@ -1041,18 +1041,21 @@
 "keep_awake.duration.custom" = "Personalizada…";
 "keep_awake.custom_hours" = "%d horas";
 "keep_awake.auto_title" = "Automático";
-"keep_awake.auto_card_desc" = "A atividade do Claude Code controla o repouso";
+"keep_awake.auto_card_desc" = "Recomendado: mantém o Mac acordado apenas enquanto o Claude Code está realmente trabalhando";
 "keep_awake.auto" = "Manter acordado enquanto o Claude Code trabalha";
-"keep_awake.auto_desc" = "Mantém o Mac acordado automaticamente enquanto uma sessão do Claude Code estiver ativa. Instala hooks do Claude Code";
-"keep_awake.grace" = "Permitir repouso após inatividade";
-"keep_awake.grace.immediately" = "Imediatamente";
+"keep_awake.auto_desc" = "Fica acordado durante sessões ativas do Claude Code e depois volta a permitir o repouso. Instala hooks do Claude Code";
+"keep_awake.grace" = "Quando o Claude terminar, ficar acordado por";
+"keep_awake.grace.immediately" = "Sem tempo extra";
 "keep_awake.hooks_note" = "A atividade é detectada por hooks do Claude Code em ~/.claude/settings.json";
 "keep_awake.sleep_type" = "Prevenção de repouso";
 "keep_awake.sleep_type_desc" = "Escolha se a tela permanece ligada enquanto o Mac fica acordado";
 "keep_awake.sleep_type.system" = "A tela pode desligar";
 "keep_awake.sleep_type.display" = "Manter a tela ligada";
-"keep_awake.lid_note" = "Não impede o repouso com a tampa fechada";
-"keep_awake.toggle_tooltip" = "Manter o Mac acordado";
+"keep_awake.lid_note" = "Com a tampa fechada, o Mac ainda entrará em repouso, a menos que esteja na tomada usando um monitor externo";
+"keep_awake.tooltip_off" = "Manter o Mac acordado — clique para ativar";
+"keep_awake.tooltip_on" = "Mantendo o Mac acordado — clique para desativar";
+"keep_awake.tooltip_until" = "Mantendo o Mac acordado até %@ — clique para desativar";
+"keep_awake.tooltip_auto" = "Mantendo o Mac acordado — o Claude Code está trabalhando";
 
 /* Sponsor slot */
 "sponsor.slot_title" = "Este espaço está disponível para patrocinadores";

--- a/Claude Usage/Resources/pt-BR.lproj/Localizable.strings
+++ b/Claude Usage/Resources/pt-BR.lproj/Localizable.strings
@@ -1058,6 +1058,7 @@
 "keep_awake.state_on_remaining" = "Ativado — faltam %@";
 "keep_awake.state_auto_active" = "Auto — o Claude Code está trabalhando";
 "keep_awake.state_auto_grace" = "Auto — Claude terminou, acordado por mais %@";
+"keep_awake.state_auto_armed" = "Auto ativado — mantém o Mac acordado enquanto o Claude Code trabalha";
 "keep_awake.hint_click_on" = "Clique para manter o Mac acordado";
 "keep_awake.hint_click_off" = "Clique para desativar";
 "keep_awake.hint_click_pause_auto" = "Clique para parar — retoma quando o Claude voltar a trabalhar";

--- a/Claude Usage/Resources/pt-BR.lproj/Localizable.strings
+++ b/Claude Usage/Resources/pt-BR.lproj/Localizable.strings
@@ -1059,9 +1059,9 @@
 "keep_awake.state_auto_active" = "Auto — o Claude Code está trabalhando";
 "keep_awake.state_auto_grace" = "Auto — Claude terminou, acordado por mais %@";
 "keep_awake.state_auto_armed" = "Auto ativado — mantém o Mac acordado enquanto o Claude Code trabalha";
-"keep_awake.hint_click_on" = "Clique para manter o Mac acordado";
+"keep_awake.hint_click_on" = "Clique para ativar — mantém o Mac acordado enquanto o Claude Code trabalha";
 "keep_awake.hint_click_off" = "Clique para desativar";
-"keep_awake.hint_click_pause_auto" = "Clique para parar — retoma quando o Claude voltar a trabalhar";
+"keep_awake.hint_click_auto_off" = "Clique para desativar o modo automático — permanece desativado até você reativá-lo";
 "keep_awake.menu_for" = "Manter acordado por %@";
 "keep_awake.menu_indefinite" = "Manter acordado até desativar";
 "keep_awake.menu_off" = "Desativar manter acordado";

--- a/Claude Usage/Resources/pt-BR.lproj/Localizable.strings
+++ b/Claude Usage/Resources/pt-BR.lproj/Localizable.strings
@@ -1027,6 +1027,33 @@
 "multiprofile.style_dots" = "Pontos";
 "multiprofile.style_percent" = "Porcentagem";
 
+/* Keep Awake */
+"section.keep_awake_title" = "Manter acordado";
+"section.keep_awake_desc" = "Impede que o Mac entre em repouso";
+"keep_awake.manual_title" = "Controle manual";
+"keep_awake.manual_desc" = "Mantém o Mac acordado quando você quiser, com timer opcional";
+"keep_awake.enable" = "Manter o Mac acordado";
+"keep_awake.enable_desc" = "Impede temporariamente que o Mac entre em repouso";
+"keep_awake.status_active" = "Mantendo o Mac acordado";
+"keep_awake.remaining" = "Desativa em %@";
+"keep_awake.duration" = "Duração";
+"keep_awake.duration.indefinite" = "Até desativar";
+"keep_awake.duration.custom" = "Personalizada…";
+"keep_awake.custom_hours" = "%d horas";
+"keep_awake.auto_title" = "Automático";
+"keep_awake.auto_card_desc" = "A atividade do Claude Code controla o repouso";
+"keep_awake.auto" = "Manter acordado enquanto o Claude Code trabalha";
+"keep_awake.auto_desc" = "Mantém o Mac acordado automaticamente enquanto uma sessão do Claude Code estiver ativa. Instala hooks do Claude Code";
+"keep_awake.grace" = "Permitir repouso após inatividade";
+"keep_awake.grace.immediately" = "Imediatamente";
+"keep_awake.hooks_note" = "A atividade é detectada por hooks do Claude Code em ~/.claude/settings.json";
+"keep_awake.sleep_type" = "Prevenção de repouso";
+"keep_awake.sleep_type_desc" = "Escolha se a tela permanece ligada enquanto o Mac fica acordado";
+"keep_awake.sleep_type.system" = "A tela pode desligar";
+"keep_awake.sleep_type.display" = "Manter a tela ligada";
+"keep_awake.lid_note" = "Não impede o repouso com a tampa fechada";
+"keep_awake.toggle_tooltip" = "Manter o Mac acordado";
+
 /* Sponsor slot */
 "sponsor.slot_title" = "Este espaço está disponível para patrocinadores";
 "sponsor.slot_cta" = "Entre em contato";

--- a/Claude Usage/Resources/pt-BR.lproj/Localizable.strings
+++ b/Claude Usage/Resources/pt-BR.lproj/Localizable.strings
@@ -1044,18 +1044,26 @@
 "keep_awake.auto_card_desc" = "Recomendado: mantém o Mac acordado apenas enquanto o Claude Code está realmente trabalhando";
 "keep_awake.auto" = "Manter acordado enquanto o Claude Code trabalha";
 "keep_awake.auto_desc" = "Fica acordado durante sessões ativas do Claude Code e depois volta a permitir o repouso. Instala hooks do Claude Code";
-"keep_awake.grace" = "Quando o Claude terminar, ficar acordado por";
-"keep_awake.grace.immediately" = "Sem tempo extra";
+"keep_awake.grace" = "Quando o Claude Code parar de trabalhar";
+"keep_awake.grace.immediately" = "Dormir imediatamente";
+"keep_awake.grace.stay" = "Ficar acordado %@";
 "keep_awake.hooks_note" = "A atividade é detectada por hooks do Claude Code em ~/.claude/settings.json";
 "keep_awake.sleep_type" = "Prevenção de repouso";
 "keep_awake.sleep_type_desc" = "Escolha se a tela permanece ligada enquanto o Mac fica acordado";
 "keep_awake.sleep_type.system" = "A tela pode desligar";
 "keep_awake.sleep_type.display" = "Manter a tela ligada";
 "keep_awake.lid_note" = "Com a tampa fechada, o Mac ainda entrará em repouso, a menos que esteja na tomada usando um monitor externo";
-"keep_awake.tooltip_off" = "Manter o Mac acordado — clique para ativar";
-"keep_awake.tooltip_on" = "Mantendo o Mac acordado — clique para desativar";
-"keep_awake.tooltip_until" = "Mantendo o Mac acordado até %@ — clique para desativar";
-"keep_awake.tooltip_auto" = "Mantendo o Mac acordado — o Claude Code está trabalhando";
+"keep_awake.state_off" = "Desativado";
+"keep_awake.state_on_indefinite" = "Ativado — acordado até você desativar (∞)";
+"keep_awake.state_on_remaining" = "Ativado — faltam %@";
+"keep_awake.state_auto_active" = "Auto — o Claude Code está trabalhando";
+"keep_awake.state_auto_grace" = "Auto — Claude terminou, acordado por mais %@";
+"keep_awake.hint_click_on" = "Clique para manter o Mac acordado";
+"keep_awake.hint_click_off" = "Clique para desativar";
+"keep_awake.hint_click_pause_auto" = "Clique para parar — retoma quando o Claude voltar a trabalhar";
+"keep_awake.menu_for" = "Manter acordado por %@";
+"keep_awake.menu_indefinite" = "Manter acordado até desativar";
+"keep_awake.menu_off" = "Desativar manter acordado";
 
 /* Sponsor slot */
 "sponsor.slot_title" = "Este espaço está disponível para patrocinadores";

--- a/Claude Usage/Resources/pt-BR.lproj/Localizable.strings
+++ b/Claude Usage/Resources/pt-BR.lproj/Localizable.strings
@@ -1038,18 +1038,26 @@
 "keep_awake.auto_card_desc" = "Recomendado: mantém o Mac acordado apenas enquanto o Claude Code está realmente trabalhando";
 "keep_awake.auto" = "Manter acordado enquanto o Claude Code trabalha";
 "keep_awake.auto_desc" = "Fica acordado durante sessões ativas do Claude Code e depois volta a permitir o repouso. Instala hooks do Claude Code";
-"keep_awake.grace" = "Quando o Claude terminar, ficar acordado por";
-"keep_awake.grace.immediately" = "Sem tempo extra";
+"keep_awake.grace" = "Quando o Claude Code parar de trabalhar";
+"keep_awake.grace.immediately" = "Dormir imediatamente";
+"keep_awake.grace.stay" = "Ficar acordado %@";
 "keep_awake.hooks_note" = "A atividade é detectada por hooks do Claude Code em ~/.claude/settings.json";
 "keep_awake.sleep_type" = "Prevenção de repouso";
 "keep_awake.sleep_type_desc" = "Escolha se a tela permanece ligada enquanto o Mac fica acordado";
 "keep_awake.sleep_type.system" = "A tela pode desligar";
 "keep_awake.sleep_type.display" = "Manter a tela ligada";
 "keep_awake.lid_note" = "Com a tampa fechada, o Mac ainda entrará em repouso, a menos que esteja na tomada usando um monitor externo";
-"keep_awake.tooltip_off" = "Manter o Mac acordado — clique para ativar";
-"keep_awake.tooltip_on" = "Mantendo o Mac acordado — clique para desativar";
-"keep_awake.tooltip_until" = "Mantendo o Mac acordado até %@ — clique para desativar";
-"keep_awake.tooltip_auto" = "Mantendo o Mac acordado — o Claude Code está trabalhando";
+"keep_awake.state_off" = "Desativado";
+"keep_awake.state_on_indefinite" = "Ativado — acordado até você desativar (∞)";
+"keep_awake.state_on_remaining" = "Ativado — faltam %@";
+"keep_awake.state_auto_active" = "Auto — o Claude Code está trabalhando";
+"keep_awake.state_auto_grace" = "Auto — Claude terminou, acordado por mais %@";
+"keep_awake.hint_click_on" = "Clique para manter o Mac acordado";
+"keep_awake.hint_click_off" = "Clique para desativar";
+"keep_awake.hint_click_pause_auto" = "Clique para parar — retoma quando o Claude voltar a trabalhar";
+"keep_awake.menu_for" = "Manter acordado por %@";
+"keep_awake.menu_indefinite" = "Manter acordado até desativar";
+"keep_awake.menu_off" = "Desativar manter acordado";
 
 /* Sponsor slot */
 "sponsor.slot_title" = "Este espaço está disponível para patrocinadores";

--- a/Claude Usage/Resources/pt-BR.lproj/Localizable.strings
+++ b/Claude Usage/Resources/pt-BR.lproj/Localizable.strings
@@ -1053,9 +1053,9 @@
 "keep_awake.state_auto_active" = "Auto — o Claude Code está trabalhando";
 "keep_awake.state_auto_grace" = "Auto — Claude terminou, acordado por mais %@";
 "keep_awake.state_auto_armed" = "Auto ativado — mantém o Mac acordado enquanto o Claude Code trabalha";
-"keep_awake.hint_click_on" = "Clique para manter o Mac acordado";
+"keep_awake.hint_click_on" = "Clique para ativar — mantém o Mac acordado enquanto o Claude Code trabalha";
 "keep_awake.hint_click_off" = "Clique para desativar";
-"keep_awake.hint_click_pause_auto" = "Clique para parar — retoma quando o Claude voltar a trabalhar";
+"keep_awake.hint_click_auto_off" = "Clique para desativar o modo automático — permanece desativado até você reativá-lo";
 "keep_awake.menu_for" = "Manter acordado por %@";
 "keep_awake.menu_indefinite" = "Manter acordado até desativar";
 "keep_awake.menu_off" = "Desativar manter acordado";

--- a/Claude Usage/Resources/pt-BR.lproj/Localizable.strings
+++ b/Claude Usage/Resources/pt-BR.lproj/Localizable.strings
@@ -1021,6 +1021,33 @@
 "multiprofile.style_dots" = "Pontos";
 "multiprofile.style_percent" = "Porcentagem";
 
+/* Keep Awake */
+"section.keep_awake_title" = "Manter acordado";
+"section.keep_awake_desc" = "Impede que o Mac entre em repouso";
+"keep_awake.manual_title" = "Controle manual";
+"keep_awake.manual_desc" = "Mantém o Mac acordado quando você quiser, com timer opcional";
+"keep_awake.enable" = "Manter o Mac acordado";
+"keep_awake.enable_desc" = "Impede temporariamente que o Mac entre em repouso";
+"keep_awake.status_active" = "Mantendo o Mac acordado";
+"keep_awake.remaining" = "Desativa em %@";
+"keep_awake.duration" = "Duração";
+"keep_awake.duration.indefinite" = "Até desativar";
+"keep_awake.duration.custom" = "Personalizada…";
+"keep_awake.custom_hours" = "%d horas";
+"keep_awake.auto_title" = "Automático";
+"keep_awake.auto_card_desc" = "A atividade do Claude Code controla o repouso";
+"keep_awake.auto" = "Manter acordado enquanto o Claude Code trabalha";
+"keep_awake.auto_desc" = "Mantém o Mac acordado automaticamente enquanto uma sessão do Claude Code estiver ativa. Instala hooks do Claude Code";
+"keep_awake.grace" = "Permitir repouso após inatividade";
+"keep_awake.grace.immediately" = "Imediatamente";
+"keep_awake.hooks_note" = "A atividade é detectada por hooks do Claude Code em ~/.claude/settings.json";
+"keep_awake.sleep_type" = "Prevenção de repouso";
+"keep_awake.sleep_type_desc" = "Escolha se a tela permanece ligada enquanto o Mac fica acordado";
+"keep_awake.sleep_type.system" = "A tela pode desligar";
+"keep_awake.sleep_type.display" = "Manter a tela ligada";
+"keep_awake.lid_note" = "Não impede o repouso com a tampa fechada";
+"keep_awake.toggle_tooltip" = "Manter o Mac acordado";
+
 /* Sponsor slot */
 "sponsor.slot_title" = "Este espaço está disponível para patrocinadores";
 "sponsor.slot_cta" = "Entre em contato";

--- a/Claude Usage/Resources/pt-BR.lproj/Localizable.strings
+++ b/Claude Usage/Resources/pt-BR.lproj/Localizable.strings
@@ -1025,7 +1025,7 @@
 "section.keep_awake_title" = "Manter acordado";
 "section.keep_awake_desc" = "Impede que o Mac entre em repouso";
 "keep_awake.manual_title" = "Controle manual";
-"keep_awake.manual_desc" = "Mantém o Mac acordado quando você quiser, com timer opcional";
+"keep_awake.manual_desc" = "Ative você mesmo, com timer opcional";
 "keep_awake.enable" = "Manter o Mac acordado";
 "keep_awake.enable_desc" = "Impede temporariamente que o Mac entre em repouso";
 "keep_awake.status_active" = "Mantendo o Mac acordado";
@@ -1035,18 +1035,21 @@
 "keep_awake.duration.custom" = "Personalizada…";
 "keep_awake.custom_hours" = "%d horas";
 "keep_awake.auto_title" = "Automático";
-"keep_awake.auto_card_desc" = "A atividade do Claude Code controla o repouso";
+"keep_awake.auto_card_desc" = "Recomendado: mantém o Mac acordado apenas enquanto o Claude Code está realmente trabalhando";
 "keep_awake.auto" = "Manter acordado enquanto o Claude Code trabalha";
-"keep_awake.auto_desc" = "Mantém o Mac acordado automaticamente enquanto uma sessão do Claude Code estiver ativa. Instala hooks do Claude Code";
-"keep_awake.grace" = "Permitir repouso após inatividade";
-"keep_awake.grace.immediately" = "Imediatamente";
+"keep_awake.auto_desc" = "Fica acordado durante sessões ativas do Claude Code e depois volta a permitir o repouso. Instala hooks do Claude Code";
+"keep_awake.grace" = "Quando o Claude terminar, ficar acordado por";
+"keep_awake.grace.immediately" = "Sem tempo extra";
 "keep_awake.hooks_note" = "A atividade é detectada por hooks do Claude Code em ~/.claude/settings.json";
 "keep_awake.sleep_type" = "Prevenção de repouso";
 "keep_awake.sleep_type_desc" = "Escolha se a tela permanece ligada enquanto o Mac fica acordado";
 "keep_awake.sleep_type.system" = "A tela pode desligar";
 "keep_awake.sleep_type.display" = "Manter a tela ligada";
-"keep_awake.lid_note" = "Não impede o repouso com a tampa fechada";
-"keep_awake.toggle_tooltip" = "Manter o Mac acordado";
+"keep_awake.lid_note" = "Com a tampa fechada, o Mac ainda entrará em repouso, a menos que esteja na tomada usando um monitor externo";
+"keep_awake.tooltip_off" = "Manter o Mac acordado — clique para ativar";
+"keep_awake.tooltip_on" = "Mantendo o Mac acordado — clique para desativar";
+"keep_awake.tooltip_until" = "Mantendo o Mac acordado até %@ — clique para desativar";
+"keep_awake.tooltip_auto" = "Mantendo o Mac acordado — o Claude Code está trabalhando";
 
 /* Sponsor slot */
 "sponsor.slot_title" = "Este espaço está disponível para patrocinadores";

--- a/Claude Usage/Resources/pt-BR.lproj/Localizable.strings
+++ b/Claude Usage/Resources/pt-BR.lproj/Localizable.strings
@@ -1052,6 +1052,7 @@
 "keep_awake.state_on_remaining" = "Ativado — faltam %@";
 "keep_awake.state_auto_active" = "Auto — o Claude Code está trabalhando";
 "keep_awake.state_auto_grace" = "Auto — Claude terminou, acordado por mais %@";
+"keep_awake.state_auto_armed" = "Auto ativado — mantém o Mac acordado enquanto o Claude Code trabalha";
 "keep_awake.hint_click_on" = "Clique para manter o Mac acordado";
 "keep_awake.hint_click_off" = "Clique para desativar";
 "keep_awake.hint_click_pause_auto" = "Clique para parar — retoma quando o Claude voltar a trabalhar";

--- a/Claude Usage/Resources/pt.lproj/Localizable.strings
+++ b/Claude Usage/Resources/pt.lproj/Localizable.strings
@@ -1044,18 +1044,26 @@
 "keep_awake.auto_card_desc" = "Recomendado: mantém o Mac ativo apenas enquanto o Claude Code está realmente a trabalhar";
 "keep_awake.auto" = "Manter ativo enquanto o Claude Code trabalha";
 "keep_awake.auto_desc" = "Fica ativo durante as sessões do Claude Code e depois volta a permitir o repouso. Instala hooks do Claude Code";
-"keep_awake.grace" = "Quando o Claude terminar, manter ativo durante";
-"keep_awake.grace.immediately" = "Sem tempo extra";
+"keep_awake.grace" = "Quando o Claude Code parar de trabalhar";
+"keep_awake.grace.immediately" = "Dormir de imediato";
+"keep_awake.grace.stay" = "Manter ativo %@";
 "keep_awake.hooks_note" = "A atividade é detetada através de hooks do Claude Code em ~/.claude/settings.json";
 "keep_awake.sleep_type" = "Prevenção de repouso";
 "keep_awake.sleep_type_desc" = "Escolha se o ecrã permanece ligado enquanto o Mac se mantém ativo";
 "keep_awake.sleep_type.system" = "O ecrã pode desligar-se";
 "keep_awake.sleep_type.display" = "Manter o ecrã ligado";
 "keep_awake.lid_note" = "Com a tampa fechada, o Mac entrará em repouso na mesma, salvo se estiver ligado à corrente com um ecrã externo";
-"keep_awake.tooltip_off" = "Manter o Mac ativo — clique para ativar";
-"keep_awake.tooltip_on" = "A manter o Mac ativo — clique para desativar";
-"keep_awake.tooltip_until" = "A manter o Mac ativo até às %@ — clique para desativar";
-"keep_awake.tooltip_auto" = "A manter o Mac ativo — o Claude Code está a trabalhar";
+"keep_awake.state_off" = "Desativado";
+"keep_awake.state_on_indefinite" = "Ativado — ativo até desativar (∞)";
+"keep_awake.state_on_remaining" = "Ativado — faltam %@";
+"keep_awake.state_auto_active" = "Auto — o Claude Code está a trabalhar";
+"keep_awake.state_auto_grace" = "Auto — o Claude terminou, ativo por mais %@";
+"keep_awake.hint_click_on" = "Clique para manter o Mac ativo";
+"keep_awake.hint_click_off" = "Clique para desativar";
+"keep_awake.hint_click_pause_auto" = "Clique para parar — retoma quando o Claude voltar a trabalhar";
+"keep_awake.menu_for" = "Manter ativo durante %@";
+"keep_awake.menu_indefinite" = "Manter ativo até desativar";
+"keep_awake.menu_off" = "Desativar manter ativo";
 
 /* Sponsor slot */
 "sponsor.slot_title" = "Este espaço está disponível para patrocinadores";

--- a/Claude Usage/Resources/pt.lproj/Localizable.strings
+++ b/Claude Usage/Resources/pt.lproj/Localizable.strings
@@ -1027,6 +1027,33 @@
 "settings.updates" = "Atualizações";
 "settings.updates.description" = "Mantenha o app atualizado";
 
+/* Keep Awake */
+"section.keep_awake_title" = "Manter ativo";
+"section.keep_awake_desc" = "Impede que o Mac entre em repouso";
+"keep_awake.manual_title" = "Controlo manual";
+"keep_awake.manual_desc" = "Mantém o Mac ativo quando quiser, com temporizador opcional";
+"keep_awake.enable" = "Manter o Mac ativo";
+"keep_awake.enable_desc" = "Impede temporariamente que o Mac entre em repouso";
+"keep_awake.status_active" = "A manter o Mac ativo";
+"keep_awake.remaining" = "Desativa-se em %@";
+"keep_awake.duration" = "Duração";
+"keep_awake.duration.indefinite" = "Até desativar";
+"keep_awake.duration.custom" = "Personalizada…";
+"keep_awake.custom_hours" = "%d horas";
+"keep_awake.auto_title" = "Automático";
+"keep_awake.auto_card_desc" = "A atividade do Claude Code controla o repouso";
+"keep_awake.auto" = "Manter ativo enquanto o Claude Code trabalha";
+"keep_awake.auto_desc" = "Mantém o Mac ativo automaticamente enquanto uma sessão do Claude Code estiver ativa. Instala hooks do Claude Code";
+"keep_awake.grace" = "Permitir repouso após inatividade";
+"keep_awake.grace.immediately" = "Imediatamente";
+"keep_awake.hooks_note" = "A atividade é detetada através de hooks do Claude Code em ~/.claude/settings.json";
+"keep_awake.sleep_type" = "Prevenção de repouso";
+"keep_awake.sleep_type_desc" = "Escolha se o ecrã permanece ligado enquanto o Mac se mantém ativo";
+"keep_awake.sleep_type.system" = "O ecrã pode desligar-se";
+"keep_awake.sleep_type.display" = "Manter o ecrã ligado";
+"keep_awake.lid_note" = "Não impede o repouso com a tampa fechada";
+"keep_awake.toggle_tooltip" = "Manter o Mac ativo";
+
 /* Sponsor slot */
 "sponsor.slot_title" = "Este espaço está disponível para patrocinadores";
 "sponsor.slot_cta" = "Entre em contato";

--- a/Claude Usage/Resources/pt.lproj/Localizable.strings
+++ b/Claude Usage/Resources/pt.lproj/Localizable.strings
@@ -1058,6 +1058,7 @@
 "keep_awake.state_on_remaining" = "Ativado — faltam %@";
 "keep_awake.state_auto_active" = "Auto — o Claude Code está a trabalhar";
 "keep_awake.state_auto_grace" = "Auto — o Claude terminou, ativo por mais %@";
+"keep_awake.state_auto_armed" = "Auto ativado — mantém o Mac ativo enquanto o Claude Code trabalha";
 "keep_awake.hint_click_on" = "Clique para manter o Mac ativo";
 "keep_awake.hint_click_off" = "Clique para desativar";
 "keep_awake.hint_click_pause_auto" = "Clique para parar — retoma quando o Claude voltar a trabalhar";

--- a/Claude Usage/Resources/pt.lproj/Localizable.strings
+++ b/Claude Usage/Resources/pt.lproj/Localizable.strings
@@ -1031,7 +1031,7 @@
 "section.keep_awake_title" = "Manter ativo";
 "section.keep_awake_desc" = "Impede que o Mac entre em repouso";
 "keep_awake.manual_title" = "Controlo manual";
-"keep_awake.manual_desc" = "Mantém o Mac ativo quando quiser, com temporizador opcional";
+"keep_awake.manual_desc" = "Ative você mesmo, com temporizador opcional";
 "keep_awake.enable" = "Manter o Mac ativo";
 "keep_awake.enable_desc" = "Impede temporariamente que o Mac entre em repouso";
 "keep_awake.status_active" = "A manter o Mac ativo";
@@ -1041,18 +1041,21 @@
 "keep_awake.duration.custom" = "Personalizada…";
 "keep_awake.custom_hours" = "%d horas";
 "keep_awake.auto_title" = "Automático";
-"keep_awake.auto_card_desc" = "A atividade do Claude Code controla o repouso";
+"keep_awake.auto_card_desc" = "Recomendado: mantém o Mac ativo apenas enquanto o Claude Code está realmente a trabalhar";
 "keep_awake.auto" = "Manter ativo enquanto o Claude Code trabalha";
-"keep_awake.auto_desc" = "Mantém o Mac ativo automaticamente enquanto uma sessão do Claude Code estiver ativa. Instala hooks do Claude Code";
-"keep_awake.grace" = "Permitir repouso após inatividade";
-"keep_awake.grace.immediately" = "Imediatamente";
+"keep_awake.auto_desc" = "Fica ativo durante as sessões do Claude Code e depois volta a permitir o repouso. Instala hooks do Claude Code";
+"keep_awake.grace" = "Quando o Claude terminar, manter ativo durante";
+"keep_awake.grace.immediately" = "Sem tempo extra";
 "keep_awake.hooks_note" = "A atividade é detetada através de hooks do Claude Code em ~/.claude/settings.json";
 "keep_awake.sleep_type" = "Prevenção de repouso";
 "keep_awake.sleep_type_desc" = "Escolha se o ecrã permanece ligado enquanto o Mac se mantém ativo";
 "keep_awake.sleep_type.system" = "O ecrã pode desligar-se";
 "keep_awake.sleep_type.display" = "Manter o ecrã ligado";
-"keep_awake.lid_note" = "Não impede o repouso com a tampa fechada";
-"keep_awake.toggle_tooltip" = "Manter o Mac ativo";
+"keep_awake.lid_note" = "Com a tampa fechada, o Mac entrará em repouso na mesma, salvo se estiver ligado à corrente com um ecrã externo";
+"keep_awake.tooltip_off" = "Manter o Mac ativo — clique para ativar";
+"keep_awake.tooltip_on" = "A manter o Mac ativo — clique para desativar";
+"keep_awake.tooltip_until" = "A manter o Mac ativo até às %@ — clique para desativar";
+"keep_awake.tooltip_auto" = "A manter o Mac ativo — o Claude Code está a trabalhar";
 
 /* Sponsor slot */
 "sponsor.slot_title" = "Este espaço está disponível para patrocinadores";

--- a/Claude Usage/Resources/pt.lproj/Localizable.strings
+++ b/Claude Usage/Resources/pt.lproj/Localizable.strings
@@ -1059,9 +1059,9 @@
 "keep_awake.state_auto_active" = "Auto — o Claude Code está a trabalhar";
 "keep_awake.state_auto_grace" = "Auto — o Claude terminou, ativo por mais %@";
 "keep_awake.state_auto_armed" = "Auto ativado — mantém o Mac ativo enquanto o Claude Code trabalha";
-"keep_awake.hint_click_on" = "Clique para manter o Mac ativo";
+"keep_awake.hint_click_on" = "Clique para ativar — mantém o Mac ativo enquanto o Claude Code trabalha";
 "keep_awake.hint_click_off" = "Clique para desativar";
-"keep_awake.hint_click_pause_auto" = "Clique para parar — retoma quando o Claude voltar a trabalhar";
+"keep_awake.hint_click_auto_off" = "Clique para desativar o modo automático — permanece desativado até o reativar";
 "keep_awake.menu_for" = "Manter ativo durante %@";
 "keep_awake.menu_indefinite" = "Manter ativo até desativar";
 "keep_awake.menu_off" = "Desativar manter ativo";

--- a/Claude Usage/Resources/pt.lproj/Localizable.strings
+++ b/Claude Usage/Resources/pt.lproj/Localizable.strings
@@ -1052,6 +1052,7 @@
 "keep_awake.state_on_remaining" = "Ativado — faltam %@";
 "keep_awake.state_auto_active" = "Auto — o Claude Code está a trabalhar";
 "keep_awake.state_auto_grace" = "Auto — o Claude terminou, ativo por mais %@";
+"keep_awake.state_auto_armed" = "Auto ativado — mantém o Mac ativo enquanto o Claude Code trabalha";
 "keep_awake.hint_click_on" = "Clique para manter o Mac ativo";
 "keep_awake.hint_click_off" = "Clique para desativar";
 "keep_awake.hint_click_pause_auto" = "Clique para parar — retoma quando o Claude voltar a trabalhar";

--- a/Claude Usage/Resources/pt.lproj/Localizable.strings
+++ b/Claude Usage/Resources/pt.lproj/Localizable.strings
@@ -1053,9 +1053,9 @@
 "keep_awake.state_auto_active" = "Auto — o Claude Code está a trabalhar";
 "keep_awake.state_auto_grace" = "Auto — o Claude terminou, ativo por mais %@";
 "keep_awake.state_auto_armed" = "Auto ativado — mantém o Mac ativo enquanto o Claude Code trabalha";
-"keep_awake.hint_click_on" = "Clique para manter o Mac ativo";
+"keep_awake.hint_click_on" = "Clique para ativar — mantém o Mac ativo enquanto o Claude Code trabalha";
 "keep_awake.hint_click_off" = "Clique para desativar";
-"keep_awake.hint_click_pause_auto" = "Clique para parar — retoma quando o Claude voltar a trabalhar";
+"keep_awake.hint_click_auto_off" = "Clique para desativar o modo automático — permanece desativado até o reativar";
 "keep_awake.menu_for" = "Manter ativo durante %@";
 "keep_awake.menu_indefinite" = "Manter ativo até desativar";
 "keep_awake.menu_off" = "Desativar manter ativo";

--- a/Claude Usage/Resources/pt.lproj/Localizable.strings
+++ b/Claude Usage/Resources/pt.lproj/Localizable.strings
@@ -1025,7 +1025,7 @@
 "section.keep_awake_title" = "Manter ativo";
 "section.keep_awake_desc" = "Impede que o Mac entre em repouso";
 "keep_awake.manual_title" = "Controlo manual";
-"keep_awake.manual_desc" = "Mantém o Mac ativo quando quiser, com temporizador opcional";
+"keep_awake.manual_desc" = "Ative você mesmo, com temporizador opcional";
 "keep_awake.enable" = "Manter o Mac ativo";
 "keep_awake.enable_desc" = "Impede temporariamente que o Mac entre em repouso";
 "keep_awake.status_active" = "A manter o Mac ativo";
@@ -1035,18 +1035,21 @@
 "keep_awake.duration.custom" = "Personalizada…";
 "keep_awake.custom_hours" = "%d horas";
 "keep_awake.auto_title" = "Automático";
-"keep_awake.auto_card_desc" = "A atividade do Claude Code controla o repouso";
+"keep_awake.auto_card_desc" = "Recomendado: mantém o Mac ativo apenas enquanto o Claude Code está realmente a trabalhar";
 "keep_awake.auto" = "Manter ativo enquanto o Claude Code trabalha";
-"keep_awake.auto_desc" = "Mantém o Mac ativo automaticamente enquanto uma sessão do Claude Code estiver ativa. Instala hooks do Claude Code";
-"keep_awake.grace" = "Permitir repouso após inatividade";
-"keep_awake.grace.immediately" = "Imediatamente";
+"keep_awake.auto_desc" = "Fica ativo durante as sessões do Claude Code e depois volta a permitir o repouso. Instala hooks do Claude Code";
+"keep_awake.grace" = "Quando o Claude terminar, manter ativo durante";
+"keep_awake.grace.immediately" = "Sem tempo extra";
 "keep_awake.hooks_note" = "A atividade é detetada através de hooks do Claude Code em ~/.claude/settings.json";
 "keep_awake.sleep_type" = "Prevenção de repouso";
 "keep_awake.sleep_type_desc" = "Escolha se o ecrã permanece ligado enquanto o Mac se mantém ativo";
 "keep_awake.sleep_type.system" = "O ecrã pode desligar-se";
 "keep_awake.sleep_type.display" = "Manter o ecrã ligado";
-"keep_awake.lid_note" = "Não impede o repouso com a tampa fechada";
-"keep_awake.toggle_tooltip" = "Manter o Mac ativo";
+"keep_awake.lid_note" = "Com a tampa fechada, o Mac entrará em repouso na mesma, salvo se estiver ligado à corrente com um ecrã externo";
+"keep_awake.tooltip_off" = "Manter o Mac ativo — clique para ativar";
+"keep_awake.tooltip_on" = "A manter o Mac ativo — clique para desativar";
+"keep_awake.tooltip_until" = "A manter o Mac ativo até às %@ — clique para desativar";
+"keep_awake.tooltip_auto" = "A manter o Mac ativo — o Claude Code está a trabalhar";
 
 /* Sponsor slot */
 "sponsor.slot_title" = "Este espaço está disponível para patrocinadores";

--- a/Claude Usage/Resources/pt.lproj/Localizable.strings
+++ b/Claude Usage/Resources/pt.lproj/Localizable.strings
@@ -1038,18 +1038,26 @@
 "keep_awake.auto_card_desc" = "Recomendado: mantém o Mac ativo apenas enquanto o Claude Code está realmente a trabalhar";
 "keep_awake.auto" = "Manter ativo enquanto o Claude Code trabalha";
 "keep_awake.auto_desc" = "Fica ativo durante as sessões do Claude Code e depois volta a permitir o repouso. Instala hooks do Claude Code";
-"keep_awake.grace" = "Quando o Claude terminar, manter ativo durante";
-"keep_awake.grace.immediately" = "Sem tempo extra";
+"keep_awake.grace" = "Quando o Claude Code parar de trabalhar";
+"keep_awake.grace.immediately" = "Dormir de imediato";
+"keep_awake.grace.stay" = "Manter ativo %@";
 "keep_awake.hooks_note" = "A atividade é detetada através de hooks do Claude Code em ~/.claude/settings.json";
 "keep_awake.sleep_type" = "Prevenção de repouso";
 "keep_awake.sleep_type_desc" = "Escolha se o ecrã permanece ligado enquanto o Mac se mantém ativo";
 "keep_awake.sleep_type.system" = "O ecrã pode desligar-se";
 "keep_awake.sleep_type.display" = "Manter o ecrã ligado";
 "keep_awake.lid_note" = "Com a tampa fechada, o Mac entrará em repouso na mesma, salvo se estiver ligado à corrente com um ecrã externo";
-"keep_awake.tooltip_off" = "Manter o Mac ativo — clique para ativar";
-"keep_awake.tooltip_on" = "A manter o Mac ativo — clique para desativar";
-"keep_awake.tooltip_until" = "A manter o Mac ativo até às %@ — clique para desativar";
-"keep_awake.tooltip_auto" = "A manter o Mac ativo — o Claude Code está a trabalhar";
+"keep_awake.state_off" = "Desativado";
+"keep_awake.state_on_indefinite" = "Ativado — ativo até desativar (∞)";
+"keep_awake.state_on_remaining" = "Ativado — faltam %@";
+"keep_awake.state_auto_active" = "Auto — o Claude Code está a trabalhar";
+"keep_awake.state_auto_grace" = "Auto — o Claude terminou, ativo por mais %@";
+"keep_awake.hint_click_on" = "Clique para manter o Mac ativo";
+"keep_awake.hint_click_off" = "Clique para desativar";
+"keep_awake.hint_click_pause_auto" = "Clique para parar — retoma quando o Claude voltar a trabalhar";
+"keep_awake.menu_for" = "Manter ativo durante %@";
+"keep_awake.menu_indefinite" = "Manter ativo até desativar";
+"keep_awake.menu_off" = "Desativar manter ativo";
 
 /* Sponsor slot */
 "sponsor.slot_title" = "Este espaço está disponível para patrocinadores";

--- a/Claude Usage/Resources/pt.lproj/Localizable.strings
+++ b/Claude Usage/Resources/pt.lproj/Localizable.strings
@@ -1021,6 +1021,33 @@
 "settings.updates" = "Atualizações";
 "settings.updates.description" = "Mantenha o app atualizado";
 
+/* Keep Awake */
+"section.keep_awake_title" = "Manter ativo";
+"section.keep_awake_desc" = "Impede que o Mac entre em repouso";
+"keep_awake.manual_title" = "Controlo manual";
+"keep_awake.manual_desc" = "Mantém o Mac ativo quando quiser, com temporizador opcional";
+"keep_awake.enable" = "Manter o Mac ativo";
+"keep_awake.enable_desc" = "Impede temporariamente que o Mac entre em repouso";
+"keep_awake.status_active" = "A manter o Mac ativo";
+"keep_awake.remaining" = "Desativa-se em %@";
+"keep_awake.duration" = "Duração";
+"keep_awake.duration.indefinite" = "Até desativar";
+"keep_awake.duration.custom" = "Personalizada…";
+"keep_awake.custom_hours" = "%d horas";
+"keep_awake.auto_title" = "Automático";
+"keep_awake.auto_card_desc" = "A atividade do Claude Code controla o repouso";
+"keep_awake.auto" = "Manter ativo enquanto o Claude Code trabalha";
+"keep_awake.auto_desc" = "Mantém o Mac ativo automaticamente enquanto uma sessão do Claude Code estiver ativa. Instala hooks do Claude Code";
+"keep_awake.grace" = "Permitir repouso após inatividade";
+"keep_awake.grace.immediately" = "Imediatamente";
+"keep_awake.hooks_note" = "A atividade é detetada através de hooks do Claude Code em ~/.claude/settings.json";
+"keep_awake.sleep_type" = "Prevenção de repouso";
+"keep_awake.sleep_type_desc" = "Escolha se o ecrã permanece ligado enquanto o Mac se mantém ativo";
+"keep_awake.sleep_type.system" = "O ecrã pode desligar-se";
+"keep_awake.sleep_type.display" = "Manter o ecrã ligado";
+"keep_awake.lid_note" = "Não impede o repouso com a tampa fechada";
+"keep_awake.toggle_tooltip" = "Manter o Mac ativo";
+
 /* Sponsor slot */
 "sponsor.slot_title" = "Este espaço está disponível para patrocinadores";
 "sponsor.slot_cta" = "Entre em contato";

--- a/Claude Usage/Resources/tr.lproj/Localizable.strings
+++ b/Claude Usage/Resources/tr.lproj/Localizable.strings
@@ -1051,9 +1051,9 @@
 "keep_awake.state_auto_active" = "Otomatik — Claude Code çalışıyor";
 "keep_awake.state_auto_grace" = "Otomatik — Claude bitirdi, %@ daha uyanık";
 "keep_awake.state_auto_armed" = "Otomatik açık — Claude Code çalışırken Mac'i uyanık tutar";
-"keep_awake.hint_click_on" = "Mac'i uyanık tutmak için tıklayın";
+"keep_awake.hint_click_on" = "Açmak için tıklayın — Claude Code çalışırken Mac'i uyanık tutar";
 "keep_awake.hint_click_off" = "Kapatmak için tıklayın";
-"keep_awake.hint_click_pause_auto" = "Durdurmak için tıklayın — Claude yeniden çalışınca devam eder";
+"keep_awake.hint_click_auto_off" = "Otomatik modu kapatmak için tıklayın — yeniden açana kadar kapalı kalır";
 "keep_awake.menu_for" = "%@ boyunca uyanık tut";
 "keep_awake.menu_indefinite" = "Kapatana kadar uyanık tut";
 "keep_awake.menu_off" = "Uyanık tutmayı kapat";

--- a/Claude Usage/Resources/tr.lproj/Localizable.strings
+++ b/Claude Usage/Resources/tr.lproj/Localizable.strings
@@ -1019,6 +1019,33 @@
 "notch.server.port_busy" = "%@ bağlantı noktası kullanımda — uygulamanın başka bir kopyası mı çalışıyor?";
 "notch.server.retry" = "Yeniden dene";
 
+/* Keep Awake */
+"section.keep_awake_title" = "Uyanık Tut";
+"section.keep_awake_desc" = "Mac'in uykuya geçmesini engeller";
+"keep_awake.manual_title" = "Elle denetim";
+"keep_awake.manual_desc" = "Mac'i istediğinizde uyanık tutar, isteğe bağlı zamanlayıcıyla";
+"keep_awake.enable" = "Mac'i uyanık tut";
+"keep_awake.enable_desc" = "Mac'in uykuya geçmesini geçici olarak engeller";
+"keep_awake.status_active" = "Mac şu anda uyanık tutuluyor";
+"keep_awake.remaining" = "%@ sonra kapanır";
+"keep_awake.duration" = "Süre";
+"keep_awake.duration.indefinite" = "Kapatana kadar";
+"keep_awake.duration.custom" = "Özel…";
+"keep_awake.custom_hours" = "%d saat";
+"keep_awake.auto_title" = "Otomatik";
+"keep_awake.auto_card_desc" = "Uyku engellemeyi Claude Code etkinliği denetler";
+"keep_awake.auto" = "Claude Code çalışırken uyanık tut";
+"keep_awake.auto_desc" = "Bir Claude Code oturumu etkinken Mac'i otomatik olarak uyanık tutar. Claude Code kancalarını kurar";
+"keep_awake.grace" = "Etkinlik bittikten sonra uykuya izin ver";
+"keep_awake.grace.immediately" = "Hemen";
+"keep_awake.hooks_note" = "Etkinlik, ~/.claude/settings.json içindeki Claude Code kancalarıyla algılanır";
+"keep_awake.sleep_type" = "Uyku engelleme";
+"keep_awake.sleep_type_desc" = "Mac uyanık tutulurken ekranın açık kalıp kalmayacağını seçin";
+"keep_awake.sleep_type.system" = "Ekran uyuyabilir";
+"keep_awake.sleep_type.display" = "Ekranı açık tut";
+"keep_awake.lid_note" = "Kapak kapalıyken uykuyu engellemez";
+"keep_awake.toggle_tooltip" = "Mac'i uyanık tut";
+
 /* Sponsor slot */
 "sponsor.slot_title" = "Bu alan sponsorlara açıktır";
 "sponsor.slot_cta" = "İletişime geçin";

--- a/Claude Usage/Resources/tr.lproj/Localizable.strings
+++ b/Claude Usage/Resources/tr.lproj/Localizable.strings
@@ -1050,6 +1050,7 @@
 "keep_awake.state_on_remaining" = "Açık — %@ kaldı";
 "keep_awake.state_auto_active" = "Otomatik — Claude Code çalışıyor";
 "keep_awake.state_auto_grace" = "Otomatik — Claude bitirdi, %@ daha uyanık";
+"keep_awake.state_auto_armed" = "Otomatik açık — Claude Code çalışırken Mac'i uyanık tutar";
 "keep_awake.hint_click_on" = "Mac'i uyanık tutmak için tıklayın";
 "keep_awake.hint_click_off" = "Kapatmak için tıklayın";
 "keep_awake.hint_click_pause_auto" = "Durdurmak için tıklayın — Claude yeniden çalışınca devam eder";

--- a/Claude Usage/Resources/tr.lproj/Localizable.strings
+++ b/Claude Usage/Resources/tr.lproj/Localizable.strings
@@ -1036,18 +1036,26 @@
 "keep_awake.auto_card_desc" = "Önerilen: Mac'i yalnızca Claude Code gerçekten çalışırken uyanık tutar";
 "keep_awake.auto" = "Claude Code çalışırken uyanık tut";
 "keep_awake.auto_desc" = "Etkin Claude Code oturumları sırasında uyanık kalır, ardından uykuya yeniden izin verir. Claude Code kancalarını kurar";
-"keep_awake.grace" = "Claude bittikten sonra uyanık kalma süresi";
-"keep_awake.grace.immediately" = "Ek süre yok";
+"keep_awake.grace" = "Claude Code çalışmayı bıraktığında";
+"keep_awake.grace.immediately" = "Hemen uykuya geç";
+"keep_awake.grace.stay" = "%@ uyanık kal";
 "keep_awake.hooks_note" = "Etkinlik, ~/.claude/settings.json içindeki Claude Code kancalarıyla algılanır";
 "keep_awake.sleep_type" = "Uyku engelleme";
 "keep_awake.sleep_type_desc" = "Mac uyanık tutulurken ekranın açık kalıp kalmayacağını seçin";
 "keep_awake.sleep_type.system" = "Ekran uyuyabilir";
 "keep_awake.sleep_type.display" = "Ekranı açık tut";
 "keep_awake.lid_note" = "Kapak kapalıyken Mac, güce bağlı ve harici ekran kullanmıyorsa yine de uykuya geçer";
-"keep_awake.tooltip_off" = "Mac'i uyanık tut — açmak için tıklayın";
-"keep_awake.tooltip_on" = "Mac uyanık tutuluyor — kapatmak için tıklayın";
-"keep_awake.tooltip_until" = "Mac %@ saatine kadar uyanık tutuluyor — kapatmak için tıklayın";
-"keep_awake.tooltip_auto" = "Mac uyanık tutuluyor — Claude Code çalışıyor";
+"keep_awake.state_off" = "Kapalı";
+"keep_awake.state_on_indefinite" = "Açık — siz kapatana kadar uyanık (∞)";
+"keep_awake.state_on_remaining" = "Açık — %@ kaldı";
+"keep_awake.state_auto_active" = "Otomatik — Claude Code çalışıyor";
+"keep_awake.state_auto_grace" = "Otomatik — Claude bitirdi, %@ daha uyanık";
+"keep_awake.hint_click_on" = "Mac'i uyanık tutmak için tıklayın";
+"keep_awake.hint_click_off" = "Kapatmak için tıklayın";
+"keep_awake.hint_click_pause_auto" = "Durdurmak için tıklayın — Claude yeniden çalışınca devam eder";
+"keep_awake.menu_for" = "%@ boyunca uyanık tut";
+"keep_awake.menu_indefinite" = "Kapatana kadar uyanık tut";
+"keep_awake.menu_off" = "Uyanık tutmayı kapat";
 
 /* Sponsor slot */
 "sponsor.slot_title" = "Bu alan sponsorlara açıktır";

--- a/Claude Usage/Resources/tr.lproj/Localizable.strings
+++ b/Claude Usage/Resources/tr.lproj/Localizable.strings
@@ -1023,7 +1023,7 @@
 "section.keep_awake_title" = "Uyanık Tut";
 "section.keep_awake_desc" = "Mac'in uykuya geçmesini engeller";
 "keep_awake.manual_title" = "Elle denetim";
-"keep_awake.manual_desc" = "Mac'i istediğinizde uyanık tutar, isteğe bağlı zamanlayıcıyla";
+"keep_awake.manual_desc" = "İstediğinizde kendiniz açın, isteğe bağlı zamanlayıcıyla";
 "keep_awake.enable" = "Mac'i uyanık tut";
 "keep_awake.enable_desc" = "Mac'in uykuya geçmesini geçici olarak engeller";
 "keep_awake.status_active" = "Mac şu anda uyanık tutuluyor";
@@ -1033,18 +1033,21 @@
 "keep_awake.duration.custom" = "Özel…";
 "keep_awake.custom_hours" = "%d saat";
 "keep_awake.auto_title" = "Otomatik";
-"keep_awake.auto_card_desc" = "Uyku engellemeyi Claude Code etkinliği denetler";
+"keep_awake.auto_card_desc" = "Önerilen: Mac'i yalnızca Claude Code gerçekten çalışırken uyanık tutar";
 "keep_awake.auto" = "Claude Code çalışırken uyanık tut";
-"keep_awake.auto_desc" = "Bir Claude Code oturumu etkinken Mac'i otomatik olarak uyanık tutar. Claude Code kancalarını kurar";
-"keep_awake.grace" = "Etkinlik bittikten sonra uykuya izin ver";
-"keep_awake.grace.immediately" = "Hemen";
+"keep_awake.auto_desc" = "Etkin Claude Code oturumları sırasında uyanık kalır, ardından uykuya yeniden izin verir. Claude Code kancalarını kurar";
+"keep_awake.grace" = "Claude bittikten sonra uyanık kalma süresi";
+"keep_awake.grace.immediately" = "Ek süre yok";
 "keep_awake.hooks_note" = "Etkinlik, ~/.claude/settings.json içindeki Claude Code kancalarıyla algılanır";
 "keep_awake.sleep_type" = "Uyku engelleme";
 "keep_awake.sleep_type_desc" = "Mac uyanık tutulurken ekranın açık kalıp kalmayacağını seçin";
 "keep_awake.sleep_type.system" = "Ekran uyuyabilir";
 "keep_awake.sleep_type.display" = "Ekranı açık tut";
-"keep_awake.lid_note" = "Kapak kapalıyken uykuyu engellemez";
-"keep_awake.toggle_tooltip" = "Mac'i uyanık tut";
+"keep_awake.lid_note" = "Kapak kapalıyken Mac, güce bağlı ve harici ekran kullanmıyorsa yine de uykuya geçer";
+"keep_awake.tooltip_off" = "Mac'i uyanık tut — açmak için tıklayın";
+"keep_awake.tooltip_on" = "Mac uyanık tutuluyor — kapatmak için tıklayın";
+"keep_awake.tooltip_until" = "Mac %@ saatine kadar uyanık tutuluyor — kapatmak için tıklayın";
+"keep_awake.tooltip_auto" = "Mac uyanık tutuluyor — Claude Code çalışıyor";
 
 /* Sponsor slot */
 "sponsor.slot_title" = "Bu alan sponsorlara açıktır";

--- a/Claude Usage/Resources/tr.lproj/Localizable.strings
+++ b/Claude Usage/Resources/tr.lproj/Localizable.strings
@@ -1013,6 +1013,33 @@
 "notch.server.port_busy" = "%@ bağlantı noktası kullanımda — uygulamanın başka bir kopyası mı çalışıyor?";
 "notch.server.retry" = "Yeniden dene";
 
+/* Keep Awake */
+"section.keep_awake_title" = "Uyanık Tut";
+"section.keep_awake_desc" = "Mac'in uykuya geçmesini engeller";
+"keep_awake.manual_title" = "Elle denetim";
+"keep_awake.manual_desc" = "Mac'i istediğinizde uyanık tutar, isteğe bağlı zamanlayıcıyla";
+"keep_awake.enable" = "Mac'i uyanık tut";
+"keep_awake.enable_desc" = "Mac'in uykuya geçmesini geçici olarak engeller";
+"keep_awake.status_active" = "Mac şu anda uyanık tutuluyor";
+"keep_awake.remaining" = "%@ sonra kapanır";
+"keep_awake.duration" = "Süre";
+"keep_awake.duration.indefinite" = "Kapatana kadar";
+"keep_awake.duration.custom" = "Özel…";
+"keep_awake.custom_hours" = "%d saat";
+"keep_awake.auto_title" = "Otomatik";
+"keep_awake.auto_card_desc" = "Uyku engellemeyi Claude Code etkinliği denetler";
+"keep_awake.auto" = "Claude Code çalışırken uyanık tut";
+"keep_awake.auto_desc" = "Bir Claude Code oturumu etkinken Mac'i otomatik olarak uyanık tutar. Claude Code kancalarını kurar";
+"keep_awake.grace" = "Etkinlik bittikten sonra uykuya izin ver";
+"keep_awake.grace.immediately" = "Hemen";
+"keep_awake.hooks_note" = "Etkinlik, ~/.claude/settings.json içindeki Claude Code kancalarıyla algılanır";
+"keep_awake.sleep_type" = "Uyku engelleme";
+"keep_awake.sleep_type_desc" = "Mac uyanık tutulurken ekranın açık kalıp kalmayacağını seçin";
+"keep_awake.sleep_type.system" = "Ekran uyuyabilir";
+"keep_awake.sleep_type.display" = "Ekranı açık tut";
+"keep_awake.lid_note" = "Kapak kapalıyken uykuyu engellemez";
+"keep_awake.toggle_tooltip" = "Mac'i uyanık tut";
+
 /* Sponsor slot */
 "sponsor.slot_title" = "Bu alan sponsorlara açıktır";
 "sponsor.slot_cta" = "İletişime geçin";

--- a/Claude Usage/Resources/tr.lproj/Localizable.strings
+++ b/Claude Usage/Resources/tr.lproj/Localizable.strings
@@ -1045,9 +1045,9 @@
 "keep_awake.state_auto_active" = "Otomatik — Claude Code çalışıyor";
 "keep_awake.state_auto_grace" = "Otomatik — Claude bitirdi, %@ daha uyanık";
 "keep_awake.state_auto_armed" = "Otomatik açık — Claude Code çalışırken Mac'i uyanık tutar";
-"keep_awake.hint_click_on" = "Mac'i uyanık tutmak için tıklayın";
+"keep_awake.hint_click_on" = "Açmak için tıklayın — Claude Code çalışırken Mac'i uyanık tutar";
 "keep_awake.hint_click_off" = "Kapatmak için tıklayın";
-"keep_awake.hint_click_pause_auto" = "Durdurmak için tıklayın — Claude yeniden çalışınca devam eder";
+"keep_awake.hint_click_auto_off" = "Otomatik modu kapatmak için tıklayın — yeniden açana kadar kapalı kalır";
 "keep_awake.menu_for" = "%@ boyunca uyanık tut";
 "keep_awake.menu_indefinite" = "Kapatana kadar uyanık tut";
 "keep_awake.menu_off" = "Uyanık tutmayı kapat";

--- a/Claude Usage/Resources/tr.lproj/Localizable.strings
+++ b/Claude Usage/Resources/tr.lproj/Localizable.strings
@@ -1017,7 +1017,7 @@
 "section.keep_awake_title" = "Uyanık Tut";
 "section.keep_awake_desc" = "Mac'in uykuya geçmesini engeller";
 "keep_awake.manual_title" = "Elle denetim";
-"keep_awake.manual_desc" = "Mac'i istediğinizde uyanık tutar, isteğe bağlı zamanlayıcıyla";
+"keep_awake.manual_desc" = "İstediğinizde kendiniz açın, isteğe bağlı zamanlayıcıyla";
 "keep_awake.enable" = "Mac'i uyanık tut";
 "keep_awake.enable_desc" = "Mac'in uykuya geçmesini geçici olarak engeller";
 "keep_awake.status_active" = "Mac şu anda uyanık tutuluyor";
@@ -1027,18 +1027,21 @@
 "keep_awake.duration.custom" = "Özel…";
 "keep_awake.custom_hours" = "%d saat";
 "keep_awake.auto_title" = "Otomatik";
-"keep_awake.auto_card_desc" = "Uyku engellemeyi Claude Code etkinliği denetler";
+"keep_awake.auto_card_desc" = "Önerilen: Mac'i yalnızca Claude Code gerçekten çalışırken uyanık tutar";
 "keep_awake.auto" = "Claude Code çalışırken uyanık tut";
-"keep_awake.auto_desc" = "Bir Claude Code oturumu etkinken Mac'i otomatik olarak uyanık tutar. Claude Code kancalarını kurar";
-"keep_awake.grace" = "Etkinlik bittikten sonra uykuya izin ver";
-"keep_awake.grace.immediately" = "Hemen";
+"keep_awake.auto_desc" = "Etkin Claude Code oturumları sırasında uyanık kalır, ardından uykuya yeniden izin verir. Claude Code kancalarını kurar";
+"keep_awake.grace" = "Claude bittikten sonra uyanık kalma süresi";
+"keep_awake.grace.immediately" = "Ek süre yok";
 "keep_awake.hooks_note" = "Etkinlik, ~/.claude/settings.json içindeki Claude Code kancalarıyla algılanır";
 "keep_awake.sleep_type" = "Uyku engelleme";
 "keep_awake.sleep_type_desc" = "Mac uyanık tutulurken ekranın açık kalıp kalmayacağını seçin";
 "keep_awake.sleep_type.system" = "Ekran uyuyabilir";
 "keep_awake.sleep_type.display" = "Ekranı açık tut";
-"keep_awake.lid_note" = "Kapak kapalıyken uykuyu engellemez";
-"keep_awake.toggle_tooltip" = "Mac'i uyanık tut";
+"keep_awake.lid_note" = "Kapak kapalıyken Mac, güce bağlı ve harici ekran kullanmıyorsa yine de uykuya geçer";
+"keep_awake.tooltip_off" = "Mac'i uyanık tut — açmak için tıklayın";
+"keep_awake.tooltip_on" = "Mac uyanık tutuluyor — kapatmak için tıklayın";
+"keep_awake.tooltip_until" = "Mac %@ saatine kadar uyanık tutuluyor — kapatmak için tıklayın";
+"keep_awake.tooltip_auto" = "Mac uyanık tutuluyor — Claude Code çalışıyor";
 
 /* Sponsor slot */
 "sponsor.slot_title" = "Bu alan sponsorlara açıktır";

--- a/Claude Usage/Resources/tr.lproj/Localizable.strings
+++ b/Claude Usage/Resources/tr.lproj/Localizable.strings
@@ -1044,6 +1044,7 @@
 "keep_awake.state_on_remaining" = "Açık — %@ kaldı";
 "keep_awake.state_auto_active" = "Otomatik — Claude Code çalışıyor";
 "keep_awake.state_auto_grace" = "Otomatik — Claude bitirdi, %@ daha uyanık";
+"keep_awake.state_auto_armed" = "Otomatik açık — Claude Code çalışırken Mac'i uyanık tutar";
 "keep_awake.hint_click_on" = "Mac'i uyanık tutmak için tıklayın";
 "keep_awake.hint_click_off" = "Kapatmak için tıklayın";
 "keep_awake.hint_click_pause_auto" = "Durdurmak için tıklayın — Claude yeniden çalışınca devam eder";

--- a/Claude Usage/Resources/tr.lproj/Localizable.strings
+++ b/Claude Usage/Resources/tr.lproj/Localizable.strings
@@ -1030,18 +1030,26 @@
 "keep_awake.auto_card_desc" = "Önerilen: Mac'i yalnızca Claude Code gerçekten çalışırken uyanık tutar";
 "keep_awake.auto" = "Claude Code çalışırken uyanık tut";
 "keep_awake.auto_desc" = "Etkin Claude Code oturumları sırasında uyanık kalır, ardından uykuya yeniden izin verir. Claude Code kancalarını kurar";
-"keep_awake.grace" = "Claude bittikten sonra uyanık kalma süresi";
-"keep_awake.grace.immediately" = "Ek süre yok";
+"keep_awake.grace" = "Claude Code çalışmayı bıraktığında";
+"keep_awake.grace.immediately" = "Hemen uykuya geç";
+"keep_awake.grace.stay" = "%@ uyanık kal";
 "keep_awake.hooks_note" = "Etkinlik, ~/.claude/settings.json içindeki Claude Code kancalarıyla algılanır";
 "keep_awake.sleep_type" = "Uyku engelleme";
 "keep_awake.sleep_type_desc" = "Mac uyanık tutulurken ekranın açık kalıp kalmayacağını seçin";
 "keep_awake.sleep_type.system" = "Ekran uyuyabilir";
 "keep_awake.sleep_type.display" = "Ekranı açık tut";
 "keep_awake.lid_note" = "Kapak kapalıyken Mac, güce bağlı ve harici ekran kullanmıyorsa yine de uykuya geçer";
-"keep_awake.tooltip_off" = "Mac'i uyanık tut — açmak için tıklayın";
-"keep_awake.tooltip_on" = "Mac uyanık tutuluyor — kapatmak için tıklayın";
-"keep_awake.tooltip_until" = "Mac %@ saatine kadar uyanık tutuluyor — kapatmak için tıklayın";
-"keep_awake.tooltip_auto" = "Mac uyanık tutuluyor — Claude Code çalışıyor";
+"keep_awake.state_off" = "Kapalı";
+"keep_awake.state_on_indefinite" = "Açık — siz kapatana kadar uyanık (∞)";
+"keep_awake.state_on_remaining" = "Açık — %@ kaldı";
+"keep_awake.state_auto_active" = "Otomatik — Claude Code çalışıyor";
+"keep_awake.state_auto_grace" = "Otomatik — Claude bitirdi, %@ daha uyanık";
+"keep_awake.hint_click_on" = "Mac'i uyanık tutmak için tıklayın";
+"keep_awake.hint_click_off" = "Kapatmak için tıklayın";
+"keep_awake.hint_click_pause_auto" = "Durdurmak için tıklayın — Claude yeniden çalışınca devam eder";
+"keep_awake.menu_for" = "%@ boyunca uyanık tut";
+"keep_awake.menu_indefinite" = "Kapatana kadar uyanık tut";
+"keep_awake.menu_off" = "Uyanık tutmayı kapat";
 
 /* Sponsor slot */
 "sponsor.slot_title" = "Bu alan sponsorlara açıktır";

--- a/Claude Usage/Resources/uk.lproj/Localizable.strings
+++ b/Claude Usage/Resources/uk.lproj/Localizable.strings
@@ -1039,18 +1039,26 @@
 "keep_awake.auto_card_desc" = "Рекомендовано: тримає Mac активним лише тоді, коли Claude Code справді працює";
 "keep_awake.auto" = "Не засинати, поки Claude Code працює";
 "keep_awake.auto_desc" = "Залишається активним під час сеансів Claude Code, а потім знову дозволяє сон. Встановлює хуки Claude Code";
-"keep_awake.grace" = "Після завершення роботи Claude лишатися активним";
-"keep_awake.grace.immediately" = "Без додаткового часу";
+"keep_awake.grace" = "Коли Claude Code завершить роботу";
+"keep_awake.grace.immediately" = "Одразу заснути";
+"keep_awake.grace.stay" = "Лишатися активним %@";
 "keep_awake.hooks_note" = "Активність визначається через хуки Claude Code у ~/.claude/settings.json";
 "keep_awake.sleep_type" = "Запобігання сну";
 "keep_awake.sleep_type_desc" = "Виберіть, чи залишається екран увімкненим, поки Mac активний";
 "keep_awake.sleep_type.system" = "Екран може вимикатися";
 "keep_awake.sleep_type.display" = "Тримати екран увімкненим";
 "keep_awake.lid_note" = "Із закритою кришкою Mac все одно засне, якщо він не підключений до живлення із зовнішнім дисплеєм";
-"keep_awake.tooltip_off" = "Не давати Mac засинати — натисніть, щоб увімкнути";
-"keep_awake.tooltip_on" = "Mac утримується активним — натисніть, щоб вимкнути";
-"keep_awake.tooltip_until" = "Mac активний до %@ — натисніть, щоб вимкнути";
-"keep_awake.tooltip_auto" = "Mac утримується активним — Claude Code працює";
+"keep_awake.state_off" = "Вимкнено";
+"keep_awake.state_on_indefinite" = "Увімкнено — активний, доки не вимкнете (∞)";
+"keep_awake.state_on_remaining" = "Увімкнено — залишилось %@";
+"keep_awake.state_auto_active" = "Авто — Claude Code працює";
+"keep_awake.state_auto_grace" = "Авто — Claude завершив, активний ще %@";
+"keep_awake.hint_click_on" = "Натисніть, щоб не давати Mac засинати";
+"keep_awake.hint_click_off" = "Натисніть, щоб вимкнути";
+"keep_awake.hint_click_pause_auto" = "Натисніть, щоб зупинити — відновиться, коли Claude знову працюватиме";
+"keep_awake.menu_for" = "Не засинати %@";
+"keep_awake.menu_indefinite" = "Не засинати, доки не вимкнено";
+"keep_awake.menu_off" = "Вимкнути утримання";
 
 /* Sponsor slot */
 "sponsor.slot_title" = "Це місце доступне для спонсорів";

--- a/Claude Usage/Resources/uk.lproj/Localizable.strings
+++ b/Claude Usage/Resources/uk.lproj/Localizable.strings
@@ -1026,7 +1026,7 @@
 "section.keep_awake_title" = "Не давати засинати";
 "section.keep_awake_desc" = "Запобігає переходу Mac у режим сну";
 "keep_awake.manual_title" = "Ручне керування";
-"keep_awake.manual_desc" = "Тримає Mac активним за запитом, з необов'язковим таймером";
+"keep_awake.manual_desc" = "Вмикайте самостійно, з необов'язковим таймером";
 "keep_awake.enable" = "Не давати Mac засинати";
 "keep_awake.enable_desc" = "Тимчасово запобігає переходу Mac у режим сну";
 "keep_awake.status_active" = "Зараз Mac утримується активним";
@@ -1036,18 +1036,21 @@
 "keep_awake.duration.custom" = "Власна…";
 "keep_awake.custom_hours" = "%d год";
 "keep_awake.auto_title" = "Автоматично";
-"keep_awake.auto_card_desc" = "Активність Claude Code керує запобіганням сну";
+"keep_awake.auto_card_desc" = "Рекомендовано: тримає Mac активним лише тоді, коли Claude Code справді працює";
 "keep_awake.auto" = "Не засинати, поки Claude Code працює";
-"keep_awake.auto_desc" = "Автоматично тримає Mac активним, поки триває сеанс Claude Code. Встановлює хуки Claude Code";
-"keep_awake.grace" = "Дозволити сон після бездіяльності";
-"keep_awake.grace.immediately" = "Одразу";
+"keep_awake.auto_desc" = "Залишається активним під час сеансів Claude Code, а потім знову дозволяє сон. Встановлює хуки Claude Code";
+"keep_awake.grace" = "Після завершення роботи Claude лишатися активним";
+"keep_awake.grace.immediately" = "Без додаткового часу";
 "keep_awake.hooks_note" = "Активність визначається через хуки Claude Code у ~/.claude/settings.json";
 "keep_awake.sleep_type" = "Запобігання сну";
 "keep_awake.sleep_type_desc" = "Виберіть, чи залишається екран увімкненим, поки Mac активний";
 "keep_awake.sleep_type.system" = "Екран може вимикатися";
 "keep_awake.sleep_type.display" = "Тримати екран увімкненим";
-"keep_awake.lid_note" = "Не запобігає сну із закритою кришкою";
-"keep_awake.toggle_tooltip" = "Не давати Mac засинати";
+"keep_awake.lid_note" = "Із закритою кришкою Mac все одно засне, якщо він не підключений до живлення із зовнішнім дисплеєм";
+"keep_awake.tooltip_off" = "Не давати Mac засинати — натисніть, щоб увімкнути";
+"keep_awake.tooltip_on" = "Mac утримується активним — натисніть, щоб вимкнути";
+"keep_awake.tooltip_until" = "Mac активний до %@ — натисніть, щоб вимкнути";
+"keep_awake.tooltip_auto" = "Mac утримується активним — Claude Code працює";
 
 /* Sponsor slot */
 "sponsor.slot_title" = "Це місце доступне для спонсорів";

--- a/Claude Usage/Resources/uk.lproj/Localizable.strings
+++ b/Claude Usage/Resources/uk.lproj/Localizable.strings
@@ -1022,6 +1022,33 @@
 "notch.server.port_busy" = "Порт %@ зайнятий — можливо, запущено іншу копію застосунку?";
 "notch.server.retry" = "Повторити";
 
+/* Keep Awake */
+"section.keep_awake_title" = "Не давати засинати";
+"section.keep_awake_desc" = "Запобігає переходу Mac у режим сну";
+"keep_awake.manual_title" = "Ручне керування";
+"keep_awake.manual_desc" = "Тримає Mac активним за запитом, з необов'язковим таймером";
+"keep_awake.enable" = "Не давати Mac засинати";
+"keep_awake.enable_desc" = "Тимчасово запобігає переходу Mac у режим сну";
+"keep_awake.status_active" = "Зараз Mac утримується активним";
+"keep_awake.remaining" = "Вимкнеться через %@";
+"keep_awake.duration" = "Тривалість";
+"keep_awake.duration.indefinite" = "Доки не вимкнете";
+"keep_awake.duration.custom" = "Власна…";
+"keep_awake.custom_hours" = "%d год";
+"keep_awake.auto_title" = "Автоматично";
+"keep_awake.auto_card_desc" = "Активність Claude Code керує запобіганням сну";
+"keep_awake.auto" = "Не засинати, поки Claude Code працює";
+"keep_awake.auto_desc" = "Автоматично тримає Mac активним, поки триває сеанс Claude Code. Встановлює хуки Claude Code";
+"keep_awake.grace" = "Дозволити сон після бездіяльності";
+"keep_awake.grace.immediately" = "Одразу";
+"keep_awake.hooks_note" = "Активність визначається через хуки Claude Code у ~/.claude/settings.json";
+"keep_awake.sleep_type" = "Запобігання сну";
+"keep_awake.sleep_type_desc" = "Виберіть, чи залишається екран увімкненим, поки Mac активний";
+"keep_awake.sleep_type.system" = "Екран може вимикатися";
+"keep_awake.sleep_type.display" = "Тримати екран увімкненим";
+"keep_awake.lid_note" = "Не запобігає сну із закритою кришкою";
+"keep_awake.toggle_tooltip" = "Не давати Mac засинати";
+
 /* Sponsor slot */
 "sponsor.slot_title" = "Це місце доступне для спонсорів";
 "sponsor.slot_cta" = "Звʼязатися";

--- a/Claude Usage/Resources/uk.lproj/Localizable.strings
+++ b/Claude Usage/Resources/uk.lproj/Localizable.strings
@@ -1053,6 +1053,7 @@
 "keep_awake.state_on_remaining" = "Увімкнено — залишилось %@";
 "keep_awake.state_auto_active" = "Авто — Claude Code працює";
 "keep_awake.state_auto_grace" = "Авто — Claude завершив, активний ще %@";
+"keep_awake.state_auto_armed" = "Авто увімкнено — тримає Mac активним, поки Claude Code працює";
 "keep_awake.hint_click_on" = "Натисніть, щоб не давати Mac засинати";
 "keep_awake.hint_click_off" = "Натисніть, щоб вимкнути";
 "keep_awake.hint_click_pause_auto" = "Натисніть, щоб зупинити — відновиться, коли Claude знову працюватиме";

--- a/Claude Usage/Resources/uk.lproj/Localizable.strings
+++ b/Claude Usage/Resources/uk.lproj/Localizable.strings
@@ -1054,9 +1054,9 @@
 "keep_awake.state_auto_active" = "Авто — Claude Code працює";
 "keep_awake.state_auto_grace" = "Авто — Claude завершив, активний ще %@";
 "keep_awake.state_auto_armed" = "Авто увімкнено — тримає Mac активним, поки Claude Code працює";
-"keep_awake.hint_click_on" = "Натисніть, щоб не давати Mac засинати";
+"keep_awake.hint_click_on" = "Натисніть, щоб увімкнути — тримає Mac активним, поки Claude Code працює";
 "keep_awake.hint_click_off" = "Натисніть, щоб вимкнути";
-"keep_awake.hint_click_pause_auto" = "Натисніть, щоб зупинити — відновиться, коли Claude знову працюватиме";
+"keep_awake.hint_click_auto_off" = "Натисніть, щоб вимкнути авторежим — лишається вимкненим, доки не увімкнете знову";
 "keep_awake.menu_for" = "Не засинати %@";
 "keep_awake.menu_indefinite" = "Не засинати, доки не вимкнено";
 "keep_awake.menu_off" = "Вимкнути утримання";

--- a/Claude Usage/Resources/uk.lproj/Localizable.strings
+++ b/Claude Usage/Resources/uk.lproj/Localizable.strings
@@ -1047,6 +1047,7 @@
 "keep_awake.state_on_remaining" = "Увімкнено — залишилось %@";
 "keep_awake.state_auto_active" = "Авто — Claude Code працює";
 "keep_awake.state_auto_grace" = "Авто — Claude завершив, активний ще %@";
+"keep_awake.state_auto_armed" = "Авто увімкнено — тримає Mac активним, поки Claude Code працює";
 "keep_awake.hint_click_on" = "Натисніть, щоб не давати Mac засинати";
 "keep_awake.hint_click_off" = "Натисніть, щоб вимкнути";
 "keep_awake.hint_click_pause_auto" = "Натисніть, щоб зупинити — відновиться, коли Claude знову працюватиме";

--- a/Claude Usage/Resources/uk.lproj/Localizable.strings
+++ b/Claude Usage/Resources/uk.lproj/Localizable.strings
@@ -1020,7 +1020,7 @@
 "section.keep_awake_title" = "Не давати засинати";
 "section.keep_awake_desc" = "Запобігає переходу Mac у режим сну";
 "keep_awake.manual_title" = "Ручне керування";
-"keep_awake.manual_desc" = "Тримає Mac активним за запитом, з необов'язковим таймером";
+"keep_awake.manual_desc" = "Вмикайте самостійно, з необов'язковим таймером";
 "keep_awake.enable" = "Не давати Mac засинати";
 "keep_awake.enable_desc" = "Тимчасово запобігає переходу Mac у режим сну";
 "keep_awake.status_active" = "Зараз Mac утримується активним";
@@ -1030,18 +1030,21 @@
 "keep_awake.duration.custom" = "Власна…";
 "keep_awake.custom_hours" = "%d год";
 "keep_awake.auto_title" = "Автоматично";
-"keep_awake.auto_card_desc" = "Активність Claude Code керує запобіганням сну";
+"keep_awake.auto_card_desc" = "Рекомендовано: тримає Mac активним лише тоді, коли Claude Code справді працює";
 "keep_awake.auto" = "Не засинати, поки Claude Code працює";
-"keep_awake.auto_desc" = "Автоматично тримає Mac активним, поки триває сеанс Claude Code. Встановлює хуки Claude Code";
-"keep_awake.grace" = "Дозволити сон після бездіяльності";
-"keep_awake.grace.immediately" = "Одразу";
+"keep_awake.auto_desc" = "Залишається активним під час сеансів Claude Code, а потім знову дозволяє сон. Встановлює хуки Claude Code";
+"keep_awake.grace" = "Після завершення роботи Claude лишатися активним";
+"keep_awake.grace.immediately" = "Без додаткового часу";
 "keep_awake.hooks_note" = "Активність визначається через хуки Claude Code у ~/.claude/settings.json";
 "keep_awake.sleep_type" = "Запобігання сну";
 "keep_awake.sleep_type_desc" = "Виберіть, чи залишається екран увімкненим, поки Mac активний";
 "keep_awake.sleep_type.system" = "Екран може вимикатися";
 "keep_awake.sleep_type.display" = "Тримати екран увімкненим";
-"keep_awake.lid_note" = "Не запобігає сну із закритою кришкою";
-"keep_awake.toggle_tooltip" = "Не давати Mac засинати";
+"keep_awake.lid_note" = "Із закритою кришкою Mac все одно засне, якщо він не підключений до живлення із зовнішнім дисплеєм";
+"keep_awake.tooltip_off" = "Не давати Mac засинати — натисніть, щоб увімкнути";
+"keep_awake.tooltip_on" = "Mac утримується активним — натисніть, щоб вимкнути";
+"keep_awake.tooltip_until" = "Mac активний до %@ — натисніть, щоб вимкнути";
+"keep_awake.tooltip_auto" = "Mac утримується активним — Claude Code працює";
 
 /* Sponsor slot */
 "sponsor.slot_title" = "Це місце доступне для спонсорів";

--- a/Claude Usage/Resources/uk.lproj/Localizable.strings
+++ b/Claude Usage/Resources/uk.lproj/Localizable.strings
@@ -1016,6 +1016,33 @@
 "notch.server.port_busy" = "Порт %@ зайнятий — можливо, запущено іншу копію застосунку?";
 "notch.server.retry" = "Повторити";
 
+/* Keep Awake */
+"section.keep_awake_title" = "Не давати засинати";
+"section.keep_awake_desc" = "Запобігає переходу Mac у режим сну";
+"keep_awake.manual_title" = "Ручне керування";
+"keep_awake.manual_desc" = "Тримає Mac активним за запитом, з необов'язковим таймером";
+"keep_awake.enable" = "Не давати Mac засинати";
+"keep_awake.enable_desc" = "Тимчасово запобігає переходу Mac у режим сну";
+"keep_awake.status_active" = "Зараз Mac утримується активним";
+"keep_awake.remaining" = "Вимкнеться через %@";
+"keep_awake.duration" = "Тривалість";
+"keep_awake.duration.indefinite" = "Доки не вимкнете";
+"keep_awake.duration.custom" = "Власна…";
+"keep_awake.custom_hours" = "%d год";
+"keep_awake.auto_title" = "Автоматично";
+"keep_awake.auto_card_desc" = "Активність Claude Code керує запобіганням сну";
+"keep_awake.auto" = "Не засинати, поки Claude Code працює";
+"keep_awake.auto_desc" = "Автоматично тримає Mac активним, поки триває сеанс Claude Code. Встановлює хуки Claude Code";
+"keep_awake.grace" = "Дозволити сон після бездіяльності";
+"keep_awake.grace.immediately" = "Одразу";
+"keep_awake.hooks_note" = "Активність визначається через хуки Claude Code у ~/.claude/settings.json";
+"keep_awake.sleep_type" = "Запобігання сну";
+"keep_awake.sleep_type_desc" = "Виберіть, чи залишається екран увімкненим, поки Mac активний";
+"keep_awake.sleep_type.system" = "Екран може вимикатися";
+"keep_awake.sleep_type.display" = "Тримати екран увімкненим";
+"keep_awake.lid_note" = "Не запобігає сну із закритою кришкою";
+"keep_awake.toggle_tooltip" = "Не давати Mac засинати";
+
 /* Sponsor slot */
 "sponsor.slot_title" = "Це місце доступне для спонсорів";
 "sponsor.slot_cta" = "Звʼязатися";

--- a/Claude Usage/Resources/uk.lproj/Localizable.strings
+++ b/Claude Usage/Resources/uk.lproj/Localizable.strings
@@ -1033,18 +1033,26 @@
 "keep_awake.auto_card_desc" = "Рекомендовано: тримає Mac активним лише тоді, коли Claude Code справді працює";
 "keep_awake.auto" = "Не засинати, поки Claude Code працює";
 "keep_awake.auto_desc" = "Залишається активним під час сеансів Claude Code, а потім знову дозволяє сон. Встановлює хуки Claude Code";
-"keep_awake.grace" = "Після завершення роботи Claude лишатися активним";
-"keep_awake.grace.immediately" = "Без додаткового часу";
+"keep_awake.grace" = "Коли Claude Code завершить роботу";
+"keep_awake.grace.immediately" = "Одразу заснути";
+"keep_awake.grace.stay" = "Лишатися активним %@";
 "keep_awake.hooks_note" = "Активність визначається через хуки Claude Code у ~/.claude/settings.json";
 "keep_awake.sleep_type" = "Запобігання сну";
 "keep_awake.sleep_type_desc" = "Виберіть, чи залишається екран увімкненим, поки Mac активний";
 "keep_awake.sleep_type.system" = "Екран може вимикатися";
 "keep_awake.sleep_type.display" = "Тримати екран увімкненим";
 "keep_awake.lid_note" = "Із закритою кришкою Mac все одно засне, якщо він не підключений до живлення із зовнішнім дисплеєм";
-"keep_awake.tooltip_off" = "Не давати Mac засинати — натисніть, щоб увімкнути";
-"keep_awake.tooltip_on" = "Mac утримується активним — натисніть, щоб вимкнути";
-"keep_awake.tooltip_until" = "Mac активний до %@ — натисніть, щоб вимкнути";
-"keep_awake.tooltip_auto" = "Mac утримується активним — Claude Code працює";
+"keep_awake.state_off" = "Вимкнено";
+"keep_awake.state_on_indefinite" = "Увімкнено — активний, доки не вимкнете (∞)";
+"keep_awake.state_on_remaining" = "Увімкнено — залишилось %@";
+"keep_awake.state_auto_active" = "Авто — Claude Code працює";
+"keep_awake.state_auto_grace" = "Авто — Claude завершив, активний ще %@";
+"keep_awake.hint_click_on" = "Натисніть, щоб не давати Mac засинати";
+"keep_awake.hint_click_off" = "Натисніть, щоб вимкнути";
+"keep_awake.hint_click_pause_auto" = "Натисніть, щоб зупинити — відновиться, коли Claude знову працюватиме";
+"keep_awake.menu_for" = "Не засинати %@";
+"keep_awake.menu_indefinite" = "Не засинати, доки не вимкнено";
+"keep_awake.menu_off" = "Вимкнути утримання";
 
 /* Sponsor slot */
 "sponsor.slot_title" = "Це місце доступне для спонсорів";

--- a/Claude Usage/Resources/uk.lproj/Localizable.strings
+++ b/Claude Usage/Resources/uk.lproj/Localizable.strings
@@ -1048,9 +1048,9 @@
 "keep_awake.state_auto_active" = "Авто — Claude Code працює";
 "keep_awake.state_auto_grace" = "Авто — Claude завершив, активний ще %@";
 "keep_awake.state_auto_armed" = "Авто увімкнено — тримає Mac активним, поки Claude Code працює";
-"keep_awake.hint_click_on" = "Натисніть, щоб не давати Mac засинати";
+"keep_awake.hint_click_on" = "Натисніть, щоб увімкнути — тримає Mac активним, поки Claude Code працює";
 "keep_awake.hint_click_off" = "Натисніть, щоб вимкнути";
-"keep_awake.hint_click_pause_auto" = "Натисніть, щоб зупинити — відновиться, коли Claude знову працюватиме";
+"keep_awake.hint_click_auto_off" = "Натисніть, щоб вимкнути авторежим — лишається вимкненим, доки не увімкнете знову";
 "keep_awake.menu_for" = "Не засинати %@";
 "keep_awake.menu_indefinite" = "Не засинати, доки не вимкнено";
 "keep_awake.menu_off" = "Вимкнути утримання";

--- a/Claude Usage/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Claude Usage/Resources/zh-Hant.lproj/Localizable.strings
@@ -1045,9 +1045,9 @@
 "keep_awake.state_auto_active" = "自動 — Claude Code 工作中";
 "keep_awake.state_auto_grace" = "自動 — Claude 已完成,再保持喚醒 %@";
 "keep_awake.state_auto_armed" = "自動已開啟 — Claude Code 工作時讓 Mac 保持喚醒";
-"keep_awake.hint_click_on" = "按一下讓 Mac 保持喚醒";
+"keep_awake.hint_click_on" = "按一下開啟 — Claude Code 工作時讓 Mac 保持喚醒";
 "keep_awake.hint_click_off" = "按一下關閉";
-"keep_awake.hint_click_pause_auto" = "按一下暫停 — Claude 再次工作時自動恢復";
+"keep_awake.hint_click_auto_off" = "按一下關閉自動模式 — 將保持關閉,直到再次開啟";
 "keep_awake.menu_for" = "保持喚醒 %@";
 "keep_awake.menu_indefinite" = "保持喚醒直到關閉";
 "keep_awake.menu_off" = "關閉保持喚醒";

--- a/Claude Usage/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Claude Usage/Resources/zh-Hant.lproj/Localizable.strings
@@ -1017,7 +1017,7 @@
 "section.keep_awake_title" = "保持喚醒";
 "section.keep_awake_desc" = "防止 Mac 進入睡眠";
 "keep_awake.manual_title" = "手動控制";
-"keep_awake.manual_desc" = "隨時讓 Mac 保持喚醒,可選擇計時器";
+"keep_awake.manual_desc" = "自行開啟保持喚醒,可選擇計時器";
 "keep_awake.enable" = "讓 Mac 保持喚醒";
 "keep_awake.enable_desc" = "暫時防止 Mac 進入睡眠";
 "keep_awake.status_active" = "目前正在讓 Mac 保持喚醒";
@@ -1027,18 +1027,21 @@
 "keep_awake.duration.custom" = "自訂…";
 "keep_awake.custom_hours" = "%d 小時";
 "keep_awake.auto_title" = "自動";
-"keep_awake.auto_card_desc" = "由 Claude Code 的活動控制睡眠防止";
+"keep_awake.auto_card_desc" = "建議:僅在 Claude Code 實際工作時讓 Mac 保持喚醒";
 "keep_awake.auto" = "Claude Code 工作時保持喚醒";
-"keep_awake.auto_desc" = "當 Claude Code 工作階段進行中時,自動讓 Mac 保持喚醒。將安裝 Claude Code 掛鉤";
-"keep_awake.grace" = "閒置後允許睡眠";
-"keep_awake.grace.immediately" = "立即";
+"keep_awake.auto_desc" = "Claude Code 工作階段進行中保持喚醒,結束後恢復允許睡眠。將安裝 Claude Code 掛鉤";
+"keep_awake.grace" = "Claude 完成後,繼續保持喚醒";
+"keep_awake.grace.immediately" = "不延長";
 "keep_awake.hooks_note" = "透過 ~/.claude/settings.json 中的 Claude Code 掛鉤偵測活動";
 "keep_awake.sleep_type" = "睡眠防止方式";
 "keep_awake.sleep_type_desc" = "選擇保持喚醒時螢幕是否維持開啟";
 "keep_awake.sleep_type.system" = "螢幕可睡眠";
 "keep_awake.sleep_type.display" = "保持螢幕開啟";
-"keep_awake.lid_note" = "闔上螢幕時無法防止睡眠";
-"keep_awake.toggle_tooltip" = "讓 Mac 保持喚醒";
+"keep_awake.lid_note" = "闔上螢幕後,除非接上電源並使用外接顯示器,Mac 仍會進入睡眠";
+"keep_awake.tooltip_off" = "讓 Mac 保持喚醒 — 按一下開啟";
+"keep_awake.tooltip_on" = "正在讓 Mac 保持喚醒 — 按一下關閉";
+"keep_awake.tooltip_until" = "保持喚醒至 %@ — 按一下關閉";
+"keep_awake.tooltip_auto" = "正在讓 Mac 保持喚醒 — Claude Code 工作中";
 
 /* Sponsor slot */
 "sponsor.slot_title" = "此位置開放贊助";

--- a/Claude Usage/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Claude Usage/Resources/zh-Hant.lproj/Localizable.strings
@@ -1013,6 +1013,33 @@
 "notch.server.port_busy" = "連接埠 %@ 已被占用 — 是否有另一個 App 正在執行？";
 "notch.server.retry" = "重試";
 
+/* Keep Awake */
+"section.keep_awake_title" = "保持喚醒";
+"section.keep_awake_desc" = "防止 Mac 進入睡眠";
+"keep_awake.manual_title" = "手動控制";
+"keep_awake.manual_desc" = "隨時讓 Mac 保持喚醒,可選擇計時器";
+"keep_awake.enable" = "讓 Mac 保持喚醒";
+"keep_awake.enable_desc" = "暫時防止 Mac 進入睡眠";
+"keep_awake.status_active" = "目前正在讓 Mac 保持喚醒";
+"keep_awake.remaining" = "%@ 後關閉";
+"keep_awake.duration" = "持續時間";
+"keep_awake.duration.indefinite" = "直到手動關閉";
+"keep_awake.duration.custom" = "自訂…";
+"keep_awake.custom_hours" = "%d 小時";
+"keep_awake.auto_title" = "自動";
+"keep_awake.auto_card_desc" = "由 Claude Code 的活動控制睡眠防止";
+"keep_awake.auto" = "Claude Code 工作時保持喚醒";
+"keep_awake.auto_desc" = "當 Claude Code 工作階段進行中時,自動讓 Mac 保持喚醒。將安裝 Claude Code 掛鉤";
+"keep_awake.grace" = "閒置後允許睡眠";
+"keep_awake.grace.immediately" = "立即";
+"keep_awake.hooks_note" = "透過 ~/.claude/settings.json 中的 Claude Code 掛鉤偵測活動";
+"keep_awake.sleep_type" = "睡眠防止方式";
+"keep_awake.sleep_type_desc" = "選擇保持喚醒時螢幕是否維持開啟";
+"keep_awake.sleep_type.system" = "螢幕可睡眠";
+"keep_awake.sleep_type.display" = "保持螢幕開啟";
+"keep_awake.lid_note" = "闔上螢幕時無法防止睡眠";
+"keep_awake.toggle_tooltip" = "讓 Mac 保持喚醒";
+
 /* Sponsor slot */
 "sponsor.slot_title" = "此位置開放贊助";
 "sponsor.slot_cta" = "與我聯繫";

--- a/Claude Usage/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Claude Usage/Resources/zh-Hant.lproj/Localizable.strings
@@ -1044,6 +1044,7 @@
 "keep_awake.state_on_remaining" = "開啟 — 剩餘 %@";
 "keep_awake.state_auto_active" = "自動 — Claude Code 工作中";
 "keep_awake.state_auto_grace" = "自動 — Claude 已完成,再保持喚醒 %@";
+"keep_awake.state_auto_armed" = "自動已開啟 — Claude Code 工作時讓 Mac 保持喚醒";
 "keep_awake.hint_click_on" = "按一下讓 Mac 保持喚醒";
 "keep_awake.hint_click_off" = "按一下關閉";
 "keep_awake.hint_click_pause_auto" = "按一下暫停 — Claude 再次工作時自動恢復";

--- a/Claude Usage/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Claude Usage/Resources/zh-Hant.lproj/Localizable.strings
@@ -1030,18 +1030,26 @@
 "keep_awake.auto_card_desc" = "建議:僅在 Claude Code 實際工作時讓 Mac 保持喚醒";
 "keep_awake.auto" = "Claude Code 工作時保持喚醒";
 "keep_awake.auto_desc" = "Claude Code 工作階段進行中保持喚醒,結束後恢復允許睡眠。將安裝 Claude Code 掛鉤";
-"keep_awake.grace" = "Claude 完成後,繼續保持喚醒";
-"keep_awake.grace.immediately" = "不延長";
+"keep_awake.grace" = "Claude Code 停止工作後";
+"keep_awake.grace.immediately" = "立即睡眠";
+"keep_awake.grace.stay" = "保持喚醒 %@";
 "keep_awake.hooks_note" = "透過 ~/.claude/settings.json 中的 Claude Code 掛鉤偵測活動";
 "keep_awake.sleep_type" = "睡眠防止方式";
 "keep_awake.sleep_type_desc" = "選擇保持喚醒時螢幕是否維持開啟";
 "keep_awake.sleep_type.system" = "螢幕可睡眠";
 "keep_awake.sleep_type.display" = "保持螢幕開啟";
 "keep_awake.lid_note" = "闔上螢幕後,除非接上電源並使用外接顯示器,Mac 仍會進入睡眠";
-"keep_awake.tooltip_off" = "讓 Mac 保持喚醒 — 按一下開啟";
-"keep_awake.tooltip_on" = "正在讓 Mac 保持喚醒 — 按一下關閉";
-"keep_awake.tooltip_until" = "保持喚醒至 %@ — 按一下關閉";
-"keep_awake.tooltip_auto" = "正在讓 Mac 保持喚醒 — Claude Code 工作中";
+"keep_awake.state_off" = "關閉";
+"keep_awake.state_on_indefinite" = "開啟 — 保持喚醒直到手動關閉(∞)";
+"keep_awake.state_on_remaining" = "開啟 — 剩餘 %@";
+"keep_awake.state_auto_active" = "自動 — Claude Code 工作中";
+"keep_awake.state_auto_grace" = "自動 — Claude 已完成,再保持喚醒 %@";
+"keep_awake.hint_click_on" = "按一下讓 Mac 保持喚醒";
+"keep_awake.hint_click_off" = "按一下關閉";
+"keep_awake.hint_click_pause_auto" = "按一下暫停 — Claude 再次工作時自動恢復";
+"keep_awake.menu_for" = "保持喚醒 %@";
+"keep_awake.menu_indefinite" = "保持喚醒直到關閉";
+"keep_awake.menu_off" = "關閉保持喚醒";
 
 /* Sponsor slot */
 "sponsor.slot_title" = "此位置開放贊助";

--- a/Claude Usage/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Claude Usage/Resources/zh-Hant.lproj/Localizable.strings
@@ -1038,6 +1038,7 @@
 "keep_awake.state_on_remaining" = "開啟 — 剩餘 %@";
 "keep_awake.state_auto_active" = "自動 — Claude Code 工作中";
 "keep_awake.state_auto_grace" = "自動 — Claude 已完成,再保持喚醒 %@";
+"keep_awake.state_auto_armed" = "自動已開啟 — Claude Code 工作時讓 Mac 保持喚醒";
 "keep_awake.hint_click_on" = "按一下讓 Mac 保持喚醒";
 "keep_awake.hint_click_off" = "按一下關閉";
 "keep_awake.hint_click_pause_auto" = "按一下暫停 — Claude 再次工作時自動恢復";

--- a/Claude Usage/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Claude Usage/Resources/zh-Hant.lproj/Localizable.strings
@@ -1011,7 +1011,7 @@
 "section.keep_awake_title" = "保持喚醒";
 "section.keep_awake_desc" = "防止 Mac 進入睡眠";
 "keep_awake.manual_title" = "手動控制";
-"keep_awake.manual_desc" = "隨時讓 Mac 保持喚醒,可選擇計時器";
+"keep_awake.manual_desc" = "自行開啟保持喚醒,可選擇計時器";
 "keep_awake.enable" = "讓 Mac 保持喚醒";
 "keep_awake.enable_desc" = "暫時防止 Mac 進入睡眠";
 "keep_awake.status_active" = "目前正在讓 Mac 保持喚醒";
@@ -1021,18 +1021,21 @@
 "keep_awake.duration.custom" = "自訂…";
 "keep_awake.custom_hours" = "%d 小時";
 "keep_awake.auto_title" = "自動";
-"keep_awake.auto_card_desc" = "由 Claude Code 的活動控制睡眠防止";
+"keep_awake.auto_card_desc" = "建議:僅在 Claude Code 實際工作時讓 Mac 保持喚醒";
 "keep_awake.auto" = "Claude Code 工作時保持喚醒";
-"keep_awake.auto_desc" = "當 Claude Code 工作階段進行中時,自動讓 Mac 保持喚醒。將安裝 Claude Code 掛鉤";
-"keep_awake.grace" = "閒置後允許睡眠";
-"keep_awake.grace.immediately" = "立即";
+"keep_awake.auto_desc" = "Claude Code 工作階段進行中保持喚醒,結束後恢復允許睡眠。將安裝 Claude Code 掛鉤";
+"keep_awake.grace" = "Claude 完成後,繼續保持喚醒";
+"keep_awake.grace.immediately" = "不延長";
 "keep_awake.hooks_note" = "透過 ~/.claude/settings.json 中的 Claude Code 掛鉤偵測活動";
 "keep_awake.sleep_type" = "睡眠防止方式";
 "keep_awake.sleep_type_desc" = "選擇保持喚醒時螢幕是否維持開啟";
 "keep_awake.sleep_type.system" = "螢幕可睡眠";
 "keep_awake.sleep_type.display" = "保持螢幕開啟";
-"keep_awake.lid_note" = "闔上螢幕時無法防止睡眠";
-"keep_awake.toggle_tooltip" = "讓 Mac 保持喚醒";
+"keep_awake.lid_note" = "闔上螢幕後,除非接上電源並使用外接顯示器,Mac 仍會進入睡眠";
+"keep_awake.tooltip_off" = "讓 Mac 保持喚醒 — 按一下開啟";
+"keep_awake.tooltip_on" = "正在讓 Mac 保持喚醒 — 按一下關閉";
+"keep_awake.tooltip_until" = "保持喚醒至 %@ — 按一下關閉";
+"keep_awake.tooltip_auto" = "正在讓 Mac 保持喚醒 — Claude Code 工作中";
 
 /* Sponsor slot */
 "sponsor.slot_title" = "此位置開放贊助";

--- a/Claude Usage/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Claude Usage/Resources/zh-Hant.lproj/Localizable.strings
@@ -1039,9 +1039,9 @@
 "keep_awake.state_auto_active" = "自動 — Claude Code 工作中";
 "keep_awake.state_auto_grace" = "自動 — Claude 已完成,再保持喚醒 %@";
 "keep_awake.state_auto_armed" = "自動已開啟 — Claude Code 工作時讓 Mac 保持喚醒";
-"keep_awake.hint_click_on" = "按一下讓 Mac 保持喚醒";
+"keep_awake.hint_click_on" = "按一下開啟 — Claude Code 工作時讓 Mac 保持喚醒";
 "keep_awake.hint_click_off" = "按一下關閉";
-"keep_awake.hint_click_pause_auto" = "按一下暫停 — Claude 再次工作時自動恢復";
+"keep_awake.hint_click_auto_off" = "按一下關閉自動模式 — 將保持關閉,直到再次開啟";
 "keep_awake.menu_for" = "保持喚醒 %@";
 "keep_awake.menu_indefinite" = "保持喚醒直到關閉";
 "keep_awake.menu_off" = "關閉保持喚醒";

--- a/Claude Usage/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Claude Usage/Resources/zh-Hant.lproj/Localizable.strings
@@ -1024,18 +1024,26 @@
 "keep_awake.auto_card_desc" = "建議:僅在 Claude Code 實際工作時讓 Mac 保持喚醒";
 "keep_awake.auto" = "Claude Code 工作時保持喚醒";
 "keep_awake.auto_desc" = "Claude Code 工作階段進行中保持喚醒,結束後恢復允許睡眠。將安裝 Claude Code 掛鉤";
-"keep_awake.grace" = "Claude 完成後,繼續保持喚醒";
-"keep_awake.grace.immediately" = "不延長";
+"keep_awake.grace" = "Claude Code 停止工作後";
+"keep_awake.grace.immediately" = "立即睡眠";
+"keep_awake.grace.stay" = "保持喚醒 %@";
 "keep_awake.hooks_note" = "透過 ~/.claude/settings.json 中的 Claude Code 掛鉤偵測活動";
 "keep_awake.sleep_type" = "睡眠防止方式";
 "keep_awake.sleep_type_desc" = "選擇保持喚醒時螢幕是否維持開啟";
 "keep_awake.sleep_type.system" = "螢幕可睡眠";
 "keep_awake.sleep_type.display" = "保持螢幕開啟";
 "keep_awake.lid_note" = "闔上螢幕後,除非接上電源並使用外接顯示器,Mac 仍會進入睡眠";
-"keep_awake.tooltip_off" = "讓 Mac 保持喚醒 — 按一下開啟";
-"keep_awake.tooltip_on" = "正在讓 Mac 保持喚醒 — 按一下關閉";
-"keep_awake.tooltip_until" = "保持喚醒至 %@ — 按一下關閉";
-"keep_awake.tooltip_auto" = "正在讓 Mac 保持喚醒 — Claude Code 工作中";
+"keep_awake.state_off" = "關閉";
+"keep_awake.state_on_indefinite" = "開啟 — 保持喚醒直到手動關閉(∞)";
+"keep_awake.state_on_remaining" = "開啟 — 剩餘 %@";
+"keep_awake.state_auto_active" = "自動 — Claude Code 工作中";
+"keep_awake.state_auto_grace" = "自動 — Claude 已完成,再保持喚醒 %@";
+"keep_awake.hint_click_on" = "按一下讓 Mac 保持喚醒";
+"keep_awake.hint_click_off" = "按一下關閉";
+"keep_awake.hint_click_pause_auto" = "按一下暫停 — Claude 再次工作時自動恢復";
+"keep_awake.menu_for" = "保持喚醒 %@";
+"keep_awake.menu_indefinite" = "保持喚醒直到關閉";
+"keep_awake.menu_off" = "關閉保持喚醒";
 
 /* Sponsor slot */
 "sponsor.slot_title" = "此位置開放贊助";

--- a/Claude Usage/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Claude Usage/Resources/zh-Hant.lproj/Localizable.strings
@@ -1007,6 +1007,33 @@
 "notch.server.port_busy" = "連接埠 %@ 已被占用 — 是否有另一個 App 正在執行？";
 "notch.server.retry" = "重試";
 
+/* Keep Awake */
+"section.keep_awake_title" = "保持喚醒";
+"section.keep_awake_desc" = "防止 Mac 進入睡眠";
+"keep_awake.manual_title" = "手動控制";
+"keep_awake.manual_desc" = "隨時讓 Mac 保持喚醒,可選擇計時器";
+"keep_awake.enable" = "讓 Mac 保持喚醒";
+"keep_awake.enable_desc" = "暫時防止 Mac 進入睡眠";
+"keep_awake.status_active" = "目前正在讓 Mac 保持喚醒";
+"keep_awake.remaining" = "%@ 後關閉";
+"keep_awake.duration" = "持續時間";
+"keep_awake.duration.indefinite" = "直到手動關閉";
+"keep_awake.duration.custom" = "自訂…";
+"keep_awake.custom_hours" = "%d 小時";
+"keep_awake.auto_title" = "自動";
+"keep_awake.auto_card_desc" = "由 Claude Code 的活動控制睡眠防止";
+"keep_awake.auto" = "Claude Code 工作時保持喚醒";
+"keep_awake.auto_desc" = "當 Claude Code 工作階段進行中時,自動讓 Mac 保持喚醒。將安裝 Claude Code 掛鉤";
+"keep_awake.grace" = "閒置後允許睡眠";
+"keep_awake.grace.immediately" = "立即";
+"keep_awake.hooks_note" = "透過 ~/.claude/settings.json 中的 Claude Code 掛鉤偵測活動";
+"keep_awake.sleep_type" = "睡眠防止方式";
+"keep_awake.sleep_type_desc" = "選擇保持喚醒時螢幕是否維持開啟";
+"keep_awake.sleep_type.system" = "螢幕可睡眠";
+"keep_awake.sleep_type.display" = "保持螢幕開啟";
+"keep_awake.lid_note" = "闔上螢幕時無法防止睡眠";
+"keep_awake.toggle_tooltip" = "讓 Mac 保持喚醒";
+
 /* Sponsor slot */
 "sponsor.slot_title" = "此位置開放贊助";
 "sponsor.slot_cta" = "與我聯繫";

--- a/Claude Usage/Resources/zh-ch.lproj/Localizable.strings
+++ b/Claude Usage/Resources/zh-ch.lproj/Localizable.strings
@@ -1013,6 +1013,33 @@
 "notch.server.port_busy" = "端口 %@ 已被占用 — 是否有另一个应用实例正在运行？";
 "notch.server.retry" = "重试";
 
+/* Keep Awake */
+"section.keep_awake_title" = "保持唤醒";
+"section.keep_awake_desc" = "防止 Mac 进入睡眠";
+"keep_awake.manual_title" = "手动控制";
+"keep_awake.manual_desc" = "随时让 Mac 保持唤醒,可选择计时器";
+"keep_awake.enable" = "让 Mac 保持唤醒";
+"keep_awake.enable_desc" = "暂时防止 Mac 进入睡眠";
+"keep_awake.status_active" = "当前正在让 Mac 保持唤醒";
+"keep_awake.remaining" = "%@ 后关闭";
+"keep_awake.duration" = "持续时间";
+"keep_awake.duration.indefinite" = "直到手动关闭";
+"keep_awake.duration.custom" = "自定义…";
+"keep_awake.custom_hours" = "%d 小时";
+"keep_awake.auto_title" = "自动";
+"keep_awake.auto_card_desc" = "由 Claude Code 的活动控制睡眠防止";
+"keep_awake.auto" = "Claude Code 工作时保持唤醒";
+"keep_awake.auto_desc" = "当 Claude Code 会话进行中时,自动让 Mac 保持唤醒。将安装 Claude Code 钩子";
+"keep_awake.grace" = "空闲后允许睡眠";
+"keep_awake.grace.immediately" = "立即";
+"keep_awake.hooks_note" = "通过 ~/.claude/settings.json 中的 Claude Code 钩子检测活动";
+"keep_awake.sleep_type" = "睡眠防止方式";
+"keep_awake.sleep_type_desc" = "选择保持唤醒时屏幕是否保持开启";
+"keep_awake.sleep_type.system" = "屏幕可睡眠";
+"keep_awake.sleep_type.display" = "保持屏幕开启";
+"keep_awake.lid_note" = "合盖时无法防止睡眠";
+"keep_awake.toggle_tooltip" = "让 Mac 保持唤醒";
+
 /* Sponsor slot */
 "sponsor.slot_title" = "此位置开放赞助";
 "sponsor.slot_cta" = "与我联系";

--- a/Claude Usage/Resources/zh-ch.lproj/Localizable.strings
+++ b/Claude Usage/Resources/zh-ch.lproj/Localizable.strings
@@ -1017,7 +1017,7 @@
 "section.keep_awake_title" = "保持唤醒";
 "section.keep_awake_desc" = "防止 Mac 进入睡眠";
 "keep_awake.manual_title" = "手动控制";
-"keep_awake.manual_desc" = "随时让 Mac 保持唤醒,可选择计时器";
+"keep_awake.manual_desc" = "自行开启保持唤醒,可选择计时器";
 "keep_awake.enable" = "让 Mac 保持唤醒";
 "keep_awake.enable_desc" = "暂时防止 Mac 进入睡眠";
 "keep_awake.status_active" = "当前正在让 Mac 保持唤醒";
@@ -1027,18 +1027,21 @@
 "keep_awake.duration.custom" = "自定义…";
 "keep_awake.custom_hours" = "%d 小时";
 "keep_awake.auto_title" = "自动";
-"keep_awake.auto_card_desc" = "由 Claude Code 的活动控制睡眠防止";
+"keep_awake.auto_card_desc" = "推荐:仅在 Claude Code 实际工作时让 Mac 保持唤醒";
 "keep_awake.auto" = "Claude Code 工作时保持唤醒";
-"keep_awake.auto_desc" = "当 Claude Code 会话进行中时,自动让 Mac 保持唤醒。将安装 Claude Code 钩子";
-"keep_awake.grace" = "空闲后允许睡眠";
-"keep_awake.grace.immediately" = "立即";
+"keep_awake.auto_desc" = "Claude Code 会话进行中保持唤醒,结束后恢复允许睡眠。将安装 Claude Code 钩子";
+"keep_awake.grace" = "Claude 完成后,继续保持唤醒";
+"keep_awake.grace.immediately" = "不延长";
 "keep_awake.hooks_note" = "通过 ~/.claude/settings.json 中的 Claude Code 钩子检测活动";
 "keep_awake.sleep_type" = "睡眠防止方式";
 "keep_awake.sleep_type_desc" = "选择保持唤醒时屏幕是否保持开启";
 "keep_awake.sleep_type.system" = "屏幕可睡眠";
 "keep_awake.sleep_type.display" = "保持屏幕开启";
-"keep_awake.lid_note" = "合盖时无法防止睡眠";
-"keep_awake.toggle_tooltip" = "让 Mac 保持唤醒";
+"keep_awake.lid_note" = "合盖后,除非接通电源并使用外接显示器,Mac 仍会进入睡眠";
+"keep_awake.tooltip_off" = "让 Mac 保持唤醒 — 点按开启";
+"keep_awake.tooltip_on" = "正在让 Mac 保持唤醒 — 点按关闭";
+"keep_awake.tooltip_until" = "保持唤醒至 %@ — 点按关闭";
+"keep_awake.tooltip_auto" = "正在让 Mac 保持唤醒 — Claude Code 工作中";
 
 /* Sponsor slot */
 "sponsor.slot_title" = "此位置开放赞助";

--- a/Claude Usage/Resources/zh-ch.lproj/Localizable.strings
+++ b/Claude Usage/Resources/zh-ch.lproj/Localizable.strings
@@ -1044,6 +1044,7 @@
 "keep_awake.state_on_remaining" = "开启 — 剩余 %@";
 "keep_awake.state_auto_active" = "自动 — Claude Code 工作中";
 "keep_awake.state_auto_grace" = "自动 — Claude 已完成,再保持唤醒 %@";
+"keep_awake.state_auto_armed" = "自动已开启 — Claude Code 工作时让 Mac 保持唤醒";
 "keep_awake.hint_click_on" = "点按让 Mac 保持唤醒";
 "keep_awake.hint_click_off" = "点按关闭";
 "keep_awake.hint_click_pause_auto" = "点按暂停 — Claude 再次工作时自动恢复";

--- a/Claude Usage/Resources/zh-ch.lproj/Localizable.strings
+++ b/Claude Usage/Resources/zh-ch.lproj/Localizable.strings
@@ -1030,18 +1030,26 @@
 "keep_awake.auto_card_desc" = "推荐:仅在 Claude Code 实际工作时让 Mac 保持唤醒";
 "keep_awake.auto" = "Claude Code 工作时保持唤醒";
 "keep_awake.auto_desc" = "Claude Code 会话进行中保持唤醒,结束后恢复允许睡眠。将安装 Claude Code 钩子";
-"keep_awake.grace" = "Claude 完成后,继续保持唤醒";
-"keep_awake.grace.immediately" = "不延长";
+"keep_awake.grace" = "Claude Code 停止工作后";
+"keep_awake.grace.immediately" = "立即睡眠";
+"keep_awake.grace.stay" = "保持唤醒 %@";
 "keep_awake.hooks_note" = "通过 ~/.claude/settings.json 中的 Claude Code 钩子检测活动";
 "keep_awake.sleep_type" = "睡眠防止方式";
 "keep_awake.sleep_type_desc" = "选择保持唤醒时屏幕是否保持开启";
 "keep_awake.sleep_type.system" = "屏幕可睡眠";
 "keep_awake.sleep_type.display" = "保持屏幕开启";
 "keep_awake.lid_note" = "合盖后,除非接通电源并使用外接显示器,Mac 仍会进入睡眠";
-"keep_awake.tooltip_off" = "让 Mac 保持唤醒 — 点按开启";
-"keep_awake.tooltip_on" = "正在让 Mac 保持唤醒 — 点按关闭";
-"keep_awake.tooltip_until" = "保持唤醒至 %@ — 点按关闭";
-"keep_awake.tooltip_auto" = "正在让 Mac 保持唤醒 — Claude Code 工作中";
+"keep_awake.state_off" = "关闭";
+"keep_awake.state_on_indefinite" = "开启 — 保持唤醒直到手动关闭(∞)";
+"keep_awake.state_on_remaining" = "开启 — 剩余 %@";
+"keep_awake.state_auto_active" = "自动 — Claude Code 工作中";
+"keep_awake.state_auto_grace" = "自动 — Claude 已完成,再保持唤醒 %@";
+"keep_awake.hint_click_on" = "点按让 Mac 保持唤醒";
+"keep_awake.hint_click_off" = "点按关闭";
+"keep_awake.hint_click_pause_auto" = "点按暂停 — Claude 再次工作时自动恢复";
+"keep_awake.menu_for" = "保持唤醒 %@";
+"keep_awake.menu_indefinite" = "保持唤醒直到关闭";
+"keep_awake.menu_off" = "关闭保持唤醒";
 
 /* Sponsor slot */
 "sponsor.slot_title" = "此位置开放赞助";

--- a/Claude Usage/Resources/zh-ch.lproj/Localizable.strings
+++ b/Claude Usage/Resources/zh-ch.lproj/Localizable.strings
@@ -1045,9 +1045,9 @@
 "keep_awake.state_auto_active" = "自动 — Claude Code 工作中";
 "keep_awake.state_auto_grace" = "自动 — Claude 已完成,再保持唤醒 %@";
 "keep_awake.state_auto_armed" = "自动已开启 — Claude Code 工作时让 Mac 保持唤醒";
-"keep_awake.hint_click_on" = "点按让 Mac 保持唤醒";
+"keep_awake.hint_click_on" = "点按开启 — Claude Code 工作时让 Mac 保持唤醒";
 "keep_awake.hint_click_off" = "点按关闭";
-"keep_awake.hint_click_pause_auto" = "点按暂停 — Claude 再次工作时自动恢复";
+"keep_awake.hint_click_auto_off" = "点按关闭自动模式 — 将保持关闭,直到再次开启";
 "keep_awake.menu_for" = "保持唤醒 %@";
 "keep_awake.menu_indefinite" = "保持唤醒直到关闭";
 "keep_awake.menu_off" = "关闭保持唤醒";

--- a/Claude Usage/Resources/zh-ch.lproj/Localizable.strings
+++ b/Claude Usage/Resources/zh-ch.lproj/Localizable.strings
@@ -1038,6 +1038,7 @@
 "keep_awake.state_on_remaining" = "开启 — 剩余 %@";
 "keep_awake.state_auto_active" = "自动 — Claude Code 工作中";
 "keep_awake.state_auto_grace" = "自动 — Claude 已完成,再保持唤醒 %@";
+"keep_awake.state_auto_armed" = "自动已开启 — Claude Code 工作时让 Mac 保持唤醒";
 "keep_awake.hint_click_on" = "点按让 Mac 保持唤醒";
 "keep_awake.hint_click_off" = "点按关闭";
 "keep_awake.hint_click_pause_auto" = "点按暂停 — Claude 再次工作时自动恢复";

--- a/Claude Usage/Resources/zh-ch.lproj/Localizable.strings
+++ b/Claude Usage/Resources/zh-ch.lproj/Localizable.strings
@@ -1007,6 +1007,33 @@
 "notch.server.port_busy" = "端口 %@ 已被占用 — 是否有另一个应用实例正在运行？";
 "notch.server.retry" = "重试";
 
+/* Keep Awake */
+"section.keep_awake_title" = "保持唤醒";
+"section.keep_awake_desc" = "防止 Mac 进入睡眠";
+"keep_awake.manual_title" = "手动控制";
+"keep_awake.manual_desc" = "随时让 Mac 保持唤醒,可选择计时器";
+"keep_awake.enable" = "让 Mac 保持唤醒";
+"keep_awake.enable_desc" = "暂时防止 Mac 进入睡眠";
+"keep_awake.status_active" = "当前正在让 Mac 保持唤醒";
+"keep_awake.remaining" = "%@ 后关闭";
+"keep_awake.duration" = "持续时间";
+"keep_awake.duration.indefinite" = "直到手动关闭";
+"keep_awake.duration.custom" = "自定义…";
+"keep_awake.custom_hours" = "%d 小时";
+"keep_awake.auto_title" = "自动";
+"keep_awake.auto_card_desc" = "由 Claude Code 的活动控制睡眠防止";
+"keep_awake.auto" = "Claude Code 工作时保持唤醒";
+"keep_awake.auto_desc" = "当 Claude Code 会话进行中时,自动让 Mac 保持唤醒。将安装 Claude Code 钩子";
+"keep_awake.grace" = "空闲后允许睡眠";
+"keep_awake.grace.immediately" = "立即";
+"keep_awake.hooks_note" = "通过 ~/.claude/settings.json 中的 Claude Code 钩子检测活动";
+"keep_awake.sleep_type" = "睡眠防止方式";
+"keep_awake.sleep_type_desc" = "选择保持唤醒时屏幕是否保持开启";
+"keep_awake.sleep_type.system" = "屏幕可睡眠";
+"keep_awake.sleep_type.display" = "保持屏幕开启";
+"keep_awake.lid_note" = "合盖时无法防止睡眠";
+"keep_awake.toggle_tooltip" = "让 Mac 保持唤醒";
+
 /* Sponsor slot */
 "sponsor.slot_title" = "此位置开放赞助";
 "sponsor.slot_cta" = "与我联系";

--- a/Claude Usage/Resources/zh-ch.lproj/Localizable.strings
+++ b/Claude Usage/Resources/zh-ch.lproj/Localizable.strings
@@ -1024,18 +1024,26 @@
 "keep_awake.auto_card_desc" = "推荐:仅在 Claude Code 实际工作时让 Mac 保持唤醒";
 "keep_awake.auto" = "Claude Code 工作时保持唤醒";
 "keep_awake.auto_desc" = "Claude Code 会话进行中保持唤醒,结束后恢复允许睡眠。将安装 Claude Code 钩子";
-"keep_awake.grace" = "Claude 完成后,继续保持唤醒";
-"keep_awake.grace.immediately" = "不延长";
+"keep_awake.grace" = "Claude Code 停止工作后";
+"keep_awake.grace.immediately" = "立即睡眠";
+"keep_awake.grace.stay" = "保持唤醒 %@";
 "keep_awake.hooks_note" = "通过 ~/.claude/settings.json 中的 Claude Code 钩子检测活动";
 "keep_awake.sleep_type" = "睡眠防止方式";
 "keep_awake.sleep_type_desc" = "选择保持唤醒时屏幕是否保持开启";
 "keep_awake.sleep_type.system" = "屏幕可睡眠";
 "keep_awake.sleep_type.display" = "保持屏幕开启";
 "keep_awake.lid_note" = "合盖后,除非接通电源并使用外接显示器,Mac 仍会进入睡眠";
-"keep_awake.tooltip_off" = "让 Mac 保持唤醒 — 点按开启";
-"keep_awake.tooltip_on" = "正在让 Mac 保持唤醒 — 点按关闭";
-"keep_awake.tooltip_until" = "保持唤醒至 %@ — 点按关闭";
-"keep_awake.tooltip_auto" = "正在让 Mac 保持唤醒 — Claude Code 工作中";
+"keep_awake.state_off" = "关闭";
+"keep_awake.state_on_indefinite" = "开启 — 保持唤醒直到手动关闭(∞)";
+"keep_awake.state_on_remaining" = "开启 — 剩余 %@";
+"keep_awake.state_auto_active" = "自动 — Claude Code 工作中";
+"keep_awake.state_auto_grace" = "自动 — Claude 已完成,再保持唤醒 %@";
+"keep_awake.hint_click_on" = "点按让 Mac 保持唤醒";
+"keep_awake.hint_click_off" = "点按关闭";
+"keep_awake.hint_click_pause_auto" = "点按暂停 — Claude 再次工作时自动恢复";
+"keep_awake.menu_for" = "保持唤醒 %@";
+"keep_awake.menu_indefinite" = "保持唤醒直到关闭";
+"keep_awake.menu_off" = "关闭保持唤醒";
 
 /* Sponsor slot */
 "sponsor.slot_title" = "此位置开放赞助";

--- a/Claude Usage/Resources/zh-ch.lproj/Localizable.strings
+++ b/Claude Usage/Resources/zh-ch.lproj/Localizable.strings
@@ -1039,9 +1039,9 @@
 "keep_awake.state_auto_active" = "自动 — Claude Code 工作中";
 "keep_awake.state_auto_grace" = "自动 — Claude 已完成,再保持唤醒 %@";
 "keep_awake.state_auto_armed" = "自动已开启 — Claude Code 工作时让 Mac 保持唤醒";
-"keep_awake.hint_click_on" = "点按让 Mac 保持唤醒";
+"keep_awake.hint_click_on" = "点按开启 — Claude Code 工作时让 Mac 保持唤醒";
 "keep_awake.hint_click_off" = "点按关闭";
-"keep_awake.hint_click_pause_auto" = "点按暂停 — Claude 再次工作时自动恢复";
+"keep_awake.hint_click_auto_off" = "点按关闭自动模式 — 将保持关闭,直到再次开启";
 "keep_awake.menu_for" = "保持唤醒 %@";
 "keep_awake.menu_indefinite" = "保持唤醒直到关闭";
 "keep_awake.menu_off" = "关闭保持唤醒";

--- a/Claude Usage/Resources/zh-ch.lproj/Localizable.strings
+++ b/Claude Usage/Resources/zh-ch.lproj/Localizable.strings
@@ -1011,7 +1011,7 @@
 "section.keep_awake_title" = "保持唤醒";
 "section.keep_awake_desc" = "防止 Mac 进入睡眠";
 "keep_awake.manual_title" = "手动控制";
-"keep_awake.manual_desc" = "随时让 Mac 保持唤醒,可选择计时器";
+"keep_awake.manual_desc" = "自行开启保持唤醒,可选择计时器";
 "keep_awake.enable" = "让 Mac 保持唤醒";
 "keep_awake.enable_desc" = "暂时防止 Mac 进入睡眠";
 "keep_awake.status_active" = "当前正在让 Mac 保持唤醒";
@@ -1021,18 +1021,21 @@
 "keep_awake.duration.custom" = "自定义…";
 "keep_awake.custom_hours" = "%d 小时";
 "keep_awake.auto_title" = "自动";
-"keep_awake.auto_card_desc" = "由 Claude Code 的活动控制睡眠防止";
+"keep_awake.auto_card_desc" = "推荐:仅在 Claude Code 实际工作时让 Mac 保持唤醒";
 "keep_awake.auto" = "Claude Code 工作时保持唤醒";
-"keep_awake.auto_desc" = "当 Claude Code 会话进行中时,自动让 Mac 保持唤醒。将安装 Claude Code 钩子";
-"keep_awake.grace" = "空闲后允许睡眠";
-"keep_awake.grace.immediately" = "立即";
+"keep_awake.auto_desc" = "Claude Code 会话进行中保持唤醒,结束后恢复允许睡眠。将安装 Claude Code 钩子";
+"keep_awake.grace" = "Claude 完成后,继续保持唤醒";
+"keep_awake.grace.immediately" = "不延长";
 "keep_awake.hooks_note" = "通过 ~/.claude/settings.json 中的 Claude Code 钩子检测活动";
 "keep_awake.sleep_type" = "睡眠防止方式";
 "keep_awake.sleep_type_desc" = "选择保持唤醒时屏幕是否保持开启";
 "keep_awake.sleep_type.system" = "屏幕可睡眠";
 "keep_awake.sleep_type.display" = "保持屏幕开启";
-"keep_awake.lid_note" = "合盖时无法防止睡眠";
-"keep_awake.toggle_tooltip" = "让 Mac 保持唤醒";
+"keep_awake.lid_note" = "合盖后,除非接通电源并使用外接显示器,Mac 仍会进入睡眠";
+"keep_awake.tooltip_off" = "让 Mac 保持唤醒 — 点按开启";
+"keep_awake.tooltip_on" = "正在让 Mac 保持唤醒 — 点按关闭";
+"keep_awake.tooltip_until" = "保持唤醒至 %@ — 点按关闭";
+"keep_awake.tooltip_auto" = "正在让 Mac 保持唤醒 — Claude Code 工作中";
 
 /* Sponsor slot */
 "sponsor.slot_title" = "此位置开放赞助";

--- a/Claude Usage/Shared/Extensions/Notification+Extensions.swift
+++ b/Claude Usage/Shared/Extensions/Notification+Extensions.swift
@@ -32,4 +32,7 @@ extension Notification.Name {
 
     /// Posted when a Claude Code notch HUD setting is toggled (enabled/auto-hide)
     static let notchHUDSettingChanged = Notification.Name("notchHUDSettingChanged")
+
+    /// Posted when a Keep Awake setting changes (auto mode, sleep mode, grace period)
+    static let keepAwakeSettingChanged = Notification.Name("keepAwakeSettingChanged")
 }

--- a/Claude Usage/Shared/Extensions/Notification+Extensions.swift
+++ b/Claude Usage/Shared/Extensions/Notification+Extensions.swift
@@ -29,4 +29,7 @@ extension Notification.Name {
 
     /// Posted when a Claude Code notch HUD setting is toggled (enabled/auto-hide)
     static let notchHUDSettingChanged = Notification.Name("notchHUDSettingChanged")
+
+    /// Posted when a Keep Awake setting changes (auto mode, sleep mode, grace period)
+    static let keepAwakeSettingChanged = Notification.Name("keepAwakeSettingChanged")
 }

--- a/Claude Usage/Shared/Services/KeepAwakeService.swift
+++ b/Claude Usage/Shared/Services/KeepAwakeService.swift
@@ -2,7 +2,7 @@
 //  KeepAwakeService.swift
 //  Claude Usage
 //
-//  Amphetamine-style sleep prevention. Holds a single named IOKit power
+//  Keep Awake sleep prevention. Holds a single named IOKit power
 //  assertion while either the manual toggle is on (optionally time-limited)
 //  or auto mode detects an active Claude Code session (with a configurable
 //  grace period after activity stops). Assertion lifecycle is centralized
@@ -58,7 +58,7 @@ final class KeepAwakeService: ObservableObject {
     /// Published: the popover button renders an "armed" state from this, and
     /// flipping it while idle changes no other published property.
     @Published private(set) var autoEnabled = false
-    private(set) var sleepMode: SleepMode = .allowDisplaySleep
+    private(set) var sleepMode: SleepMode = .preventDisplaySleep
     /// Manual duration in seconds; 0 = indefinite.
     private(set) var defaultDuration: TimeInterval = 0
     /// Auto mode keeps the assertion this long after sessions go idle; 0 = release immediately.
@@ -83,7 +83,7 @@ final class KeepAwakeService: ObservableObject {
     }
     var loadSettings: () -> (autoEnabled: Bool, sleepMode: SleepMode, defaultDuration: TimeInterval, gracePeriod: TimeInterval) = {
         let store = SharedDataStore.shared
-        let mode = store.loadKeepAwakeSleepMode().flatMap(SleepMode.init(rawValue:)) ?? .allowDisplaySleep
+        let mode = store.loadKeepAwakeSleepMode().flatMap(SleepMode.init(rawValue:)) ?? .preventDisplaySleep
         return (
             autoEnabled: store.loadKeepAwakeAutoEnabled(),
             sleepMode: mode,

--- a/Claude Usage/Shared/Services/KeepAwakeService.swift
+++ b/Claude Usage/Shared/Services/KeepAwakeService.swift
@@ -144,19 +144,24 @@ final class KeepAwakeService: ObservableObject {
     }
 
     /// One-click mental model for the popover button: lit means "your Mac is
-    /// being kept awake", and clicking always flips that. Off → start a manual
-    /// hold. On → end whatever is holding, including dismissing a current auto
-    /// hold (auto resumes on Claude's next activity; the setting stays on).
+    /// being kept awake", and clicking always flips that. On → end whatever is
+    /// holding, including dismissing a current auto hold (the setting stays
+    /// on). Off → resume the dismissed auto hold if it would still be holding;
+    /// only start a manual hold when auto has nothing to hold right now.
     func smartToggle() {
         if isAssertionHeld {
             isManualOn = false
             manualExpiry = nil
             if isAutoHolding {
                 autoSuppressed = true
-                lastActiveDate = nil
             }
             reconcile()
         } else {
+            if autoEnabled, autoSuppressed {
+                autoSuppressed = false
+                reconcile()
+                if isAssertionHeld { return }
+            }
             setManual(on: true)
         }
     }

--- a/Claude Usage/Shared/Services/KeepAwakeService.swift
+++ b/Claude Usage/Shared/Services/KeepAwakeService.swift
@@ -49,6 +49,9 @@ final class KeepAwakeService: ObservableObject {
     @Published private(set) var isAssertionHeld = false
     /// True while the auto branch (active session or grace period) holds the assertion.
     @Published private(set) var isAutoHolding = false
+    /// When the auto branch is in its grace window, the instant it will let go;
+    /// nil while sessions are actively working (or auto isn't holding).
+    @Published private(set) var autoGraceExpiry: Date?
 
     // MARK: - Settings (reloaded via settingsChanged())
 
@@ -94,6 +97,10 @@ final class KeepAwakeService: ObservableObject {
     private var heldMode: SleepMode?
     /// Last instant a Claude Code session was seen actively working.
     private var lastActiveDate: Date?
+    /// Set by smartToggle() while an auto hold is dismissed; cleared when
+    /// activity next resumes so auto mode picks the following task back up.
+    private var autoSuppressed = false
+    private var wereSessionsActive = false
     private var deadlineTimer: Timer?
     private var cancellables: Set<AnyCancellable> = []
     private var started = false
@@ -136,15 +143,48 @@ final class KeepAwakeService: ObservableObject {
         setManual(on: !isManualOn)
     }
 
-    func setManual(on: Bool) {
+    /// One-click mental model for the popover button: lit means "your Mac is
+    /// being kept awake", and clicking always flips that. Off → start a manual
+    /// hold. On → end whatever is holding, including dismissing a current auto
+    /// hold (auto resumes on Claude's next activity; the setting stays on).
+    func smartToggle() {
+        if isAssertionHeld {
+            isManualOn = false
+            manualExpiry = nil
+            if isAutoHolding {
+                autoSuppressed = true
+                lastActiveDate = nil
+            }
+            reconcile()
+        } else {
+            setManual(on: true)
+        }
+    }
+
+    /// `duration` overrides the persisted default (menu quick-picks); 0 = indefinite.
+    func setManual(on: Bool, duration: TimeInterval? = nil) {
         if on {
             isManualOn = true
-            manualExpiry = defaultDuration > 0 ? now().addingTimeInterval(defaultDuration) : nil
+            let holdDuration = duration ?? defaultDuration
+            manualExpiry = holdDuration > 0 ? now().addingTimeInterval(holdDuration) : nil
         } else {
             isManualOn = false
             manualExpiry = nil
         }
         reconcile()
+    }
+
+    /// Single entry point for flipping auto mode (settings pane and the
+    /// button's context menu): persists, manages the shared hooks, and
+    /// notifies AppDelegate to re-gate the hook server.
+    func setAutoEnabled(_ enabled: Bool) {
+        SharedDataStore.shared.saveKeepAwakeAutoEnabled(enabled)
+        if enabled {
+            NotchHookInstaller.shared.install()
+        } else if !SharedDataStore.shared.loadNotchHUDEnabled() {
+            NotchHookInstaller.shared.uninstall()
+        }
+        NotificationCenter.default.post(name: .keepAwakeSettingChanged, object: nil)
     }
 
     /// Re-reads persisted settings and reapplies them (sleep-mode changes
@@ -174,6 +214,11 @@ final class KeepAwakeService: ObservableObject {
         // period keeps holding until it elapses or activity resumes.
         let sessionsActive = !currentSessions.isEmpty
             && !currentSessions.allSatisfy { $0.status == .idle }
+        if sessionsActive, !wereSessionsActive {
+            // A fresh burst of activity lifts any smartToggle dismissal.
+            autoSuppressed = false
+        }
+        wereSessionsActive = sessionsActive
         if sessionsActive {
             lastActiveDate = reference
         }
@@ -181,7 +226,7 @@ final class KeepAwakeService: ObservableObject {
             guard !sessionsActive, gracePeriod > 0, let last = lastActiveDate else { return false }
             return reference.timeIntervalSince(last) < gracePeriod
         }()
-        let autoActive = autoEnabled && (sessionsActive || inGrace)
+        let autoActive = autoEnabled && !autoSuppressed && (sessionsActive || inGrace)
 
         // Apply: at most one assertion, re-acquired when the mode changed.
         let desired = manualActive || autoActive
@@ -199,6 +244,9 @@ final class KeepAwakeService: ObservableObject {
 
         isAssertionHeld = assertionID != nil
         isAutoHolding = autoActive && isAssertionHeld
+        autoGraceExpiry = (isAutoHolding && !sessionsActive && gracePeriod > 0)
+            ? lastActiveDate?.addingTimeInterval(gracePeriod)
+            : nil
         scheduleDeadlineCheck(sessionsActive: sessionsActive, reference: reference)
     }
 

--- a/Claude Usage/Shared/Services/KeepAwakeService.swift
+++ b/Claude Usage/Shared/Services/KeepAwakeService.swift
@@ -97,10 +97,6 @@ final class KeepAwakeService: ObservableObject {
     private var heldMode: SleepMode?
     /// Last instant a Claude Code session was seen actively working.
     private var lastActiveDate: Date?
-    /// Set by smartToggle() while an auto hold is dismissed; cleared when
-    /// activity next resumes so auto mode picks the following task back up.
-    private var autoSuppressed = false
-    private var wereSessionsActive = false
     private var deadlineTimer: Timer?
     private var cancellables: Set<AnyCancellable> = []
     private var started = false
@@ -143,26 +139,16 @@ final class KeepAwakeService: ObservableObject {
         setManual(on: !isManualOn)
     }
 
-    /// One-click mental model for the popover button: lit means "your Mac is
-    /// being kept awake", and clicking always flips that. On → end whatever is
-    /// holding, including dismissing a current auto hold (the setting stays
-    /// on). Off → resume the dismissed auto hold if it would still be holding;
-    /// only start a manual hold when auto has nothing to hold right now.
+    /// The popover button is primarily an auto-mode switch: the first click a
+    /// user ever makes turns auto mode on (that click is the hooks opt-in),
+    /// and clicking while auto is on turns it off — remembered until turned
+    /// back on. Manual/timed holds only exist when explicitly chosen (menu
+    /// quick-picks or the settings pane); a click cancels those first.
     func smartToggle() {
-        if isAssertionHeld {
-            isManualOn = false
-            manualExpiry = nil
-            if isAutoHolding {
-                autoSuppressed = true
-            }
-            reconcile()
+        if isManualOn {
+            setManual(on: false)
         } else {
-            if autoEnabled, autoSuppressed {
-                autoSuppressed = false
-                reconcile()
-                if isAssertionHeld { return }
-            }
-            setManual(on: true)
+            setAutoEnabled(!autoEnabled)
         }
     }
 
@@ -179,10 +165,16 @@ final class KeepAwakeService: ObservableObject {
         reconcile()
     }
 
-    /// Single entry point for flipping auto mode (settings pane and the
-    /// button's context menu): persists, manages the shared hooks, and
-    /// notifies AppDelegate to re-gate the hook server.
+    /// Single entry point for flipping auto mode (popover click, context menu,
+    /// settings pane): persists + manages hooks via the seam, then reapplies.
     func setAutoEnabled(_ enabled: Bool) {
+        persistAutoEnabled(enabled)
+        settingsChanged()
+    }
+
+    /// Test seam: persists the auto-mode setting, manages the shared hooks,
+    /// and notifies AppDelegate to re-gate the hook server.
+    var persistAutoEnabled: (Bool) -> Void = { enabled in
         SharedDataStore.shared.saveKeepAwakeAutoEnabled(enabled)
         if enabled {
             NotchHookInstaller.shared.install()
@@ -219,11 +211,6 @@ final class KeepAwakeService: ObservableObject {
         // period keeps holding until it elapses or activity resumes.
         let sessionsActive = !currentSessions.isEmpty
             && !currentSessions.allSatisfy { $0.status == .idle }
-        if sessionsActive, !wereSessionsActive {
-            // A fresh burst of activity lifts any smartToggle dismissal.
-            autoSuppressed = false
-        }
-        wereSessionsActive = sessionsActive
         if sessionsActive {
             lastActiveDate = reference
         }
@@ -231,7 +218,7 @@ final class KeepAwakeService: ObservableObject {
             guard !sessionsActive, gracePeriod > 0, let last = lastActiveDate else { return false }
             return reference.timeIntervalSince(last) < gracePeriod
         }()
-        let autoActive = autoEnabled && !autoSuppressed && (sessionsActive || inGrace)
+        let autoActive = autoEnabled && (sessionsActive || inGrace)
 
         // Apply: at most one assertion, re-acquired when the mode changed.
         let desired = manualActive || autoActive

--- a/Claude Usage/Shared/Services/KeepAwakeService.swift
+++ b/Claude Usage/Shared/Services/KeepAwakeService.swift
@@ -60,7 +60,7 @@ final class KeepAwakeService: ObservableObject {
     /// Manual duration in seconds; 0 = indefinite.
     private(set) var defaultDuration: TimeInterval = 0
     /// Auto mode keeps the assertion this long after sessions go idle; 0 = release immediately.
-    private(set) var gracePeriod: TimeInterval = 15 * 60
+    private(set) var gracePeriod: TimeInterval = 30 * 60
 
     // MARK: - Test seams
 

--- a/Claude Usage/Shared/Services/KeepAwakeService.swift
+++ b/Claude Usage/Shared/Services/KeepAwakeService.swift
@@ -1,0 +1,247 @@
+//
+//  KeepAwakeService.swift
+//  Claude Usage
+//
+//  Amphetamine-style sleep prevention. Holds a single named IOKit power
+//  assertion while either the manual toggle is on (optionally time-limited)
+//  or auto mode detects an active Claude Code session (with a configurable
+//  grace period after activity stops). Assertion lifecycle is centralized
+//  in reconcile() so create/release stays idempotent, and the kernel drops
+//  the assertion automatically if the process exits.
+//
+//  Idle-sleep assertions do NOT prevent sleep when the lid is closed; the
+//  settings UI documents this.
+//
+
+import Foundation
+import Combine
+import IOKit.pwr_mgt
+
+@MainActor
+final class KeepAwakeService: ObservableObject {
+    static let shared = KeepAwakeService()
+
+    enum SleepMode: String, CaseIterable {
+        /// System stays awake, display may sleep (default — long Claude Code
+        /// runs keep going with the screen off).
+        case allowDisplaySleep
+        /// Display and system both stay awake.
+        case preventDisplaySleep
+
+        var assertionType: String {
+            switch self {
+            case .allowDisplaySleep:
+                return kIOPMAssertionTypePreventUserIdleSystemSleep as String
+            case .preventDisplaySleep:
+                return kIOPMAssertionTypePreventUserIdleDisplaySleep as String
+            }
+        }
+    }
+
+    // ASCII-only: pmset renders non-ASCII assertion names as mojibake.
+    static let assertionName = "Claude Usage - Keep Awake"
+
+    // MARK: - Published state
+
+    @Published private(set) var isManualOn = false
+    /// Wall-clock instant the manual hold auto-disables; nil = indefinite/off.
+    @Published private(set) var manualExpiry: Date?
+    @Published private(set) var isAssertionHeld = false
+    /// True while the auto branch (active session or grace period) holds the assertion.
+    @Published private(set) var isAutoHolding = false
+
+    // MARK: - Settings (reloaded via settingsChanged())
+
+    private(set) var autoEnabled = false
+    private(set) var sleepMode: SleepMode = .allowDisplaySleep
+    /// Manual duration in seconds; 0 = indefinite.
+    private(set) var defaultDuration: TimeInterval = 0
+    /// Auto mode keeps the assertion this long after sessions go idle; 0 = release immediately.
+    private(set) var gracePeriod: TimeInterval = 15 * 60
+
+    // MARK: - Test seams
+
+    /// Injectable clock for tests.
+    var now: () -> Date = { Date() }
+    var createAssertion: (SleepMode) -> IOPMAssertionID? = { mode in
+        var id = IOPMAssertionID(0)
+        let result = IOPMAssertionCreateWithName(
+            mode.assertionType as CFString,
+            IOPMAssertionLevel(kIOPMAssertionLevelOn),
+            KeepAwakeService.assertionName as CFString,
+            &id
+        )
+        return result == kIOReturnSuccess ? id : nil
+    }
+    var releaseAssertion: (IOPMAssertionID) -> Void = { id in
+        IOPMAssertionRelease(id)
+    }
+    var loadSettings: () -> (autoEnabled: Bool, sleepMode: SleepMode, defaultDuration: TimeInterval, gracePeriod: TimeInterval) = {
+        let store = SharedDataStore.shared
+        let mode = store.loadKeepAwakeSleepMode().flatMap(SleepMode.init(rawValue:)) ?? .allowDisplaySleep
+        return (
+            autoEnabled: store.loadKeepAwakeAutoEnabled(),
+            sleepMode: mode,
+            defaultDuration: store.loadKeepAwakeDefaultDuration(),
+            gracePeriod: store.loadKeepAwakeAutoGracePeriod()
+        )
+    }
+
+    // MARK: - Private state
+
+    private let sessionStore: NotchSessionStore
+    private var assertionID: IOPMAssertionID?
+    private var heldMode: SleepMode?
+    /// Last instant a Claude Code session was seen actively working.
+    private var lastActiveDate: Date?
+    private var deadlineTimer: Timer?
+    private var cancellables: Set<AnyCancellable> = []
+    private var started = false
+
+    init(sessionStore: NotchSessionStore = .shared) {
+        self.sessionStore = sessionStore
+    }
+
+    // MARK: - Lifecycle
+
+    func start() {
+        guard !started else { return }
+        started = true
+
+        reloadSettings()
+        sessionStore.$sessions
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] sessions in
+                self?.reconcile(sessions: sessions)
+            }
+            .store(in: &cancellables)
+        reconcile()
+    }
+
+    func stop() {
+        cancellables.removeAll()
+        deadlineTimer?.invalidate()
+        deadlineTimer = nil
+        isManualOn = false
+        manualExpiry = nil
+        releaseIfHeld()
+        isAssertionHeld = false
+        isAutoHolding = false
+        started = false
+    }
+
+    // MARK: - Manual control
+
+    func toggleManual() {
+        setManual(on: !isManualOn)
+    }
+
+    func setManual(on: Bool) {
+        if on {
+            isManualOn = true
+            manualExpiry = defaultDuration > 0 ? now().addingTimeInterval(defaultDuration) : nil
+        } else {
+            isManualOn = false
+            manualExpiry = nil
+        }
+        reconcile()
+    }
+
+    /// Re-reads persisted settings and reapplies them (sleep-mode changes
+    /// release + re-acquire the assertion with the new type).
+    func settingsChanged() {
+        reloadSettings()
+        reconcile()
+    }
+
+    // MARK: - Reconcile
+
+    /// Single idempotent sync point between desired state and the held
+    /// assertion. `sessions` overrides the store's array when delivered via
+    /// the Combine sink (whose values arrive before the store property updates).
+    func reconcile(sessions: [ClaudeCodeSession]? = nil) {
+        let reference = now()
+        let currentSessions = sessions ?? sessionStore.sessions
+
+        // Manual branch, expiring the timed hold if its deadline passed.
+        if isManualOn, let expiry = manualExpiry, reference >= expiry {
+            isManualOn = false
+            manualExpiry = nil
+        }
+        let manualActive = isManualOn
+
+        // Auto branch: active sessions hold; after they stop, the grace
+        // period keeps holding until it elapses or activity resumes.
+        let sessionsActive = !currentSessions.isEmpty
+            && !currentSessions.allSatisfy { $0.status == .idle }
+        if sessionsActive {
+            lastActiveDate = reference
+        }
+        let inGrace: Bool = {
+            guard !sessionsActive, gracePeriod > 0, let last = lastActiveDate else { return false }
+            return reference.timeIntervalSince(last) < gracePeriod
+        }()
+        let autoActive = autoEnabled && (sessionsActive || inGrace)
+
+        // Apply: at most one assertion, re-acquired when the mode changed.
+        let desired = manualActive || autoActive
+        if desired {
+            if assertionID == nil || heldMode != sleepMode {
+                releaseIfHeld()
+                if let id = createAssertion(sleepMode) {
+                    assertionID = id
+                    heldMode = sleepMode
+                }
+            }
+        } else {
+            releaseIfHeld()
+        }
+
+        isAssertionHeld = assertionID != nil
+        isAutoHolding = autoActive && isAssertionHeld
+        scheduleDeadlineCheck(sessionsActive: sessionsActive, reference: reference)
+    }
+
+    // MARK: - Private
+
+    private func reloadSettings() {
+        let settings = loadSettings()
+        autoEnabled = settings.autoEnabled
+        sleepMode = settings.sleepMode
+        defaultDuration = settings.defaultDuration
+        gracePeriod = settings.gracePeriod
+    }
+
+    private func releaseIfHeld() {
+        if let id = assertionID {
+            releaseAssertion(id)
+            assertionID = nil
+            heldMode = nil
+        }
+    }
+
+    /// Timers only exist to revisit wall-clock deadlines (manual expiry,
+    /// grace-period end); session events re-reconcile via the Combine sink.
+    private func scheduleDeadlineCheck(sessionsActive: Bool, reference: Date) {
+        deadlineTimer?.invalidate()
+        deadlineTimer = nil
+
+        var deadlines: [Date] = []
+        if isManualOn, let expiry = manualExpiry {
+            deadlines.append(expiry)
+        }
+        if autoEnabled, !sessionsActive, gracePeriod > 0, let last = lastActiveDate {
+            let graceEnd = last.addingTimeInterval(gracePeriod)
+            if graceEnd > reference { deadlines.append(graceEnd) }
+        }
+        guard let fireDate = deadlines.min() else { return }
+
+        // Small pad so the check runs just after the deadline passes.
+        let interval = max(0.5, fireDate.timeIntervalSince(reference) + 0.1)
+        let timer = Timer(timeInterval: interval, repeats: false) { [weak self] _ in
+            Task { @MainActor [weak self] in self?.reconcile() }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        deadlineTimer = timer
+    }
+}

--- a/Claude Usage/Shared/Services/KeepAwakeService.swift
+++ b/Claude Usage/Shared/Services/KeepAwakeService.swift
@@ -55,7 +55,9 @@ final class KeepAwakeService: ObservableObject {
 
     // MARK: - Settings (reloaded via settingsChanged())
 
-    private(set) var autoEnabled = false
+    /// Published: the popover button renders an "armed" state from this, and
+    /// flipping it while idle changes no other published property.
+    @Published private(set) var autoEnabled = false
     private(set) var sleepMode: SleepMode = .allowDisplaySleep
     /// Manual duration in seconds; 0 = indefinite.
     private(set) var defaultDuration: TimeInterval = 0

--- a/Claude Usage/Shared/Services/KeepAwakeService.swift
+++ b/Claude Usage/Shared/Services/KeepAwakeService.swift
@@ -22,10 +22,11 @@ final class KeepAwakeService: ObservableObject {
     static let shared = KeepAwakeService()
 
     enum SleepMode: String, CaseIterable {
-        /// System stays awake, display may sleep (default — long Claude Code
-        /// runs keep going with the screen off).
+        /// System stays awake, display may sleep. Battery-friendlier, but a
+        /// dark, locked display can look like the Mac actually slept.
         case allowDisplaySleep
-        /// Display and system both stay awake.
+        /// Display and system both stay awake (default — keeps the awake state
+        /// visible at a glance).
         case preventDisplaySleep
 
         var assertionType: String {

--- a/Claude Usage/Shared/Services/KeepAwakeService.swift
+++ b/Claude Usage/Shared/Services/KeepAwakeService.swift
@@ -62,7 +62,7 @@ final class KeepAwakeService: ObservableObject {
     /// Manual duration in seconds; 0 = indefinite.
     private(set) var defaultDuration: TimeInterval = 0
     /// Auto mode keeps the assertion this long after sessions go idle; 0 = release immediately.
-    private(set) var gracePeriod: TimeInterval = 30 * 60
+    private(set) var gracePeriod: TimeInterval = 60 * 60
 
     // MARK: - Test seams
 

--- a/Claude Usage/Shared/Storage/SharedDataStore.swift
+++ b/Claude Usage/Shared/Storage/SharedDataStore.swift
@@ -167,7 +167,10 @@ class SharedDataStore {
 
     func loadKeepAwakeAutoGracePeriod() -> TimeInterval {
         if defaults.object(forKey: Constants.UserDefaultsKeys.keepAwakeAutoGracePeriod) == nil {
-            return 30 * 60
+            // Hooks emit no events while Claude Code compacts or streams a long
+            // response without tool calls, so sessions can look idle mid-work;
+            // a generous default bridges those gaps.
+            return 60 * 60
         }
         return defaults.double(forKey: Constants.UserDefaultsKeys.keepAwakeAutoGracePeriod)
     }

--- a/Claude Usage/Shared/Storage/SharedDataStore.swift
+++ b/Claude Usage/Shared/Storage/SharedDataStore.swift
@@ -129,6 +129,47 @@ class SharedDataStore {
         return token
     }
 
+    // MARK: - Keep Awake
+
+    func saveKeepAwakeAutoEnabled(_ enabled: Bool) {
+        defaults.set(enabled, forKey: Constants.UserDefaultsKeys.keepAwakeAutoEnabled)
+    }
+
+    func loadKeepAwakeAutoEnabled() -> Bool {
+        // Default false: enabling installs hooks into ~/.claude/settings.json,
+        // which must be an explicit user choice.
+        return defaults.bool(forKey: Constants.UserDefaultsKeys.keepAwakeAutoEnabled)
+    }
+
+    func saveKeepAwakeSleepMode(_ rawValue: String) {
+        defaults.set(rawValue, forKey: Constants.UserDefaultsKeys.keepAwakeSleepMode)
+    }
+
+    func loadKeepAwakeSleepMode() -> String? {
+        return defaults.string(forKey: Constants.UserDefaultsKeys.keepAwakeSleepMode)
+    }
+
+    /// Default manual keep-awake duration in seconds. 0 means indefinite.
+    func saveKeepAwakeDefaultDuration(_ duration: TimeInterval) {
+        defaults.set(duration, forKey: Constants.UserDefaultsKeys.keepAwakeDefaultDuration)
+    }
+
+    func loadKeepAwakeDefaultDuration() -> TimeInterval {
+        return defaults.double(forKey: Constants.UserDefaultsKeys.keepAwakeDefaultDuration)
+    }
+
+    /// How long auto mode keeps the Mac awake after Claude Code goes idle.
+    func saveKeepAwakeAutoGracePeriod(_ period: TimeInterval) {
+        defaults.set(period, forKey: Constants.UserDefaultsKeys.keepAwakeAutoGracePeriod)
+    }
+
+    func loadKeepAwakeAutoGracePeriod() -> TimeInterval {
+        if defaults.object(forKey: Constants.UserDefaultsKeys.keepAwakeAutoGracePeriod) == nil {
+            return 15 * 60
+        }
+        return defaults.double(forKey: Constants.UserDefaultsKeys.keepAwakeAutoGracePeriod)
+    }
+
     // MARK: - Statusline Configuration
 
     func saveStatuslineShowModel(_ show: Bool) {

--- a/Claude Usage/Shared/Storage/SharedDataStore.swift
+++ b/Claude Usage/Shared/Storage/SharedDataStore.swift
@@ -136,8 +136,12 @@ class SharedDataStore {
     }
 
     func loadKeepAwakeAutoEnabled() -> Bool {
-        // Default false: enabling installs hooks into ~/.claude/settings.json,
-        // which must be an explicit user choice.
+        // Default true: keep-awake works out of the box while Claude Code is
+        // busy. Note this installs hooks into ~/.claude/settings.json at
+        // launch; the toggle in Settings removes them again.
+        if defaults.object(forKey: Constants.UserDefaultsKeys.keepAwakeAutoEnabled) == nil {
+            return true
+        }
         return defaults.bool(forKey: Constants.UserDefaultsKeys.keepAwakeAutoEnabled)
     }
 
@@ -165,7 +169,7 @@ class SharedDataStore {
 
     func loadKeepAwakeAutoGracePeriod() -> TimeInterval {
         if defaults.object(forKey: Constants.UserDefaultsKeys.keepAwakeAutoGracePeriod) == nil {
-            return 15 * 60
+            return 30 * 60
         }
         return defaults.double(forKey: Constants.UserDefaultsKeys.keepAwakeAutoGracePeriod)
     }

--- a/Claude Usage/Shared/Storage/SharedDataStore.swift
+++ b/Claude Usage/Shared/Storage/SharedDataStore.swift
@@ -136,12 +136,10 @@ class SharedDataStore {
     }
 
     func loadKeepAwakeAutoEnabled() -> Bool {
-        // Default true: keep-awake works out of the box while Claude Code is
-        // busy. Note this installs hooks into ~/.claude/settings.json at
-        // launch; the toggle in Settings removes them again.
-        if defaults.object(forKey: Constants.UserDefaultsKeys.keepAwakeAutoEnabled) == nil {
-            return true
-        }
+        // Default false: nothing is active until the user's first click on the
+        // popover button (or the settings toggle), which enables auto mode and
+        // installs the hooks — that click is the explicit opt-in. Once turned
+        // off, it stays off until turned back on.
         return defaults.bool(forKey: Constants.UserDefaultsKeys.keepAwakeAutoEnabled)
     }
 

--- a/Claude Usage/Shared/Storage/SharedDataStore.swift
+++ b/Claude Usage/Shared/Storage/SharedDataStore.swift
@@ -152,6 +152,47 @@ class SharedDataStore {
         return token
     }
 
+    // MARK: - Keep Awake
+
+    func saveKeepAwakeAutoEnabled(_ enabled: Bool) {
+        defaults.set(enabled, forKey: Constants.UserDefaultsKeys.keepAwakeAutoEnabled)
+    }
+
+    func loadKeepAwakeAutoEnabled() -> Bool {
+        // Default false: enabling installs hooks into ~/.claude/settings.json,
+        // which must be an explicit user choice.
+        return defaults.bool(forKey: Constants.UserDefaultsKeys.keepAwakeAutoEnabled)
+    }
+
+    func saveKeepAwakeSleepMode(_ rawValue: String) {
+        defaults.set(rawValue, forKey: Constants.UserDefaultsKeys.keepAwakeSleepMode)
+    }
+
+    func loadKeepAwakeSleepMode() -> String? {
+        return defaults.string(forKey: Constants.UserDefaultsKeys.keepAwakeSleepMode)
+    }
+
+    /// Default manual keep-awake duration in seconds. 0 means indefinite.
+    func saveKeepAwakeDefaultDuration(_ duration: TimeInterval) {
+        defaults.set(duration, forKey: Constants.UserDefaultsKeys.keepAwakeDefaultDuration)
+    }
+
+    func loadKeepAwakeDefaultDuration() -> TimeInterval {
+        return defaults.double(forKey: Constants.UserDefaultsKeys.keepAwakeDefaultDuration)
+    }
+
+    /// How long auto mode keeps the Mac awake after Claude Code goes idle.
+    func saveKeepAwakeAutoGracePeriod(_ period: TimeInterval) {
+        defaults.set(period, forKey: Constants.UserDefaultsKeys.keepAwakeAutoGracePeriod)
+    }
+
+    func loadKeepAwakeAutoGracePeriod() -> TimeInterval {
+        if defaults.object(forKey: Constants.UserDefaultsKeys.keepAwakeAutoGracePeriod) == nil {
+            return 15 * 60
+        }
+        return defaults.double(forKey: Constants.UserDefaultsKeys.keepAwakeAutoGracePeriod)
+    }
+
     // MARK: - Statusline Configuration
 
     func saveStatuslineShowModel(_ show: Bool) {

--- a/Claude Usage/Shared/Storage/SharedDataStore.swift
+++ b/Claude Usage/Shared/Storage/SharedDataStore.swift
@@ -159,8 +159,12 @@ class SharedDataStore {
     }
 
     func loadKeepAwakeAutoEnabled() -> Bool {
-        // Default false: enabling installs hooks into ~/.claude/settings.json,
-        // which must be an explicit user choice.
+        // Default true: keep-awake works out of the box while Claude Code is
+        // busy. Note this installs hooks into ~/.claude/settings.json at
+        // launch; the toggle in Settings removes them again.
+        if defaults.object(forKey: Constants.UserDefaultsKeys.keepAwakeAutoEnabled) == nil {
+            return true
+        }
         return defaults.bool(forKey: Constants.UserDefaultsKeys.keepAwakeAutoEnabled)
     }
 
@@ -188,7 +192,7 @@ class SharedDataStore {
 
     func loadKeepAwakeAutoGracePeriod() -> TimeInterval {
         if defaults.object(forKey: Constants.UserDefaultsKeys.keepAwakeAutoGracePeriod) == nil {
-            return 15 * 60
+            return 30 * 60
         }
         return defaults.double(forKey: Constants.UserDefaultsKeys.keepAwakeAutoGracePeriod)
     }

--- a/Claude Usage/Shared/Storage/SharedDataStore.swift
+++ b/Claude Usage/Shared/Storage/SharedDataStore.swift
@@ -159,12 +159,10 @@ class SharedDataStore {
     }
 
     func loadKeepAwakeAutoEnabled() -> Bool {
-        // Default true: keep-awake works out of the box while Claude Code is
-        // busy. Note this installs hooks into ~/.claude/settings.json at
-        // launch; the toggle in Settings removes them again.
-        if defaults.object(forKey: Constants.UserDefaultsKeys.keepAwakeAutoEnabled) == nil {
-            return true
-        }
+        // Default false: nothing is active until the user's first click on the
+        // popover button (or the settings toggle), which enables auto mode and
+        // installs the hooks — that click is the explicit opt-in. Once turned
+        // off, it stays off until turned back on.
         return defaults.bool(forKey: Constants.UserDefaultsKeys.keepAwakeAutoEnabled)
     }
 

--- a/Claude Usage/Shared/Storage/SharedDataStore.swift
+++ b/Claude Usage/Shared/Storage/SharedDataStore.swift
@@ -190,7 +190,10 @@ class SharedDataStore {
 
     func loadKeepAwakeAutoGracePeriod() -> TimeInterval {
         if defaults.object(forKey: Constants.UserDefaultsKeys.keepAwakeAutoGracePeriod) == nil {
-            return 30 * 60
+            // Hooks emit no events while Claude Code compacts or streams a long
+            // response without tool calls, so sessions can look idle mid-work;
+            // a generous default bridges those gaps.
+            return 60 * 60
         }
         return defaults.double(forKey: Constants.UserDefaultsKeys.keepAwakeAutoGracePeriod)
     }

--- a/Claude Usage/Shared/Utilities/Constants.swift
+++ b/Claude Usage/Shared/Utilities/Constants.swift
@@ -61,6 +61,12 @@ enum Constants {
         static let notchHUDEnabled = "notchHUDEnabled"
         static let notchHUDAutoHide = "notchHUDAutoHide"
         static let notchHUDPathToken = "notchHUDPathToken"
+
+        // Keep Awake
+        static let keepAwakeAutoEnabled = "keepAwakeAutoEnabled"
+        static let keepAwakeSleepMode = "keepAwakeSleepMode"
+        static let keepAwakeDefaultDuration = "keepAwakeDefaultDuration"
+        static let keepAwakeAutoGracePeriod = "keepAwakeAutoGracePeriod"
     }
 
     // Claude Code notch HUD (hook listener + display)

--- a/Claude Usage/Views/Settings/App/KeepAwakeSettingsView.swift
+++ b/Claude Usage/Views/Settings/App/KeepAwakeSettingsView.swift
@@ -46,15 +46,7 @@ struct KeepAwakeSettingsView: View {
         }
         .onAppear(perform: loadPickerState)
         .onChange(of: autoEnabled) { _, newValue in
-            SharedDataStore.shared.saveKeepAwakeAutoEnabled(newValue)
-            if newValue {
-                NotchHookInstaller.shared.install()
-            } else if !SharedDataStore.shared.loadNotchHUDEnabled() {
-                // The notch HUD shares the hooks — only remove them when no
-                // feature needs session events anymore.
-                NotchHookInstaller.shared.uninstall()
-            }
-            NotificationCenter.default.post(name: .keepAwakeSettingChanged, object: nil)
+            service.setAutoEnabled(newValue)
         }
         .onChange(of: sleepMode) { _, newValue in
             SharedDataStore.shared.saveKeepAwakeSleepMode(newValue.rawValue)
@@ -153,7 +145,7 @@ struct KeepAwakeSettingsView: View {
                         Picker("", selection: $graceChoice) {
                             Text("keep_awake.grace.immediately".localized).tag(TimeInterval(0))
                             ForEach(Self.gracePresets, id: \.self) { preset in
-                                Text(Self.format(preset)).tag(preset)
+                                Text("keep_awake.grace.stay".localized(with: Self.format(preset))).tag(preset)
                             }
                             Text("keep_awake.duration.custom".localized).tag(Self.customTag)
                         }

--- a/Claude Usage/Views/Settings/App/KeepAwakeSettingsView.swift
+++ b/Claude Usage/Views/Settings/App/KeepAwakeSettingsView.swift
@@ -22,7 +22,7 @@ struct KeepAwakeSettingsView: View {
     @State private var autoEnabled: Bool = SharedDataStore.shared.loadKeepAwakeAutoEnabled()
     @State private var sleepMode: KeepAwakeService.SleepMode =
         SharedDataStore.shared.loadKeepAwakeSleepMode()
-            .flatMap(KeepAwakeService.SleepMode.init(rawValue:)) ?? .allowDisplaySleep
+            .flatMap(KeepAwakeService.SleepMode.init(rawValue:)) ?? .preventDisplaySleep
 
     @State private var durationChoice: TimeInterval = 0
     @State private var customDurationHours: Int = 3
@@ -175,10 +175,10 @@ struct KeepAwakeSettingsView: View {
         ) {
             VStack(alignment: .leading, spacing: DesignTokens.Spacing.cardPadding) {
                 Picker("", selection: $sleepMode) {
-                    Text("keep_awake.sleep_type.system".localized)
-                        .tag(KeepAwakeService.SleepMode.allowDisplaySleep)
                     Text("keep_awake.sleep_type.display".localized)
                         .tag(KeepAwakeService.SleepMode.preventDisplaySleep)
+                    Text("keep_awake.sleep_type.system".localized)
+                        .tag(KeepAwakeService.SleepMode.allowDisplaySleep)
                 }
                 .pickerStyle(.segmented)
                 .labelsHidden()

--- a/Claude Usage/Views/Settings/App/KeepAwakeSettingsView.swift
+++ b/Claude Usage/Views/Settings/App/KeepAwakeSettingsView.swift
@@ -38,8 +38,8 @@ struct KeepAwakeSettingsView: View {
                     subtitle: "section.keep_awake_desc".localized
                 )
 
-                manualCard
                 autoCard
+                manualCard
                 sleepTypeCard
             }
             .padding()

--- a/Claude Usage/Views/Settings/App/KeepAwakeSettingsView.swift
+++ b/Claude Usage/Views/Settings/App/KeepAwakeSettingsView.swift
@@ -1,0 +1,284 @@
+//
+//  KeepAwakeSettingsView.swift
+//  Claude Usage
+//
+//  Settings for Keep Awake: manual toggle with duration (presets or custom
+//  hours), auto mode driven by Claude Code sessions with a configurable
+//  grace period, and the sleep-prevention type (system vs display).
+//
+
+import SwiftUI
+
+struct KeepAwakeSettingsView: View {
+    /// Sentinel tag for the "Custom…" picker rows.
+    private static let customTag: TimeInterval = -1
+
+    private static let durationPresets: [TimeInterval] = [15 * 60, 30 * 60, 3600, 2 * 3600, 4 * 3600, 8 * 3600]
+    private static let gracePresets: [TimeInterval] = [15 * 60, 30 * 60, 3600]
+
+    @ObservedObject private var service = KeepAwakeService.shared
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    @State private var autoEnabled: Bool = SharedDataStore.shared.loadKeepAwakeAutoEnabled()
+    @State private var sleepMode: KeepAwakeService.SleepMode =
+        SharedDataStore.shared.loadKeepAwakeSleepMode()
+            .flatMap(KeepAwakeService.SleepMode.init(rawValue:)) ?? .allowDisplaySleep
+
+    @State private var durationChoice: TimeInterval = 0
+    @State private var customDurationHours: Int = 3
+    @State private var graceChoice: TimeInterval = 15 * 60
+    @State private var customGraceHours: Int = 1
+    @State private var statusPulse = false
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: DesignTokens.Spacing.section) {
+                SettingsPageHeader(
+                    title: "section.keep_awake_title".localized,
+                    subtitle: "section.keep_awake_desc".localized
+                )
+
+                manualCard
+                autoCard
+                sleepTypeCard
+            }
+            .padding()
+        }
+        .onAppear(perform: loadPickerState)
+        .onChange(of: autoEnabled) { _, newValue in
+            SharedDataStore.shared.saveKeepAwakeAutoEnabled(newValue)
+            if newValue {
+                NotchHookInstaller.shared.install()
+            } else if !SharedDataStore.shared.loadNotchHUDEnabled() {
+                // The notch HUD shares the hooks — only remove them when no
+                // feature needs session events anymore.
+                NotchHookInstaller.shared.uninstall()
+            }
+            NotificationCenter.default.post(name: .keepAwakeSettingChanged, object: nil)
+        }
+        .onChange(of: sleepMode) { _, newValue in
+            SharedDataStore.shared.saveKeepAwakeSleepMode(newValue.rawValue)
+            NotificationCenter.default.post(name: .keepAwakeSettingChanged, object: nil)
+        }
+        .onChange(of: durationChoice) { _, _ in saveDuration() }
+        .onChange(of: customDurationHours) { _, _ in saveDuration() }
+        .onChange(of: graceChoice) { _, _ in saveGracePeriod() }
+        .onChange(of: customGraceHours) { _, _ in saveGracePeriod() }
+    }
+
+    // MARK: - Manual card
+
+    private var manualCard: some View {
+        SettingsSectionCard(
+            title: "keep_awake.manual_title".localized,
+            subtitle: "keep_awake.manual_desc".localized
+        ) {
+            VStack(alignment: .leading, spacing: DesignTokens.Spacing.cardPadding) {
+                SettingToggle(
+                    title: "keep_awake.enable".localized,
+                    description: "keep_awake.enable_desc".localized,
+                    isOn: Binding(
+                        get: { service.isManualOn },
+                        set: { service.setManual(on: $0) }
+                    )
+                )
+
+                if service.isAssertionHeld {
+                    statusRow
+                }
+
+                pickerRow(label: "keep_awake.duration".localized) {
+                    Picker("", selection: $durationChoice) {
+                        Text("keep_awake.duration.indefinite".localized).tag(TimeInterval(0))
+                        ForEach(Self.durationPresets, id: \.self) { preset in
+                            Text(Self.format(preset)).tag(preset)
+                        }
+                        Text("keep_awake.duration.custom".localized).tag(Self.customTag)
+                    }
+                }
+
+                if durationChoice == Self.customTag {
+                    customHoursStepper(hours: $customDurationHours)
+                }
+            }
+        }
+    }
+
+    private var statusRow: some View {
+        HStack(spacing: 8) {
+            Circle()
+                .fill(Color.green)
+                .frame(width: 8, height: 8)
+                .scaleEffect(statusPulse && !reduceMotion ? 1.25 : 1.0)
+                .animation(
+                    reduceMotion ? nil : .easeInOut(duration: 1.0).repeatForever(autoreverses: true),
+                    value: statusPulse
+                )
+                .onAppear { statusPulse = true }
+                .onDisappear { statusPulse = false }
+
+            if let expiry = service.manualExpiry {
+                TimelineView(.periodic(from: .now, by: 1)) { context in
+                    Text("keep_awake.remaining".localized(with: Self.formatRemaining(until: expiry, from: context.date)))
+                        .font(DesignTokens.Typography.body)
+                        .foregroundColor(SettingsColors.secondary)
+                }
+            } else {
+                Text("keep_awake.status_active".localized)
+                    .font(DesignTokens.Typography.body)
+                    .foregroundColor(SettingsColors.secondary)
+            }
+            Spacer()
+        }
+        .transition(.opacity.combined(with: .move(edge: .top)))
+    }
+
+    // MARK: - Auto card
+
+    private var autoCard: some View {
+        SettingsSectionCard(
+            title: "keep_awake.auto_title".localized,
+            subtitle: "keep_awake.auto_card_desc".localized
+        ) {
+            VStack(alignment: .leading, spacing: DesignTokens.Spacing.cardPadding) {
+                SettingToggle(
+                    title: "keep_awake.auto".localized,
+                    description: "keep_awake.auto_desc".localized,
+                    badge: .beta,
+                    isOn: $autoEnabled
+                )
+
+                Group {
+                    pickerRow(label: "keep_awake.grace".localized) {
+                        Picker("", selection: $graceChoice) {
+                            Text("keep_awake.grace.immediately".localized).tag(TimeInterval(0))
+                            ForEach(Self.gracePresets, id: \.self) { preset in
+                                Text(Self.format(preset)).tag(preset)
+                            }
+                            Text("keep_awake.duration.custom".localized).tag(Self.customTag)
+                        }
+                    }
+
+                    if graceChoice == Self.customTag {
+                        customHoursStepper(hours: $customGraceHours)
+                    }
+                }
+                .disabled(!autoEnabled)
+                .opacity(autoEnabled ? 1.0 : 0.5)
+                .padding(.leading, 16)
+
+                Text("keep_awake.hooks_note".localized)
+                    .font(DesignTokens.Typography.body)
+                    .foregroundColor(SettingsColors.secondary)
+            }
+        }
+    }
+
+    // MARK: - Sleep type card
+
+    private var sleepTypeCard: some View {
+        SettingsSectionCard(
+            title: "keep_awake.sleep_type".localized,
+            subtitle: "keep_awake.sleep_type_desc".localized
+        ) {
+            VStack(alignment: .leading, spacing: DesignTokens.Spacing.cardPadding) {
+                Picker("", selection: $sleepMode) {
+                    Text("keep_awake.sleep_type.system".localized)
+                        .tag(KeepAwakeService.SleepMode.allowDisplaySleep)
+                    Text("keep_awake.sleep_type.display".localized)
+                        .tag(KeepAwakeService.SleepMode.preventDisplaySleep)
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+
+                Text("keep_awake.lid_note".localized)
+                    .font(DesignTokens.Typography.body)
+                    .foregroundColor(SettingsColors.secondary)
+            }
+        }
+    }
+
+    // MARK: - Shared row builders
+
+    private func pickerRow<Content: View>(label: String, @ViewBuilder content: () -> Content) -> some View {
+        HStack {
+            Text(label)
+                .font(DesignTokens.Typography.body)
+            Spacer()
+            content()
+                .labelsHidden()
+                .fixedSize()
+        }
+    }
+
+    private func customHoursStepper(hours: Binding<Int>) -> some View {
+        HStack {
+            Spacer()
+            Stepper(
+                "keep_awake.custom_hours".localized(with: hours.wrappedValue),
+                value: hours,
+                in: 1...24
+            )
+            .font(DesignTokens.Typography.body)
+            .fixedSize()
+        }
+    }
+
+    // MARK: - Persistence
+
+    private func loadPickerState() {
+        let duration = SharedDataStore.shared.loadKeepAwakeDefaultDuration()
+        if duration == 0 || Self.durationPresets.contains(duration) {
+            durationChoice = duration
+        } else {
+            durationChoice = Self.customTag
+            customDurationHours = max(1, min(24, Int((duration / 3600).rounded())))
+        }
+
+        let grace = SharedDataStore.shared.loadKeepAwakeAutoGracePeriod()
+        if grace == 0 || Self.gracePresets.contains(grace) {
+            graceChoice = grace
+        } else {
+            graceChoice = Self.customTag
+            customGraceHours = max(1, min(24, Int((grace / 3600).rounded())))
+        }
+    }
+
+    private func saveDuration() {
+        let duration = durationChoice == Self.customTag
+            ? TimeInterval(customDurationHours) * 3600
+            : durationChoice
+        SharedDataStore.shared.saveKeepAwakeDefaultDuration(duration)
+        NotificationCenter.default.post(name: .keepAwakeSettingChanged, object: nil)
+    }
+
+    private func saveGracePeriod() {
+        let grace = graceChoice == Self.customTag
+            ? TimeInterval(customGraceHours) * 3600
+            : graceChoice
+        SharedDataStore.shared.saveKeepAwakeAutoGracePeriod(grace)
+        NotificationCenter.default.post(name: .keepAwakeSettingChanged, object: nil)
+    }
+
+    // MARK: - Formatting
+
+    private static func format(_ interval: TimeInterval) -> String {
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = interval < 3600 ? [.minute] : [.hour]
+        formatter.unitsStyle = .abbreviated
+        return formatter.string(from: interval) ?? ""
+    }
+
+    private static func formatRemaining(until expiry: Date, from reference: Date) -> String {
+        let remaining = max(0, expiry.timeIntervalSince(reference))
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = remaining < 3600 ? [.minute, .second] : [.hour, .minute]
+        formatter.unitsStyle = .abbreviated
+        return formatter.string(from: remaining) ?? ""
+    }
+}
+
+#Preview {
+    KeepAwakeSettingsView()
+        .frame(width: 520, height: 560)
+}

--- a/Claude Usage/Views/Settings/App/NotchHUDSettingsView.swift
+++ b/Claude Usage/Views/Settings/App/NotchHUDSettingsView.swift
@@ -64,7 +64,9 @@ struct NotchHUDSettingsView: View {
             SharedDataStore.shared.saveNotchHUDEnabled(newValue)
             if newValue {
                 NotchHookInstaller.shared.install()
-            } else {
+            } else if !SharedDataStore.shared.loadKeepAwakeAutoEnabled() {
+                // Keep Awake's auto mode shares the hooks — only remove them
+                // when no feature needs session events anymore.
                 NotchHookInstaller.shared.uninstall()
             }
             hookStatus = NotchHookInstaller.shared.checkStatus()

--- a/Claude Usage/Views/SettingsView.swift
+++ b/Claude Usage/Views/SettingsView.swift
@@ -306,6 +306,8 @@ struct SettingsView: View {
                     ClaudeCodeView()
                 case .notchHUD:
                     NotchHUDSettingsView()
+                case .keepAwake:
+                    KeepAwakeSettingsView()
                 case .shortcuts:
                     ShortcutsSettingsView()
                 case .updates:
@@ -600,6 +602,7 @@ enum SettingsSection: String, CaseIterable {
     case language
     case claudeCode
     case notchHUD
+    case keepAwake
     case shortcuts
     case updates
     case support
@@ -621,6 +624,7 @@ enum SettingsSection: String, CaseIterable {
         case .language: return "language.title".localized
         case .claudeCode: return "settings.claude_cli".localized
         case .notchHUD: return "notch.hud.section_title".localized
+        case .keepAwake: return "section.keep_awake_title".localized
         case .shortcuts: return "section.shortcuts_title".localized
         case .updates: return "settings.updates".localized
         case .support: return "section.support_title".localized
@@ -644,6 +648,7 @@ enum SettingsSection: String, CaseIterable {
         case .language: return "globe"
         case .claudeCode: return "chevron.left.forwardslash.chevron.right"
         case .notchHUD: return "inset.filled.topthird.rectangle"
+        case .keepAwake: return "cup.and.saucer.fill"
         case .shortcuts: return "keyboard"
         case .updates: return "arrow.down.circle.fill"
         case .support: return "heart.fill"
@@ -667,6 +672,7 @@ enum SettingsSection: String, CaseIterable {
         case .language: return "language.subtitle".localized
         case .claudeCode: return "settings.claude_cli.description".localized
         case .notchHUD: return "notch.hud.section_desc".localized
+        case .keepAwake: return "section.keep_awake_desc".localized
         case .shortcuts: return "section.shortcuts_desc".localized
         case .updates: return "settings.updates.description".localized
         case .support: return "section.support_desc".localized

--- a/Claude Usage/Views/SettingsView.swift
+++ b/Claude Usage/Views/SettingsView.swift
@@ -308,6 +308,8 @@ struct SettingsView: View {
                     ClaudeCodeView()
                 case .notchHUD:
                     NotchHUDSettingsView()
+                case .keepAwake:
+                    KeepAwakeSettingsView()
                 case .shortcuts:
                     ShortcutsSettingsView()
                 case .updates:
@@ -617,6 +619,7 @@ enum SettingsSection: String, CaseIterable {
     case language
     case claudeCode
     case notchHUD
+    case keepAwake
     case shortcuts
     case updates
     case support
@@ -639,6 +642,7 @@ enum SettingsSection: String, CaseIterable {
         case .language: return "language.title".localized
         case .claudeCode: return "settings.claude_cli".localized
         case .notchHUD: return "notch.hud.section_title".localized
+        case .keepAwake: return "section.keep_awake_title".localized
         case .shortcuts: return "section.shortcuts_title".localized
         case .updates: return "settings.updates".localized
         case .support: return "section.support_title".localized
@@ -663,6 +667,7 @@ enum SettingsSection: String, CaseIterable {
         case .language: return "globe"
         case .claudeCode: return "chevron.left.forwardslash.chevron.right"
         case .notchHUD: return "inset.filled.topthird.rectangle"
+        case .keepAwake: return "cup.and.saucer.fill"
         case .shortcuts: return "keyboard"
         case .updates: return "arrow.down.circle.fill"
         case .support: return "heart.fill"
@@ -687,6 +692,7 @@ enum SettingsSection: String, CaseIterable {
         case .language: return "language.subtitle".localized
         case .claudeCode: return "settings.claude_cli.description".localized
         case .notchHUD: return "notch.hud.section_desc".localized
+        case .keepAwake: return "section.keep_awake_desc".localized
         case .shortcuts: return "section.shortcuts_desc".localized
         case .updates: return "settings.updates.description".localized
         case .support: return "section.support_desc".localized

--- a/Claude UsageTests/KeepAwakeServiceTests.swift
+++ b/Claude UsageTests/KeepAwakeServiceTests.swift
@@ -37,10 +37,20 @@ final class KeepAwakeServiceTests: XCTestCase {
         service.releaseAssertion = { [unowned self] id in
             releasedIDs.append(id)
         }
+        // setAutoEnabled must not touch real UserDefaults/hooks in tests:
+        // route the persistence seam back into the loadSettings seam.
+        service.persistAutoEnabled = { [unowned self] enabled in
+            configure(autoEnabled: enabled, sleepMode: currentSleepMode,
+                      defaultDuration: currentDuration, gracePeriod: currentGrace)
+        }
         // Neutral defaults; individual tests override via configure().
         configure(autoEnabled: false, sleepMode: .allowDisplaySleep, defaultDuration: 0, gracePeriod: 15 * 60)
         service.start()
     }
+
+    private var currentSleepMode: KeepAwakeService.SleepMode = .allowDisplaySleep
+    private var currentDuration: TimeInterval = 0
+    private var currentGrace: TimeInterval = 15 * 60
 
     private func configure(
         autoEnabled: Bool,
@@ -48,6 +58,9 @@ final class KeepAwakeServiceTests: XCTestCase {
         defaultDuration: TimeInterval = 0,
         gracePeriod: TimeInterval = 15 * 60
     ) {
+        currentSleepMode = sleepMode
+        currentDuration = defaultDuration
+        currentGrace = gracePeriod
         service.loadSettings = {
             (autoEnabled: autoEnabled, sleepMode: sleepMode,
              defaultDuration: defaultDuration, gracePeriod: gracePeriod)
@@ -262,62 +275,56 @@ final class KeepAwakeServiceTests: XCTestCase {
         XCTAssertTrue(releasedIDs.isEmpty)
     }
 
-    // MARK: - Smart toggle (popover button)
+    // MARK: - Smart toggle (popover button = auto-mode switch)
 
-    func testSmartToggleStartsManualWhenIdle() {
+    func testFirstClickEnablesAutoModeNotManual() {
+        XCTAssertFalse(service.autoEnabled)
         service.smartToggle()
-        XCTAssertTrue(service.isManualOn)
-        XCTAssertTrue(service.isAssertionHeld)
+
+        XCTAssertTrue(service.autoEnabled, "first click opts into auto mode")
+        XCTAssertFalse(service.isManualOn, "no manual hold is created")
+        XCTAssertFalse(service.isAssertionHeld, "armed but idle until Claude works")
+
+        store.apply(.sessionStart(id: "s1", cwd: nil))
+        service.reconcile()
+        XCTAssertTrue(service.isAutoHolding, "auto holds as soon as Claude works")
     }
 
-    func testSmartToggleTurnsOffManual() {
-        service.setManual(on: true)
-        service.smartToggle()
-        XCTAssertFalse(service.isManualOn)
-        XCTAssertFalse(service.isAssertionHeld)
-    }
-
-    func testSmartToggleDismissesAutoHoldUntilNextActivity() {
+    func testClickTurnsAutoOffAndItStaysOff() {
         configure(autoEnabled: true, gracePeriod: 15 * 60)
         store.apply(.sessionStart(id: "s1", cwd: nil))
         service.reconcile()
         XCTAssertTrue(service.isAutoHolding)
 
         service.smartToggle()
+        XCTAssertFalse(service.autoEnabled, "click during auto hold turns auto mode off")
         XCTAssertFalse(service.isAssertionHeld)
 
-        // The same continuous burst of work stays dismissed…
+        // Off is remembered: further activity never re-holds on its own.
         store.apply(.preToolUse(id: "s1", cwd: nil, status: .runningCommand, task: "build"))
         service.reconcile()
-        XCTAssertFalse(service.isAssertionHeld)
-
-        // …including its grace window after it stops…
         store.apply(.stop(id: "s1"))
         service.reconcile()
-        XCTAssertFalse(service.isAssertionHeld)
-
-        // …but Claude picking work back up resumes auto mode.
         store.apply(.preToolUse(id: "s1", cwd: nil, status: .writingCode, task: "edit"))
         service.reconcile()
-        XCTAssertTrue(service.isAssertionHeld)
-        XCTAssertTrue(service.isAutoHolding)
+        XCTAssertFalse(service.isAssertionHeld)
     }
 
-    func testSmartToggleCycleResumesAutoHoldNotManual() {
+    func testClickCycleReturnsToAutoDuringWork() {
         configure(autoEnabled: true, gracePeriod: 15 * 60)
         store.apply(.sessionStart(id: "s1", cwd: nil))
         service.reconcile()
-        XCTAssertTrue(service.isAutoHolding)
 
         service.smartToggle()
         XCTAssertFalse(service.isAssertionHeld)
 
         service.smartToggle()
+        XCTAssertTrue(service.autoEnabled)
         XCTAssertTrue(service.isAutoHolding, "cycling off/on returns to the auto hold")
         XCTAssertFalse(service.isManualOn, "no manual hold should be created")
     }
 
-    func testSmartToggleCycleResumesAutoGraceWindow() {
+    func testClickCycleReturnsToAutoGraceWindow() {
         configure(autoEnabled: true, gracePeriod: 15 * 60)
         store.apply(.sessionStart(id: "s1", cwd: nil))
         service.reconcile()
@@ -334,18 +341,20 @@ final class KeepAwakeServiceTests: XCTestCase {
         XCTAssertFalse(service.isManualOn)
     }
 
-    func testSmartToggleFallsBackToManualWhenAutoHasNothingToHold() {
-        configure(autoEnabled: true, gracePeriod: 15 * 60)
+    func testClickCancelsManualHoldFirstThenAuto() {
+        configure(autoEnabled: true, gracePeriod: 0)
         store.apply(.sessionStart(id: "s1", cwd: nil))
         service.reconcile()
-        store.apply(.stop(id: "s1"))
-        service.reconcile()
+        service.setManual(on: true, duration: 3600)
 
         service.smartToggle()
-        advance(16 * 60)
+        XCTAssertFalse(service.isManualOn, "first click cancels the manual hold")
+        XCTAssertTrue(service.autoEnabled, "auto mode untouched")
+        XCTAssertTrue(service.isAutoHolding, "auto still holding — icon stays lit")
+
         service.smartToggle()
-        XCTAssertTrue(service.isManualOn, "grace expired while dismissed → manual hold")
-        XCTAssertTrue(service.isAssertionHeld)
+        XCTAssertFalse(service.autoEnabled, "second click turns auto off")
+        XCTAssertFalse(service.isAssertionHeld)
     }
 
     func testMenuDurationOverridesDefault() {

--- a/Claude UsageTests/KeepAwakeServiceTests.swift
+++ b/Claude UsageTests/KeepAwakeServiceTests.swift
@@ -44,17 +44,17 @@ final class KeepAwakeServiceTests: XCTestCase {
                       defaultDuration: currentDuration, gracePeriod: currentGrace)
         }
         // Neutral defaults; individual tests override via configure().
-        configure(autoEnabled: false, sleepMode: .allowDisplaySleep, defaultDuration: 0, gracePeriod: 15 * 60)
+        configure(autoEnabled: false, sleepMode: .preventDisplaySleep, defaultDuration: 0, gracePeriod: 15 * 60)
         service.start()
     }
 
-    private var currentSleepMode: KeepAwakeService.SleepMode = .allowDisplaySleep
+    private var currentSleepMode: KeepAwakeService.SleepMode = .preventDisplaySleep
     private var currentDuration: TimeInterval = 0
     private var currentGrace: TimeInterval = 15 * 60
 
     private func configure(
         autoEnabled: Bool,
-        sleepMode: KeepAwakeService.SleepMode = .allowDisplaySleep,
+        sleepMode: KeepAwakeService.SleepMode = .preventDisplaySleep,
         defaultDuration: TimeInterval = 0,
         gracePeriod: TimeInterval = 15 * 60
     ) {
@@ -78,7 +78,7 @@ final class KeepAwakeServiceTests: XCTestCase {
         service.setManual(on: true)
 
         XCTAssertTrue(service.isAssertionHeld)
-        XCTAssertEqual(createdModes, [.allowDisplaySleep])
+        XCTAssertEqual(createdModes, [.preventDisplaySleep])
         XCTAssertNil(service.manualExpiry, "indefinite by default")
 
         service.setManual(on: false)
@@ -95,10 +95,10 @@ final class KeepAwakeServiceTests: XCTestCase {
         XCTAssertTrue(releasedIDs.isEmpty)
     }
 
-    func testManualUsesPreventDisplaySleepWhenConfigured() {
-        configure(autoEnabled: false, sleepMode: .preventDisplaySleep)
+    func testManualUsesAllowDisplaySleepWhenConfigured() {
+        configure(autoEnabled: false, sleepMode: .allowDisplaySleep)
         service.setManual(on: true)
-        XCTAssertEqual(createdModes, [.preventDisplaySleep])
+        XCTAssertEqual(createdModes, [.allowDisplaySleep])
     }
 
     // MARK: - Timed manual hold
@@ -382,11 +382,11 @@ final class KeepAwakeServiceTests: XCTestCase {
 
     func testSleepModeChangeWhileHeldReacquiresOnce() {
         service.setManual(on: true)
-        XCTAssertEqual(createdModes, [.allowDisplaySleep])
+        XCTAssertEqual(createdModes, [.preventDisplaySleep])
 
-        configure(autoEnabled: false, sleepMode: .preventDisplaySleep)
+        configure(autoEnabled: false, sleepMode: .allowDisplaySleep)
 
-        XCTAssertEqual(createdModes, [.allowDisplaySleep, .preventDisplaySleep])
+        XCTAssertEqual(createdModes, [.preventDisplaySleep, .allowDisplaySleep])
         XCTAssertEqual(releasedIDs, [1], "exactly one release + one re-create")
         XCTAssertTrue(service.isAssertionHeld)
     }

--- a/Claude UsageTests/KeepAwakeServiceTests.swift
+++ b/Claude UsageTests/KeepAwakeServiceTests.swift
@@ -262,6 +262,68 @@ final class KeepAwakeServiceTests: XCTestCase {
         XCTAssertTrue(releasedIDs.isEmpty)
     }
 
+    // MARK: - Smart toggle (popover button)
+
+    func testSmartToggleStartsManualWhenIdle() {
+        service.smartToggle()
+        XCTAssertTrue(service.isManualOn)
+        XCTAssertTrue(service.isAssertionHeld)
+    }
+
+    func testSmartToggleTurnsOffManual() {
+        service.setManual(on: true)
+        service.smartToggle()
+        XCTAssertFalse(service.isManualOn)
+        XCTAssertFalse(service.isAssertionHeld)
+    }
+
+    func testSmartToggleDismissesAutoHoldUntilNextActivity() {
+        configure(autoEnabled: true, gracePeriod: 15 * 60)
+        store.apply(.sessionStart(id: "s1", cwd: nil))
+        service.reconcile()
+        XCTAssertTrue(service.isAutoHolding)
+
+        service.smartToggle()
+        XCTAssertFalse(service.isAssertionHeld)
+
+        // The same continuous burst of work stays dismissed…
+        store.apply(.preToolUse(id: "s1", cwd: nil, status: .runningCommand, task: "build"))
+        service.reconcile()
+        XCTAssertFalse(service.isAssertionHeld)
+
+        // …including its grace window after it stops…
+        store.apply(.stop(id: "s1"))
+        service.reconcile()
+        XCTAssertFalse(service.isAssertionHeld)
+
+        // …but Claude picking work back up resumes auto mode.
+        store.apply(.preToolUse(id: "s1", cwd: nil, status: .writingCode, task: "edit"))
+        service.reconcile()
+        XCTAssertTrue(service.isAssertionHeld)
+        XCTAssertTrue(service.isAutoHolding)
+    }
+
+    func testMenuDurationOverridesDefault() {
+        configure(autoEnabled: false, defaultDuration: 0)
+        service.setManual(on: true, duration: 3600)
+        XCTAssertEqual(service.manualExpiry, fakeNow.addingTimeInterval(3600))
+
+        advance(61 * 60)
+        service.reconcile()
+        XCTAssertFalse(service.isAssertionHeld)
+    }
+
+    func testAutoGraceExpiryPublishedDuringGraceOnly() {
+        configure(autoEnabled: true, gracePeriod: 15 * 60)
+        store.apply(.sessionStart(id: "s1", cwd: nil))
+        service.reconcile()
+        XCTAssertNil(service.autoGraceExpiry, "nil while actively working")
+
+        store.apply(.stop(id: "s1"))
+        service.reconcile()
+        XCTAssertEqual(service.autoGraceExpiry, fakeNow.addingTimeInterval(15 * 60))
+    }
+
     // MARK: - Sleep-mode change
 
     func testSleepModeChangeWhileHeldReacquiresOnce() {

--- a/Claude UsageTests/KeepAwakeServiceTests.swift
+++ b/Claude UsageTests/KeepAwakeServiceTests.swift
@@ -1,0 +1,304 @@
+//
+//  KeepAwakeServiceTests.swift
+//  Claude UsageTests
+//
+//  State-machine tests for KeepAwakeService using an injected clock and fake
+//  assertion closures, mirroring the NotchSessionStore test idiom.
+//
+
+import XCTest
+@testable import Claude_Usage
+
+@MainActor
+final class KeepAwakeServiceTests: XCTestCase {
+
+    private var store: NotchSessionStore!
+    private var service: KeepAwakeService!
+    private var fakeNow: Date!
+    private var createdModes: [KeepAwakeService.SleepMode] = []
+    private var releasedIDs: [IOPMAssertionID] = []
+    private var nextAssertionID: IOPMAssertionID = 0
+
+    override func setUp() async throws {
+        store = NotchSessionStore()
+        service = KeepAwakeService(sessionStore: store)
+        fakeNow = Date()
+        createdModes = []
+        releasedIDs = []
+        nextAssertionID = 0
+
+        store.now = { [unowned self] in fakeNow }
+        service.now = { [unowned self] in fakeNow }
+        service.createAssertion = { [unowned self] mode in
+            createdModes.append(mode)
+            nextAssertionID += 1
+            return nextAssertionID
+        }
+        service.releaseAssertion = { [unowned self] id in
+            releasedIDs.append(id)
+        }
+        // Neutral defaults; individual tests override via configure().
+        configure(autoEnabled: false, sleepMode: .allowDisplaySleep, defaultDuration: 0, gracePeriod: 15 * 60)
+        service.start()
+    }
+
+    private func configure(
+        autoEnabled: Bool,
+        sleepMode: KeepAwakeService.SleepMode = .allowDisplaySleep,
+        defaultDuration: TimeInterval = 0,
+        gracePeriod: TimeInterval = 15 * 60
+    ) {
+        service.loadSettings = {
+            (autoEnabled: autoEnabled, sleepMode: sleepMode,
+             defaultDuration: defaultDuration, gracePeriod: gracePeriod)
+        }
+        service.settingsChanged()
+    }
+
+    private func advance(_ seconds: TimeInterval) {
+        fakeNow = fakeNow.addingTimeInterval(seconds)
+    }
+
+    // MARK: - Manual toggle
+
+    func testManualOnCreatesOneAssertionWithDefaultMode() {
+        service.setManual(on: true)
+
+        XCTAssertTrue(service.isAssertionHeld)
+        XCTAssertEqual(createdModes, [.allowDisplaySleep])
+        XCTAssertNil(service.manualExpiry, "indefinite by default")
+
+        service.setManual(on: false)
+        XCTAssertFalse(service.isAssertionHeld)
+        XCTAssertEqual(releasedIDs, [1])
+    }
+
+    func testReconcileIsIdempotent() {
+        service.setManual(on: true)
+        service.reconcile()
+        service.reconcile()
+
+        XCTAssertEqual(createdModes.count, 1, "repeated reconcile must not stack assertions")
+        XCTAssertTrue(releasedIDs.isEmpty)
+    }
+
+    func testManualUsesPreventDisplaySleepWhenConfigured() {
+        configure(autoEnabled: false, sleepMode: .preventDisplaySleep)
+        service.setManual(on: true)
+        XCTAssertEqual(createdModes, [.preventDisplaySleep])
+    }
+
+    // MARK: - Timed manual hold
+
+    func testTimedManualExpiresAndReleases() {
+        configure(autoEnabled: false, defaultDuration: 15 * 60)
+        service.setManual(on: true)
+        XCTAssertEqual(service.manualExpiry, fakeNow.addingTimeInterval(15 * 60))
+        XCTAssertTrue(service.isAssertionHeld)
+
+        advance(14 * 60)
+        service.reconcile()
+        XCTAssertTrue(service.isAssertionHeld, "still inside the window")
+
+        advance(2 * 60)
+        service.reconcile()
+        XCTAssertFalse(service.isAssertionHeld)
+        XCTAssertFalse(service.isManualOn)
+        XCTAssertNil(service.manualExpiry)
+        XCTAssertEqual(releasedIDs, [1])
+    }
+
+    func testCustomThreeHourDurationHonored() {
+        configure(autoEnabled: false, defaultDuration: 3 * 60 * 60)
+        service.setManual(on: true)
+
+        advance(2 * 60 * 60 + 59 * 60)
+        service.reconcile()
+        XCTAssertTrue(service.isAssertionHeld)
+
+        advance(2 * 60)
+        service.reconcile()
+        XCTAssertFalse(service.isAssertionHeld)
+    }
+
+    // MARK: - Auto mode
+
+    func testAutoHoldsWhileSessionActive() {
+        configure(autoEnabled: true)
+        store.apply(.sessionStart(id: "s1", cwd: nil))
+        service.reconcile()
+
+        XCTAssertTrue(service.isAssertionHeld)
+        XCTAssertTrue(service.isAutoHolding)
+    }
+
+    func testAutoDisabledIgnoresSessions() {
+        configure(autoEnabled: false)
+        store.apply(.sessionStart(id: "s1", cwd: nil))
+        service.reconcile()
+        XCTAssertFalse(service.isAssertionHeld)
+    }
+
+    func testIdleSessionHeldThroughGraceThenReleased() {
+        configure(autoEnabled: true, gracePeriod: 15 * 60)
+        store.apply(.sessionStart(id: "s1", cwd: nil))
+        service.reconcile()
+        XCTAssertTrue(service.isAssertionHeld)
+
+        store.apply(.stop(id: "s1"))
+        service.reconcile()
+        XCTAssertTrue(service.isAssertionHeld, "grace period keeps the hold")
+
+        advance(14 * 60)
+        service.reconcile()
+        XCTAssertTrue(service.isAssertionHeld)
+
+        advance(2 * 60)
+        service.reconcile()
+        XCTAssertFalse(service.isAssertionHeld)
+        XCTAssertFalse(service.isAutoHolding)
+    }
+
+    func testSessionEndUsesGraceToo() {
+        configure(autoEnabled: true, gracePeriod: 10 * 60)
+        store.apply(.sessionStart(id: "s1", cwd: nil))
+        service.reconcile()
+
+        store.apply(.sessionEnd(id: "s1"))
+        service.reconcile()
+        XCTAssertTrue(service.isAssertionHeld)
+
+        advance(11 * 60)
+        service.reconcile()
+        XCTAssertFalse(service.isAssertionHeld)
+    }
+
+    func testZeroGraceReleasesImmediately() {
+        configure(autoEnabled: true, gracePeriod: 0)
+        store.apply(.sessionStart(id: "s1", cwd: nil))
+        service.reconcile()
+        XCTAssertTrue(service.isAssertionHeld)
+
+        store.apply(.stop(id: "s1"))
+        service.reconcile()
+        XCTAssertFalse(service.isAssertionHeld)
+    }
+
+    func testCustomOneHourGraceHonored() {
+        configure(autoEnabled: true, gracePeriod: 60 * 60)
+        store.apply(.sessionStart(id: "s1", cwd: nil))
+        service.reconcile()
+        store.apply(.sessionEnd(id: "s1"))
+        service.reconcile()
+
+        advance(59 * 60)
+        service.reconcile()
+        XCTAssertTrue(service.isAssertionHeld)
+
+        advance(2 * 60)
+        service.reconcile()
+        XCTAssertFalse(service.isAssertionHeld)
+    }
+
+    func testActivityResumingMidGraceCancelsRelease() {
+        configure(autoEnabled: true, gracePeriod: 15 * 60)
+        store.apply(.sessionStart(id: "s1", cwd: nil))
+        service.reconcile()
+        store.apply(.stop(id: "s1"))
+        service.reconcile()
+
+        advance(10 * 60)
+        store.apply(.preToolUse(id: "s1", cwd: nil, status: .runningCommand, task: "build"))
+        service.reconcile()
+        XCTAssertTrue(service.isAssertionHeld)
+
+        // Old grace deadline passes; hold survives because activity resumed.
+        advance(6 * 60)
+        service.reconcile()
+        XCTAssertTrue(service.isAssertionHeld)
+        XCTAssertEqual(createdModes.count, 1, "hold never dropped, so never re-created")
+    }
+
+    // MARK: - Manual + auto composition
+
+    func testManualOutlivesAutoGoingIdle() {
+        configure(autoEnabled: true, gracePeriod: 0)
+        service.setManual(on: true)
+        store.apply(.sessionStart(id: "s1", cwd: nil))
+        service.reconcile()
+
+        store.apply(.stop(id: "s1"))
+        service.reconcile()
+        XCTAssertTrue(service.isAssertionHeld, "manual keeps holding after auto drops")
+        XCTAssertFalse(service.isAutoHolding)
+
+        service.setManual(on: false)
+        XCTAssertFalse(service.isAssertionHeld)
+    }
+
+    func testAutoOutlivesManualTurningOff() {
+        configure(autoEnabled: true, gracePeriod: 0)
+        store.apply(.sessionStart(id: "s1", cwd: nil))
+        service.reconcile()
+        service.setManual(on: true)
+
+        service.setManual(on: false)
+        XCTAssertTrue(service.isAssertionHeld, "auto keeps holding after manual off")
+        XCTAssertTrue(service.isAutoHolding)
+
+        store.apply(.sessionEnd(id: "s1"))
+        service.reconcile()
+        XCTAssertFalse(service.isAssertionHeld)
+    }
+
+    func testOverlapNeverDoubleCreates() {
+        configure(autoEnabled: true, gracePeriod: 0)
+        service.setManual(on: true)
+        store.apply(.sessionStart(id: "s1", cwd: nil))
+        service.reconcile()
+        service.reconcile()
+
+        XCTAssertEqual(createdModes.count, 1)
+        XCTAssertTrue(releasedIDs.isEmpty)
+    }
+
+    // MARK: - Sleep-mode change
+
+    func testSleepModeChangeWhileHeldReacquiresOnce() {
+        service.setManual(on: true)
+        XCTAssertEqual(createdModes, [.allowDisplaySleep])
+
+        configure(autoEnabled: false, sleepMode: .preventDisplaySleep)
+
+        XCTAssertEqual(createdModes, [.allowDisplaySleep, .preventDisplaySleep])
+        XCTAssertEqual(releasedIDs, [1], "exactly one release + one re-create")
+        XCTAssertTrue(service.isAssertionHeld)
+    }
+
+    // MARK: - Stale sweep integration
+
+    func testStaleSweepReleasesCrashedSessionHold() {
+        configure(autoEnabled: true, gracePeriod: 0)
+        store.apply(.sessionStart(id: "crashed", cwd: nil))
+        service.reconcile()
+        XCTAssertTrue(service.isAssertionHeld)
+
+        // Session process died without sessionEnd: no events ever again.
+        advance(Constants.NotchHUD.staleSessionTimeout + 60)
+        store.sweepStaleSessions()
+        service.reconcile()
+
+        XCTAssertFalse(service.isAssertionHeld, "sweep must not leave the Mac awake forever")
+    }
+
+    // MARK: - Lifecycle
+
+    func testStopReleasesEverything() {
+        service.setManual(on: true)
+        service.stop()
+
+        XCTAssertFalse(service.isAssertionHeld)
+        XCTAssertFalse(service.isManualOn)
+        XCTAssertEqual(releasedIDs, [1])
+    }
+}

--- a/Claude UsageTests/KeepAwakeServiceTests.swift
+++ b/Claude UsageTests/KeepAwakeServiceTests.swift
@@ -303,6 +303,51 @@ final class KeepAwakeServiceTests: XCTestCase {
         XCTAssertTrue(service.isAutoHolding)
     }
 
+    func testSmartToggleCycleResumesAutoHoldNotManual() {
+        configure(autoEnabled: true, gracePeriod: 15 * 60)
+        store.apply(.sessionStart(id: "s1", cwd: nil))
+        service.reconcile()
+        XCTAssertTrue(service.isAutoHolding)
+
+        service.smartToggle()
+        XCTAssertFalse(service.isAssertionHeld)
+
+        service.smartToggle()
+        XCTAssertTrue(service.isAutoHolding, "cycling off/on returns to the auto hold")
+        XCTAssertFalse(service.isManualOn, "no manual hold should be created")
+    }
+
+    func testSmartToggleCycleResumesAutoGraceWindow() {
+        configure(autoEnabled: true, gracePeriod: 15 * 60)
+        store.apply(.sessionStart(id: "s1", cwd: nil))
+        service.reconcile()
+        store.apply(.stop(id: "s1"))
+        service.reconcile()
+        XCTAssertNotNil(service.autoGraceExpiry)
+
+        service.smartToggle()
+        XCTAssertFalse(service.isAssertionHeld)
+
+        advance(5 * 60)
+        service.smartToggle()
+        XCTAssertTrue(service.isAutoHolding, "still inside the grace window → auto resumes")
+        XCTAssertFalse(service.isManualOn)
+    }
+
+    func testSmartToggleFallsBackToManualWhenAutoHasNothingToHold() {
+        configure(autoEnabled: true, gracePeriod: 15 * 60)
+        store.apply(.sessionStart(id: "s1", cwd: nil))
+        service.reconcile()
+        store.apply(.stop(id: "s1"))
+        service.reconcile()
+
+        service.smartToggle()
+        advance(16 * 60)
+        service.smartToggle()
+        XCTAssertTrue(service.isManualOn, "grace expired while dismissed → manual hold")
+        XCTAssertTrue(service.isAssertionHeld)
+    }
+
     func testMenuDurationOverridesDefault() {
         configure(autoEnabled: false, defaultDuration: 0)
         service.setManual(on: true, duration: 3600)

--- a/Claude UsageTests/SharedDataStoreTests.swift
+++ b/Claude UsageTests/SharedDataStoreTests.swift
@@ -182,13 +182,14 @@ final class SharedDataStoreTests: XCTestCase {
 
     func testKeepAwakeAutoEnabled() {
         UserDefaults.standard.removeObject(forKey: Constants.UserDefaultsKeys.keepAwakeAutoEnabled)
-        XCTAssertTrue(sharedDataStore.loadKeepAwakeAutoEnabled(), "auto mode defaults on")
-
-        sharedDataStore.saveKeepAwakeAutoEnabled(false)
-        XCTAssertFalse(sharedDataStore.loadKeepAwakeAutoEnabled(), "explicit off survives")
+        XCTAssertFalse(sharedDataStore.loadKeepAwakeAutoEnabled(),
+                       "off until the user's first click/toggle opts in")
 
         sharedDataStore.saveKeepAwakeAutoEnabled(true)
         XCTAssertTrue(sharedDataStore.loadKeepAwakeAutoEnabled())
+
+        sharedDataStore.saveKeepAwakeAutoEnabled(false)
+        XCTAssertFalse(sharedDataStore.loadKeepAwakeAutoEnabled(), "off is remembered")
     }
 
     func testKeepAwakeSleepMode() {

--- a/Claude UsageTests/SharedDataStoreTests.swift
+++ b/Claude UsageTests/SharedDataStoreTests.swift
@@ -178,6 +178,49 @@ final class SharedDataStoreTests: XCTestCase {
         XCTAssertFalse(sharedDataStore.shouldShowGitHubStarPrompt())
     }
 
+    // MARK: - Keep Awake Tests
+
+    func testKeepAwakeAutoEnabled() {
+        UserDefaults.standard.removeObject(forKey: Constants.UserDefaultsKeys.keepAwakeAutoEnabled)
+        XCTAssertFalse(sharedDataStore.loadKeepAwakeAutoEnabled(), "must default off (installs hooks)")
+
+        sharedDataStore.saveKeepAwakeAutoEnabled(true)
+        XCTAssertTrue(sharedDataStore.loadKeepAwakeAutoEnabled())
+
+        sharedDataStore.saveKeepAwakeAutoEnabled(false)
+        XCTAssertFalse(sharedDataStore.loadKeepAwakeAutoEnabled())
+    }
+
+    func testKeepAwakeSleepMode() {
+        UserDefaults.standard.removeObject(forKey: Constants.UserDefaultsKeys.keepAwakeSleepMode)
+        XCTAssertNil(sharedDataStore.loadKeepAwakeSleepMode())
+
+        sharedDataStore.saveKeepAwakeSleepMode("preventDisplaySleep")
+        XCTAssertEqual(sharedDataStore.loadKeepAwakeSleepMode(), "preventDisplaySleep")
+
+        sharedDataStore.saveKeepAwakeSleepMode("allowDisplaySleep")
+        XCTAssertEqual(sharedDataStore.loadKeepAwakeSleepMode(), "allowDisplaySleep")
+    }
+
+    func testKeepAwakeDefaultDuration() {
+        UserDefaults.standard.removeObject(forKey: Constants.UserDefaultsKeys.keepAwakeDefaultDuration)
+        XCTAssertEqual(sharedDataStore.loadKeepAwakeDefaultDuration(), 0, "0 = indefinite by default")
+
+        sharedDataStore.saveKeepAwakeDefaultDuration(3 * 60 * 60)
+        XCTAssertEqual(sharedDataStore.loadKeepAwakeDefaultDuration(), 3 * 60 * 60)
+    }
+
+    func testKeepAwakeAutoGracePeriod() {
+        UserDefaults.standard.removeObject(forKey: Constants.UserDefaultsKeys.keepAwakeAutoGracePeriod)
+        XCTAssertEqual(sharedDataStore.loadKeepAwakeAutoGracePeriod(), 15 * 60, "defaults to 15 minutes")
+
+        sharedDataStore.saveKeepAwakeAutoGracePeriod(60 * 60)
+        XCTAssertEqual(sharedDataStore.loadKeepAwakeAutoGracePeriod(), 60 * 60)
+
+        sharedDataStore.saveKeepAwakeAutoGracePeriod(0)
+        XCTAssertEqual(sharedDataStore.loadKeepAwakeAutoGracePeriod(), 0, "explicit 0 (immediately) survives")
+    }
+
     func testResetGitHubStarPromptForTesting() {
         // Set some state
         sharedDataStore.saveHasStarredGitHub(true)

--- a/Claude UsageTests/SharedDataStoreTests.swift
+++ b/Claude UsageTests/SharedDataStoreTests.swift
@@ -213,7 +213,7 @@ final class SharedDataStoreTests: XCTestCase {
 
     func testKeepAwakeAutoGracePeriod() {
         UserDefaults.standard.removeObject(forKey: Constants.UserDefaultsKeys.keepAwakeAutoGracePeriod)
-        XCTAssertEqual(sharedDataStore.loadKeepAwakeAutoGracePeriod(), 30 * 60, "defaults to 30 minutes")
+        XCTAssertEqual(sharedDataStore.loadKeepAwakeAutoGracePeriod(), 60 * 60, "defaults to 1 hour")
 
         sharedDataStore.saveKeepAwakeAutoGracePeriod(60 * 60)
         XCTAssertEqual(sharedDataStore.loadKeepAwakeAutoGracePeriod(), 60 * 60)

--- a/Claude UsageTests/SharedDataStoreTests.swift
+++ b/Claude UsageTests/SharedDataStoreTests.swift
@@ -182,13 +182,13 @@ final class SharedDataStoreTests: XCTestCase {
 
     func testKeepAwakeAutoEnabled() {
         UserDefaults.standard.removeObject(forKey: Constants.UserDefaultsKeys.keepAwakeAutoEnabled)
-        XCTAssertFalse(sharedDataStore.loadKeepAwakeAutoEnabled(), "must default off (installs hooks)")
+        XCTAssertTrue(sharedDataStore.loadKeepAwakeAutoEnabled(), "auto mode defaults on")
+
+        sharedDataStore.saveKeepAwakeAutoEnabled(false)
+        XCTAssertFalse(sharedDataStore.loadKeepAwakeAutoEnabled(), "explicit off survives")
 
         sharedDataStore.saveKeepAwakeAutoEnabled(true)
         XCTAssertTrue(sharedDataStore.loadKeepAwakeAutoEnabled())
-
-        sharedDataStore.saveKeepAwakeAutoEnabled(false)
-        XCTAssertFalse(sharedDataStore.loadKeepAwakeAutoEnabled())
     }
 
     func testKeepAwakeSleepMode() {
@@ -212,7 +212,7 @@ final class SharedDataStoreTests: XCTestCase {
 
     func testKeepAwakeAutoGracePeriod() {
         UserDefaults.standard.removeObject(forKey: Constants.UserDefaultsKeys.keepAwakeAutoGracePeriod)
-        XCTAssertEqual(sharedDataStore.loadKeepAwakeAutoGracePeriod(), 15 * 60, "defaults to 15 minutes")
+        XCTAssertEqual(sharedDataStore.loadKeepAwakeAutoGracePeriod(), 30 * 60, "defaults to 30 minutes")
 
         sharedDataStore.saveKeepAwakeAutoGracePeriod(60 * 60)
         XCTAssertEqual(sharedDataStore.loadKeepAwakeAutoGracePeriod(), 60 * 60)


### PR DESCRIPTION
## Description

Adds an **Keep Awake** feature so long Claude Code runs don't die when the Mac idles into sleep. Everything is off until the user opts in with a single click.

**Auto mode (the main feature, beta).** A cup icon in the popover header acts as the switch. The first click turns auto mode on — that click is the explicit opt-in that installs the Claude Code hooks (same consent model as the notch HUD, which shares them). From then on the Mac is kept awake only while a Claude Code session is actually working, plus a configurable wind-down after it stops ("Sleep right away / Stay awake 15 min / 30 min / 1 h / custom hours", default 1 hour — Claude Code emits no hook events while compacting or streaming long responses, so a generous wind-down avoids the Mac sleeping mid-task); activity resuming cancels the pending release. Clicking again turns auto off, and off is remembered until it's turned back on.

**Manual holds (explicit only).** Right-click the cup for quick durations (15 min / 1 h / 2 h / 8 h / until turned off), or use the new Settings pane, which also offers presets plus custom hours. A click on the cup cancels a running manual hold.

**Sleep-prevention type.** "Keep screen on" (default — the awake state is always visible at a glance) or "Screen may sleep" (system stays awake with the display off, kindest to battery). The UI states plainly that closing the lid still sleeps the Mac unless it's plugged in with an external display.

**Glanceable state.** The cup renders three tiers: gray (off), dim orange (auto armed, idle), bright orange with rising steam wisps and a breathing glow (actively keeping the Mac awake — so animation always means "held right now"). Hovering shows a live status card: mode, time remaining or ∞, wind-down countdown, and what a click will do. All animation respects Reduce Motion.

### Implementation notes

- Single named IOKit assertion (`IOPMAssertionCreateWithName`, visible as `"Claude Usage - Keep Awake"` in `pmset -g assertions` and Activity Monitor → Energy). One idempotent `reconcile()` in the new `KeepAwakeService` owns create/release; the kernel drops the assertion automatically if the app exits.
- The hook listener + session-store lifecycle now run when *either* the notch HUD or Keep Awake auto mode needs them; hooks are only uninstalled when both are off. Stale-sweep/reset ownership moved from `NotchHUDController` to `AppDelegate` so session state survives toggling the HUD off while auto mode is active — behavior-neutral when Keep Awake is off.
- A crashed Claude session can't hold the Mac awake forever: the existing 120 s stale sweep releases the assertion (covered by a test).
- No sandbox/entitlement changes, no Keychain use; settings persist via standard `UserDefaults`.

## Changes

- New `Shared/Services/KeepAwakeService.swift` — assertion lifecycle and the manual/timer/auto/wind-down state machine, with injectable clock and assertion seams for testing
- New `Views/Settings/App/KeepAwakeSettingsView.swift` + `SettingsSection.keepAwake` — auto card (with wind-down picker), manual card (duration presets + custom hours, live countdown), sleep-type card
- `MenuBar/PopoverContentView.swift` — animated cup button (`KeepAwakeHeaderButton`), hover status card, right-click menu
- `App/AppDelegate.swift` — hook server + stale sweep gated on `notchHUDEnabled || keepAwakeAutoEnabled`; Keep Awake service lifecycle
- `MenuBar/NotchHUD/NotchHUDController.swift` — sweep/reset ownership moved to AppDelegate (see notes)
- 29 new tests (service state machine + persistence); full suite passing
- 38 localization keys added to all 13 languages

## Screenshots / Screen Recordings


https://github.com/user-attachments/assets/aebc1791-3521-456b-8406-9b92e3574815

<img width="1440" height="1506" alt="keep-awake-settings" src="https://github.com/user-attachments/assets/3989f07a-1fa5-409a-be96-55441f78918e" />
<img width="680" height="600" alt="keep-awake-popover" src="https://github.com/user-attachments/assets/9f921466-a660-438a-9b71-e6b0889d88fa" />


The named assertion while auto mode holds during a live Claude Code session:

```
$ pmset -g assertions | grep "Claude Usage"
   pid 61690(Claude Usage): [0x0000ab1500018e84] 00:00:22 PreventUserIdleSystemSleep named: "Claude Usage - Keep Awake"
```

## Checklist

- [x] I have tested these changes on a running build
- [x] I have attached screenshots/recordings for any visual changes 
- [x] I have not introduced App Group or grouped Keychain usage
- [x] I have added localization keys for any new user-facing strings

---

### Testing done

- 29 new unit tests (state machine: manual/timer expiry, auto + wind-down, click semantics including "off is remembered", sleep-mode re-acquire, crashed-session sweep, persistence round-trips); full suite green.
- Live end-to-end on macOS: with auto on, the app detected a real working Claude Code session via hooks with no manual trigger — assertion appeared in `pmset` while the session worked, survived HUD toggling, and vanished on app quit.
- Verified hooks are only written on explicit opt-in and removed when both consuming features are off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

