### PR TITLE
fix(notifications): respect per-profile notifications toggle for auto…

### DIFF
--- a/Claude Usage/MenuBar/MenuBarManager.swift
+++ b/Claude Usage/MenuBar/MenuBarManager.swift
@@ -1494,12 +1494,17 @@ class MenuBarManager: NSObject, ObservableObject {
         // Activate the next profile
         let fromName = currentProfile.name
         let toName = nextProfile.name
+        let notificationSettings = currentProfile.notificationSettings
         Task {
             await profileManager.activateProfile(nextProfile.id)
 
             await MainActor.run {
                 // Send notification
-                NotificationManager.shared.sendAutoSwitchNotification(fromProfile: fromName, toProfile: toName)
+                NotificationManager.shared.sendAutoSwitchNotification(
+                    fromProfile: fromName,
+                    toProfile: toName,
+                    settings: notificationSettings
+                )
 
                 // Post notification for UI reactivity
                 NotificationCenter.default.post(name: .autoSwitchProfileTriggered, object: nil)

--- a/Claude Usage/Shared/Services/AutoStartSessionService.swift
+++ b/Claude Usage/Shared/Services/AutoStartSessionService.swift
@@ -373,7 +373,8 @@ final class AutoStartSessionService {
                 notificationManager.sendAutoStartNotification(
                     profileName: profile.name,
                     success: true,
-                    error: nil
+                    error: nil,
+                    settings: profile.notificationSettings
                 )
             }
 
@@ -385,7 +386,8 @@ final class AutoStartSessionService {
                 notificationManager.sendAutoStartNotification(
                     profileName: profile.name,
                     success: false,
-                    error: error.localizedDescription
+                    error: error.localizedDescription,
+                    settings: profile.notificationSettings
                 )
             }
         }

--- a/Claude Usage/Shared/Services/NotificationManager.swift
+++ b/Claude Usage/Shared/Services/NotificationManager.swift
@@ -255,7 +255,12 @@ class NotificationManager: NotificationServiceProtocol {
     }
 
     /// Sends auto-start session notification
-    func sendAutoStartNotification(profileName: String, success: Bool, error: String?) {
+    func sendAutoStartNotification(profileName: String, success: Bool, error: String?, settings: NotificationSettings) {
+        // Check if notifications are enabled for this profile
+        guard settings.enabled else {
+            return
+        }
+
         let content = UNMutableNotificationContent()
 
         if success {
@@ -289,7 +294,15 @@ class NotificationManager: NotificationServiceProtocol {
     }
 
     /// Sends a notification when auto-switching profiles due to session limit
-    func sendAutoSwitchNotification(fromProfile: String, toProfile: String) {
+    ///
+    /// - Parameter settings: Notification settings of the profile being switched away from,
+    ///   i.e. the one whose session hit the limit and triggered the switch.
+    func sendAutoSwitchNotification(fromProfile: String, toProfile: String, settings: NotificationSettings) {
+        // Check if notifications are enabled for this profile
+        guard settings.enabled else {
+            return
+        }
+
         let content = UNMutableNotificationContent()
         content.title = "notification.profile_auto_switched.title".localized
         content.body = "notification.profile_auto_switched.message".localized(with: fromProfile, toProfile)


### PR DESCRIPTION
…-start and auto-switch

- Gate sendAutoStartNotification on the profile's notificationSettings.enabled, matching the existing guard in checkAndNotify
- Gate sendAutoSwitchNotification on the notification settings of the profile whose session hit the limit and triggered the switch
- Pass profile.notificationSettings from both AutoStartSessionService call sites (success and failure branches)
- Capture notification settings in MenuBarManager before activateProfile runs, since activation changes the active profile
- Fixes #259: disabling notifications had no effect on session auto-start or profile auto-switch alerts, which called UNUserNotificationCenter directly

## Description

<!-- Briefly describe what this PR does and why -->

## Changes

-

## Screenshots / Screen Recordings

<!-- REQUIRED for any visual/UI changes. Please attach screenshots or screen recordings of the running app showing your changes. PRs with visual changes that don't include screenshots will not be reviewed. -->

<!-- If your change is not visual (e.g., logic-only, refactoring), write "N/A - no visual changes" -->

## Important Guidelines

- **Do NOT use App Groups Keychain with app group identifiers.** This app is distributed outside the App Store via a Developer ID certificate. App Group entitlements require Keychain access prompts on every launch, which breaks the user experience. Use standard `UserDefaults` and standard Keychain access (without group identifiers) instead.
- Follow existing code patterns and architecture (MVVM, protocol-oriented)
- Add localization keys for any new user-facing strings (9 languages supported)
- Test on macOS 14.0+ (Sonoma)

## Checklist

- [x] I have tested these changes on a running build
- [x] I have attached screenshots/recordings for any visual changes
- [x] I have not introduced App Group or grouped Keychain usage
- [x] I have added localization keys for any new user-facing strings
