### PR TITLE
fix(notch): name sessions from any hook event and stop truncating project names

### DIFF
--- a/Claude Usage/MenuBar/NotchHUD/NotchCompactViews.swift
+++ b/Claude Usage/MenuBar/NotchHUD/NotchCompactViews.swift
@@ -25,9 +25,13 @@ struct NotchCompactLeadingView: View {
                     .font(.system(size: 11, weight: .medium))
                     .foregroundStyle(.white)
                     .lineLimit(1)
-                    .truncationMode(.middle)
-                    .frame(maxWidth: 96, alignment: .leading)
+                    // Long project names shrink a little before truncating,
+                    // so the bar never grows past its cap.
+                    .minimumScaleFactor(0.8)
+                    .truncationMode(.tail)
+                    .frame(maxWidth: 150, alignment: .leading)
             }
+            .help(session.displayName)
             .contentShape(Rectangle())
             .onTapGesture { NotchHUDController.shared.toggleExpanded() }
         }

--- a/Claude Usage/MenuBar/NotchHUD/NotchHUDController.swift
+++ b/Claude Usage/MenuBar/NotchHUD/NotchHUDController.swift
@@ -173,7 +173,7 @@ final class NotchHUDController {
         store.apply(.sessionStart(id: "mock-1", cwd: "/Users/dev/api-server"))
         store.apply(.preToolUse(id: "mock-1", cwd: nil, status: .runningCommand, task: "swift build"))
         store.apply(.sessionStart(id: "mock-2", cwd: "/Users/dev/webapp"))
-        store.apply(.notification(id: "mock-2", message: "Claude needs your permission to use Bash"))
+        store.apply(.notification(id: "mock-2", cwd: nil, message: "Claude needs your permission to use Bash"))
     }
     #endif
 }

--- a/Claude Usage/MenuBar/NotchHUD/NotchHUDController.swift
+++ b/Claude Usage/MenuBar/NotchHUD/NotchHUDController.swift
@@ -19,6 +19,7 @@ final class NotchHUDController {
     private var dynamicNotch: DynamicNotch<NotchExpandedView, NotchCompactLeadingView, NotchCompactTrailingView>?
     private var cancellables: Set<AnyCancellable> = []
     private var idleHideTask: Task<Void, Never>?
+    private var autoCollapseTask: Task<Void, Never>?
     private var screenObserver: NSObjectProtocol?
 
     private var isVisible = false
@@ -61,6 +62,8 @@ final class NotchHUDController {
         cancellables.removeAll()
         idleHideTask?.cancel()
         idleHideTask = nil
+        autoCollapseTask?.cancel()
+        autoCollapseTask = nil
         if let observer = screenObserver {
             NotificationCenter.default.removeObserver(observer)
             screenObserver = nil
@@ -80,12 +83,30 @@ final class NotchHUDController {
         guard let notch = dynamicNotch, isVisible else { return }
         let expand = !isExpanded
         isExpanded = expand
+        autoCollapseTask?.cancel()
         Task {
             if expand {
                 await notch.expand()
+                self.startAutoCollapse()
             } else {
                 await self.showCompactState(notch)
             }
+        }
+    }
+
+    /// Expansion is transient, like the iOS island: once the pointer has left
+    /// the panel for a while, fall back to compact so the expanded window
+    /// doesn't linger as an invisible click shield over the menu bar area.
+    private func startAutoCollapse() {
+        autoCollapseTask?.cancel()
+        autoCollapseTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(Constants.NotchHUD.expandedAutoCollapseDelay * 1_000_000_000))
+            while !Task.isCancelled, self?.dynamicNotch?.isHovering == true {
+                try? await Task.sleep(nanoseconds: 1_000_000_000)
+            }
+            guard !Task.isCancelled, let self, self.isExpanded, let notch = self.dynamicNotch else { return }
+            self.isExpanded = false
+            await self.showCompactState(notch)
         }
     }
 
@@ -129,6 +150,7 @@ final class NotchHUDController {
     private func hideNow(_ notch: DynamicNotch<NotchExpandedView, NotchCompactLeadingView, NotchCompactTrailingView>) {
         isVisible = false
         isExpanded = false
+        autoCollapseTask?.cancel()
         Task { await notch.hide() }
     }
 

--- a/Claude Usage/MenuBar/NotchHUD/NotchHUDController.swift
+++ b/Claude Usage/MenuBar/NotchHUD/NotchHUDController.swift
@@ -193,7 +193,7 @@ final class NotchHUDController {
         store.apply(.sessionStart(id: "mock-1", cwd: "/Users/dev/api-server"))
         store.apply(.preToolUse(id: "mock-1", cwd: nil, status: .runningCommand, task: "swift build"))
         store.apply(.sessionStart(id: "mock-2", cwd: "/Users/dev/webapp"))
-        store.apply(.notification(id: "mock-2", message: "Claude needs your permission to use Bash"))
+        store.apply(.notification(id: "mock-2", cwd: nil, message: "Claude needs your permission to use Bash"))
     }
     #endif
 }

--- a/Claude Usage/MenuBar/NotchHUD/NotchHUDController.swift
+++ b/Claude Usage/MenuBar/NotchHUD/NotchHUDController.swift
@@ -19,6 +19,7 @@ final class NotchHUDController {
     private var dynamicNotch: DynamicNotch<NotchExpandedView, NotchCompactLeadingView, NotchCompactTrailingView>?
     private var cancellables: Set<AnyCancellable> = []
     private var idleHideTask: Task<Void, Never>?
+    private var autoCollapseTask: Task<Void, Never>?
     private var screenObserver: NSObjectProtocol?
 
     private var isVisible = false
@@ -61,6 +62,8 @@ final class NotchHUDController {
         cancellables.removeAll()
         idleHideTask?.cancel()
         idleHideTask = nil
+        autoCollapseTask?.cancel()
+        autoCollapseTask = nil
         if let observer = screenObserver {
             NotificationCenter.default.removeObserver(observer)
             screenObserver = nil
@@ -92,12 +95,30 @@ final class NotchHUDController {
         guard let notch = dynamicNotch, isVisible else { return }
         let expand = !isExpanded
         isExpanded = expand
+        autoCollapseTask?.cancel()
         Task {
             if expand, let screen = self.targetScreen {
                 await notch.expand(on: screen)
+                self.startAutoCollapse()
             } else {
                 await self.showCompactState(notch)
             }
+        }
+    }
+
+    /// Expansion is transient, like the iOS island: once the pointer has left
+    /// the panel for a while, fall back to compact so the expanded window
+    /// doesn't linger as an invisible click shield over the menu bar area.
+    private func startAutoCollapse() {
+        autoCollapseTask?.cancel()
+        autoCollapseTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(Constants.NotchHUD.expandedAutoCollapseDelay * 1_000_000_000))
+            while !Task.isCancelled, self?.dynamicNotch?.isHovering == true {
+                try? await Task.sleep(nanoseconds: 1_000_000_000)
+            }
+            guard !Task.isCancelled, let self, self.isExpanded, let notch = self.dynamicNotch else { return }
+            self.isExpanded = false
+            await self.showCompactState(notch)
         }
     }
 
@@ -141,6 +162,7 @@ final class NotchHUDController {
     private func hideNow(_ notch: DynamicNotch<NotchExpandedView, NotchCompactLeadingView, NotchCompactTrailingView>) {
         isVisible = false
         isExpanded = false
+        autoCollapseTask?.cancel()
         Task { await notch.hide() }
     }
 

--- a/Claude Usage/Shared/Services/NotchHUD/NotchHookEvent.swift
+++ b/Claude Usage/Shared/Services/NotchHUD/NotchHookEvent.swift
@@ -10,15 +10,20 @@
 import Foundation
 
 /// A passive observation event from a Claude Code hook.
+///
+/// Every hook payload carries `cwd`, so every mutating event forwards it: a
+/// session first observed mid-flight (tracker restarted, or a sub-process
+/// that never fires SessionStart) still gets named after its project instead
+/// of falling back to a bare session id.
 enum NotchHookEvent: Equatable {
     case sessionStart(id: String, cwd: String?)
     case sessionEnd(id: String)
-    case userPromptSubmit(id: String, prompt: String?)
+    case userPromptSubmit(id: String, cwd: String?, prompt: String?)
     case preToolUse(id: String, cwd: String?, status: SessionStatus, task: String)
-    case postToolUse(id: String)
-    case toolFailure(id: String)
-    case stop(id: String)
-    case notification(id: String, message: String?)
+    case postToolUse(id: String, cwd: String?)
+    case toolFailure(id: String, cwd: String?)
+    case stop(id: String, cwd: String?)
+    case notification(id: String, cwd: String?, message: String?)
 
     /// The hook URL path suffix each event is received on (after the token segment).
     static let pathSuffixes: [String] = [
@@ -40,7 +45,7 @@ enum NotchHookEvent: Equatable {
         case "session-end":
             return .sessionEnd(id: sessionId)
         case "user-prompt-submit":
-            return .userPromptSubmit(id: sessionId, prompt: payload["prompt"] as? String)
+            return .userPromptSubmit(id: sessionId, cwd: cwd, prompt: payload["prompt"] as? String)
         case "pre-tool-use":
             let activity = ToolActivityMapper.map(
                 toolName: payload["tool_name"] as? String ?? "",
@@ -48,13 +53,13 @@ enum NotchHookEvent: Equatable {
             )
             return .preToolUse(id: sessionId, cwd: cwd, status: activity.status, task: activity.task)
         case "post-tool-use":
-            return .postToolUse(id: sessionId)
+            return .postToolUse(id: sessionId, cwd: cwd)
         case "post-tool-use-failure":
-            return .toolFailure(id: sessionId)
+            return .toolFailure(id: sessionId, cwd: cwd)
         case "stop":
-            return .stop(id: sessionId)
+            return .stop(id: sessionId, cwd: cwd)
         case "notification":
-            return .notification(id: sessionId, message: payload["message"] as? String)
+            return .notification(id: sessionId, cwd: cwd, message: payload["message"] as? String)
         default:
             return nil
         }

--- a/Claude Usage/Shared/Services/NotchHUD/NotchSessionStore.swift
+++ b/Claude Usage/Shared/Services/NotchHUD/NotchSessionStore.swift
@@ -49,8 +49,8 @@ final class NotchSessionStore: ObservableObject {
         case let .sessionEnd(id):
             sessions.removeAll { $0.id == id }
 
-        case let .userPromptSubmit(id, prompt):
-            upsert(id: id) { session in
+        case let .userPromptSubmit(id, cwd, prompt):
+            upsert(id: id, cwd: cwd) { session in
                 session.status = .thinking
                 session.currentTask = nil
                 if let prompt = prompt, !prompt.isEmpty {
@@ -64,25 +64,25 @@ final class NotchSessionStore: ObservableObject {
                 session.currentTask = task
             }
 
-        case let .postToolUse(id):
-            upsert(id: id) { session in
+        case let .postToolUse(id, cwd):
+            upsert(id: id, cwd: cwd) { session in
                 session.status = .thinking
                 session.hasRecentError = false
             }
 
-        case let .toolFailure(id):
-            upsert(id: id) { session in
+        case let .toolFailure(id, cwd):
+            upsert(id: id, cwd: cwd) { session in
                 session.hasRecentError = true
             }
 
-        case let .stop(id):
-            upsert(id: id) { session in
+        case let .stop(id, cwd):
+            upsert(id: id, cwd: cwd) { session in
                 session.status = .idle
                 session.currentTask = nil
             }
 
-        case let .notification(id, message):
-            upsert(id: id) { session in
+        case let .notification(id, cwd, message):
+            upsert(id: id, cwd: cwd) { session in
                 session.status = .needsAttention
                 if let message = message, !message.isEmpty {
                     session.currentTask = String(message.prefix(80))

--- a/Claude Usage/Shared/Services/NotchHUD/NotchSessionStore.swift
+++ b/Claude Usage/Shared/Services/NotchHUD/NotchSessionStore.swift
@@ -83,6 +83,14 @@ final class NotchSessionStore: ObservableObject {
 
         case let .notification(id, cwd, message):
             upsert(id: id, cwd: cwd) { session in
+                // A notification arriving while the session is already .idle is
+                // Claude Code's "waiting for your input" nudge, fired ~60s after
+                // the Stop hook: the task is finished, not blocked. Re-raising
+                // attention here would let auto keep-awake re-arm on a done
+                // session and hold the Mac awake until the terminal closes. A
+                // genuine permission prompt arrives mid-work (the session is
+                // never .idle then) and still raises the cue.
+                guard session.status != .idle else { return }
                 session.status = .needsAttention
                 if let message = message, !message.isEmpty {
                     session.currentTask = String(message.prefix(80))

--- a/Claude Usage/Shared/Utilities/Constants.swift
+++ b/Claude Usage/Shared/Utilities/Constants.swift
@@ -76,6 +76,9 @@ enum Constants {
         static let attentionStaleTimeout: TimeInterval = 600
         /// Delay before the HUD hides once every session is idle (auto-hide on).
         static let idleHideDelay: TimeInterval = 5
+        /// Expanded HUD collapses back to compact after this long without the
+        /// pointer over it (expansion is transient, like the iOS island).
+        static let expandedAutoCollapseDelay: TimeInterval = 8
         static let maxBodyBytes = 65_536
         static let maxHeaderBytes = 8_192
     }

--- a/Claude Usage/Shared/Utilities/Constants.swift
+++ b/Claude Usage/Shared/Utilities/Constants.swift
@@ -76,6 +76,9 @@ enum Constants {
         static let attentionStaleTimeout: TimeInterval = 600
         /// Delay before the HUD hides once every session is idle (auto-hide on).
         static let idleHideDelay: TimeInterval = 5
+        /// Expanded HUD collapses back to compact after this long without the
+        /// pointer over it (expansion is transient, like the iOS island).
+        static let expandedAutoCollapseDelay: TimeInterval = 8
         /// Hook body cap. Sized off a sample of real Claude Code hook
         /// traffic: the median over-cap body was ~210 KB and the max
         /// ~680 KB (image Reads dominate; Claude Code downscales images before

--- a/Claude UsageTests/NotchHUDCoreTests.swift
+++ b/Claude UsageTests/NotchHUDCoreTests.swift
@@ -152,6 +152,18 @@ final class NotchSessionStoreTests: XCTestCase {
         XCTAssertEqual(store.sessions[0].status, .runningCommand)
     }
 
+    func testNotificationAfterStopKeepsSessionIdle() {
+        store.apply(.sessionStart(id: "s1", cwd: nil))
+        store.apply(.stop(id: "s1", cwd: nil))
+        XCTAssertEqual(store.sessions[0].status, .idle)
+
+        // Claude Code's "waiting for your input" nudge fires ~60s after Stop.
+        // A finished session must stay idle so auto keep-awake doesn't re-arm
+        // and hold the Mac awake until the terminal closes.
+        store.apply(.notification(id: "s1", cwd: nil, message: "Claude is waiting for your input"))
+        XCTAssertEqual(store.sessions[0].status, .idle)
+    }
+
     func testStopSetsIdleAndSessionEndRemoves() {
         store.apply(.sessionStart(id: "s1", cwd: nil))
         store.apply(.stop(id: "s1", cwd: nil))

--- a/Claude UsageTests/NotchHUDCoreTests.swift
+++ b/Claude UsageTests/NotchHUDCoreTests.swift
@@ -108,10 +108,10 @@ final class NotchHookEventTests: XCTestCase {
                                            payload: ["session_id": "s", "cwd": "/p"]),
                        .sessionStart(id: "s", cwd: "/p"))
         XCTAssertEqual(NotchHookEvent.from(pathSuffix: "stop", payload: ["session_id": "s"]),
-                       .stop(id: "s"))
+                       .stop(id: "s", cwd: nil))
         XCTAssertEqual(NotchHookEvent.from(pathSuffix: "notification",
                                            payload: ["session_id": "s", "message": "waiting"]),
-                       .notification(id: "s", message: "waiting"))
+                       .notification(id: "s", cwd: nil, message: "waiting"))
     }
 }
 
@@ -133,9 +133,19 @@ final class NotchSessionStoreTests: XCTestCase {
         XCTAssertEqual(store.sessions[0].displayName, "proj")
     }
 
+    func testLateObservedSessionIsNamedFromAnyEventCwd() {
+        // Sessions first seen mid-flight (tracker restart, sub-process without
+        // a SessionStart) must not be stuck as "Session XXXXX".
+        store.apply(.notification(id: "late", cwd: "/Users/dev/webapp", message: "waiting"))
+        XCTAssertEqual(store.sessions[0].displayName, "webapp")
+
+        store.apply(.stop(id: "sub", cwd: "/Users/dev/api-server"))
+        XCTAssertEqual(store.sessions[1].displayName, "api-server")
+    }
+
     func testNotificationSetsAttentionAndNextActivityClearsIt() {
         store.apply(.sessionStart(id: "s1", cwd: "/p"))
-        store.apply(.notification(id: "s1", message: "Claude needs your permission"))
+        store.apply(.notification(id: "s1", cwd: nil, message: "Claude needs your permission"))
         XCTAssertEqual(store.sessions[0].status, .needsAttention)
 
         store.apply(.preToolUse(id: "s1", cwd: nil, status: .runningCommand, task: "ls"))
@@ -144,7 +154,7 @@ final class NotchSessionStoreTests: XCTestCase {
 
     func testStopSetsIdleAndSessionEndRemoves() {
         store.apply(.sessionStart(id: "s1", cwd: nil))
-        store.apply(.stop(id: "s1"))
+        store.apply(.stop(id: "s1", cwd: nil))
         XCTAssertEqual(store.sessions[0].status, .idle)
         store.apply(.sessionEnd(id: "s1"))
         XCTAssertTrue(store.sessions.isEmpty)
@@ -152,16 +162,16 @@ final class NotchSessionStoreTests: XCTestCase {
 
     func testToolFailureSetsErrorFlagAndPostToolUseClearsIt() {
         store.apply(.sessionStart(id: "s1", cwd: nil))
-        store.apply(.toolFailure(id: "s1"))
+        store.apply(.toolFailure(id: "s1", cwd: nil))
         XCTAssertTrue(store.sessions[0].hasRecentError)
-        store.apply(.postToolUse(id: "s1"))
+        store.apply(.postToolUse(id: "s1", cwd: nil))
         XCTAssertFalse(store.sessions[0].hasRecentError)
     }
 
     func testPrimarySessionPrefersAttention() {
         store.apply(.preToolUse(id: "busy", cwd: nil, status: .runningCommand, task: "build"))
         store.apply(.sessionStart(id: "waiting", cwd: nil))
-        store.apply(.notification(id: "waiting", message: "input needed"))
+        store.apply(.notification(id: "waiting", cwd: nil, message: "input needed"))
         XCTAssertEqual(store.primarySession?.id, "waiting")
     }
 
@@ -171,7 +181,7 @@ final class NotchSessionStoreTests: XCTestCase {
 
         store.apply(.sessionStart(id: "old", cwd: nil))
         store.apply(.sessionStart(id: "attention", cwd: nil))
-        store.apply(.notification(id: "attention", message: "waiting"))
+        store.apply(.notification(id: "attention", cwd: nil, message: "waiting"))
 
         // 3 minutes later: normal session swept (120s), attention survives (600s grace)
         fakeNow = fakeNow.addingTimeInterval(180)
@@ -185,7 +195,7 @@ final class NotchSessionStoreTests: XCTestCase {
     }
 
     func testPromptTruncatedTo80() {
-        store.apply(.userPromptSubmit(id: "s1", prompt: String(repeating: "p", count: 200)))
+        store.apply(.userPromptSubmit(id: "s1", cwd: nil, prompt: String(repeating: "p", count: 200)))
         XCTAssertEqual(store.sessions[0].lastUserPrompt?.count, 80)
     }
 }

--- a/Claude UsageTests/NotchHUDCoreTests.swift
+++ b/Claude UsageTests/NotchHUDCoreTests.swift
@@ -176,6 +176,18 @@ final class NotchSessionStoreTests: XCTestCase {
         XCTAssertEqual(store.sessions[0].status, .runningCommand)
     }
 
+    func testNotificationAfterStopKeepsSessionIdle() {
+        store.apply(.sessionStart(id: "s1", cwd: nil))
+        store.apply(.stop(id: "s1", cwd: nil))
+        XCTAssertEqual(store.sessions[0].status, .idle)
+
+        // Claude Code's "waiting for your input" nudge fires ~60s after Stop.
+        // A finished session must stay idle so auto keep-awake doesn't re-arm
+        // and hold the Mac awake until the terminal closes.
+        store.apply(.notification(id: "s1", cwd: nil, message: "Claude is waiting for your input"))
+        XCTAssertEqual(store.sessions[0].status, .idle)
+    }
+
     func testStopSetsIdleAndSessionEndRemoves() {
         store.apply(.sessionStart(id: "s1", cwd: nil))
         store.apply(.stop(id: "s1", cwd: nil))

--- a/Claude UsageTests/NotchHUDCoreTests.swift
+++ b/Claude UsageTests/NotchHUDCoreTests.swift
@@ -132,10 +132,10 @@ final class NotchHookEventTests: XCTestCase {
                                            payload: ["session_id": "s", "cwd": "/p"]),
                        .sessionStart(id: "s", cwd: "/p"))
         XCTAssertEqual(NotchHookEvent.from(pathSuffix: "stop", payload: ["session_id": "s"]),
-                       .stop(id: "s"))
+                       .stop(id: "s", cwd: nil))
         XCTAssertEqual(NotchHookEvent.from(pathSuffix: "notification",
                                            payload: ["session_id": "s", "message": "waiting"]),
-                       .notification(id: "s", message: "waiting"))
+                       .notification(id: "s", cwd: nil, message: "waiting"))
     }
 }
 
@@ -157,9 +157,19 @@ final class NotchSessionStoreTests: XCTestCase {
         XCTAssertEqual(store.sessions[0].displayName, "proj")
     }
 
+    func testLateObservedSessionIsNamedFromAnyEventCwd() {
+        // Sessions first seen mid-flight (tracker restart, sub-process without
+        // a SessionStart) must not be stuck as "Session XXXXX".
+        store.apply(.notification(id: "late", cwd: "/Users/dev/webapp", message: "waiting"))
+        XCTAssertEqual(store.sessions[0].displayName, "webapp")
+
+        store.apply(.stop(id: "sub", cwd: "/Users/dev/api-server"))
+        XCTAssertEqual(store.sessions[1].displayName, "api-server")
+    }
+
     func testNotificationSetsAttentionAndNextActivityClearsIt() {
         store.apply(.sessionStart(id: "s1", cwd: "/p"))
-        store.apply(.notification(id: "s1", message: "Claude needs your permission"))
+        store.apply(.notification(id: "s1", cwd: nil, message: "Claude needs your permission"))
         XCTAssertEqual(store.sessions[0].status, .needsAttention)
 
         store.apply(.preToolUse(id: "s1", cwd: nil, status: .runningCommand, task: "ls"))
@@ -168,7 +178,7 @@ final class NotchSessionStoreTests: XCTestCase {
 
     func testStopSetsIdleAndSessionEndRemoves() {
         store.apply(.sessionStart(id: "s1", cwd: nil))
-        store.apply(.stop(id: "s1"))
+        store.apply(.stop(id: "s1", cwd: nil))
         XCTAssertEqual(store.sessions[0].status, .idle)
         store.apply(.sessionEnd(id: "s1"))
         XCTAssertTrue(store.sessions.isEmpty)
@@ -176,16 +186,16 @@ final class NotchSessionStoreTests: XCTestCase {
 
     func testToolFailureSetsErrorFlagAndPostToolUseClearsIt() {
         store.apply(.sessionStart(id: "s1", cwd: nil))
-        store.apply(.toolFailure(id: "s1"))
+        store.apply(.toolFailure(id: "s1", cwd: nil))
         XCTAssertTrue(store.sessions[0].hasRecentError)
-        store.apply(.postToolUse(id: "s1"))
+        store.apply(.postToolUse(id: "s1", cwd: nil))
         XCTAssertFalse(store.sessions[0].hasRecentError)
     }
 
     func testPrimarySessionPrefersAttention() {
         store.apply(.preToolUse(id: "busy", cwd: nil, status: .runningCommand, task: "build"))
         store.apply(.sessionStart(id: "waiting", cwd: nil))
-        store.apply(.notification(id: "waiting", message: "input needed"))
+        store.apply(.notification(id: "waiting", cwd: nil, message: "input needed"))
         XCTAssertEqual(store.primarySession?.id, "waiting")
     }
 
@@ -195,7 +205,7 @@ final class NotchSessionStoreTests: XCTestCase {
 
         store.apply(.sessionStart(id: "old", cwd: nil))
         store.apply(.sessionStart(id: "attention", cwd: nil))
-        store.apply(.notification(id: "attention", message: "waiting"))
+        store.apply(.notification(id: "attention", cwd: nil, message: "waiting"))
 
         // 3 minutes later: normal session swept (120s), attention survives (600s grace)
         fakeNow = fakeNow.addingTimeInterval(180)
@@ -209,7 +219,7 @@ final class NotchSessionStoreTests: XCTestCase {
     }
 
     func testPromptTruncatedTo80() {
-        store.apply(.userPromptSubmit(id: "s1", prompt: String(repeating: "p", count: 200)))
+        store.apply(.userPromptSubmit(id: "s1", cwd: nil, prompt: String(repeating: "p", count: 200)))
         XCTAssertEqual(store.sessions[0].lastUserPrompt?.count, 80)
     }
 }


### PR DESCRIPTION
## Description

Two display fixes and two behavior fixes for the Claude Code notch HUD, all found in daily use:

1. **Sessions observed mid-flight showed as `Session 9DEA3` instead of their project name.** Every Claude Code hook payload includes `cwd`, but the HUD only read it from `session-start` and `pre-tool-use` events. Any session first seen through another event — a session that was already running when the app started, or a sub-process that never fires `SessionStart` — was created without a project path and fell back to a bare session id. Now every event carries `cwd`, so a session is named the moment anything is heard from it.

2. **Project names were truncated aggressively in the compact HUD.** The name slot was capped at 96 pt with middle truncation, so even this repository's own folder, `Claude-Usage-Tracker`, rendered as `Claude-…Tracker`. The cap is now 150 pt: names slightly over it shrink up to 20 % before truncating (tail truncation), very long names still cap safely (verified with an 84-character project name), and hovering the name shows the full text as a tooltip. The status verb on the right is unchanged.

3. **The expanded session list stayed open until explicitly clicked closed, blocking clicks on menu bar items beneath it.** Expansion is now transient, matching the interaction model of the iOS Dynamic Island: once the pointer has been away from the panel for 8 seconds, it folds back to compact on its own. Hovering it keeps it open.

4. **A finished session kept re-ringing the attention bell — and held the Mac awake — until the terminal was closed.** Claude Code fires the `Notification` hook ("waiting for your input") ~60 s after `Stop`, when the task is already done. The reducer flipped that idle session back to `.needsAttention`, which re-showed the attention cue and — because auto Keep Awake treats `.needsAttention` as active — re-armed the wake hold, so the Mac stayed awake until `SessionEnd`. The reducer now leaves an already-idle session idle; a genuine permission prompt still arrives mid-work (never idle) and is unaffected.

No new user-facing strings (no localization changes needed). No Keychain/App Group changes. Tested on macOS 26 (Tahoe) on a notched MacBook Pro; unit tests updated and passing, including new regression tests for the naming fix and the idle-notification fix.

## Changes

- `NotchHookEvent.swift` — all mutating event cases now carry `cwd`; decoding passes it through from every hook payload
- `NotchSessionStore.swift` — the reducer upserts `projectPath` from any event that provides it; a `.notification` arriving while a session is already idle no longer re-raises `.needsAttention`
- `NotchCompactViews.swift` — name slot 96 pt → 150 pt, `minimumScaleFactor(0.8)`, tail truncation, full-name tooltip
- `NotchHUDController.swift` — expanded state auto-collapses after 8 s without hover (`Constants.NotchHUD.expandedAutoCollapseDelay`)
- `NotchHUDCoreTests.swift` — regression test: sessions first observed via `notification`/`stop` events are named from that event's `cwd`, plus one asserting a post-`Stop` idle nudge keeps the session idle
- `KeepAwakeServiceTests.swift` — mechanical updates for the new event signatures

## Screenshots / Screen Recordings

**Compact HUD — project name (before / after):**

<img width="1480" height="362" alt="before-still-thinking" src="https://github.com/user-attachments/assets/ad951780-505c-47f9-b2dd-1b79b61c321f" /> (shows `Claude-…Tracker`)
<img width="1480" height="362" alt="after-still-thinking" src="https://github.com/user-attachments/assets/422ec36d-5a81-4553-9ccc-aa905d1295b0" /> (shows `Claude-Usage-Tracker` in full)

*(The session-naming fix isn't shown separately: it needs a session with no observed start event to reproduce, which doesn't photograph on demand. Before this change such a session displayed as `Session 9DEA3`; with it, the same session displays its project folder name, e.g. `my-cool-project`.)*

**Expanded list (before / after):**

<img width="1480" height="362" alt="before-still-expanded" src="https://github.com/user-attachments/assets/3ef173c9-1254-493a-a4eb-fd8365610063" />
<img width="1480" height="362" alt="after-still-expanded" src="https://github.com/user-attachments/assets/c983e9a2-09dc-420e-925b-79bc4d55900a" />

**Live demos:**

Before — 19 s, truncated name throughout; expanded panel stays open until clicked:

https://github.com/user-attachments/assets/cdfb4336-2a47-44ce-a171-72ddd079f614

After — 13 s, full name, live status changes, and the expanded panel auto-collapsing on its own at ~0:08–0:12:

https://github.com/user-attachments/assets/ffbdfb4f-0309-43cb-8bbc-2f4bddf3a45e

## Checklist

- [x] I have tested these changes on a running build
- [x] I have attached screenshots/recordings for any visual changes
- [x] I have not introduced App Group or grouped Keychain usage
- [x] I have added localization keys for any new user-facing strings *(none added — no new strings)*

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


