### PR TITLE
 feat(popover): show member's own month-to-date spend for Enterprise plans

### DIFF
--- a/Claude Usage/MenuBar/PopoverContentView.swift
+++ b/Claude Usage/MenuBar/PopoverContentView.swift
@@ -705,11 +705,11 @@ struct SmartUsageDashboard: View {
                 }
             }
 
-            // Personal usage — this member's own month-to-date spend (the number
+            // Monthly spend — this member's own month-to-date spend (the number
             // shown on claude.ai/settings/usage), distinct from the org-wide
             // Extra Usage above. Only rendered when the endpoint returned a value.
             if let personalUsed = usage.personalSpendUsed {
-                PersonalUsageRow(
+                MonthlySpendRow(
                     usedMinorUnits: personalUsed,
                     currency: usage.personalSpendCurrency ?? "USD",
                     limitCents: profileManager.activeProfile?.monthlySpendLimitCents,
@@ -884,13 +884,12 @@ struct UsageRow: View {
     }
 }
 
-// MARK: - Contextual Insights
-// MARK: - Personal Usage Row
+// MARK: - Monthly Spend Row
 
 /// The authenticated member's own month-to-date spend. When a monthly target is
 /// set on the profile this renders as a progress bar (matching Extra Usage);
 /// otherwise it shows just the amount, since the API exposes no per-member limit.
-struct PersonalUsageRow: View {
+struct MonthlySpendRow: View {
     let usedMinorUnits: Double
     let currency: String
     let limitCents: Double?
@@ -901,7 +900,7 @@ struct PersonalUsageRow: View {
     var body: some View {
         if let limit = limitCents, limit > 0 {
             UsageRow(
-                title: "menubar.personal_usage".localized,
+                title: "menubar.monthly_spend".localized,
                 subtitle: String(format: "%.2f / %.2f %@", usedDollars, limit / 100.0, currency),
                 usedPercentage: (usedMinorUnits / limit) * 100.0,
                 showRemaining: showRemaining,
@@ -911,10 +910,10 @@ struct PersonalUsageRow: View {
         } else {
             HStack(alignment: .firstTextBaseline) {
                 VStack(alignment: .leading, spacing: 1) {
-                    Text("menubar.personal_usage".localized)
+                    Text("menubar.monthly_spend".localized)
                         .font(.system(size: 13, weight: .medium))
                         .foregroundColor(.primary)
-                    Text("popover.personal_usage_period".localized)
+                    Text("popover.monthly_spend_period".localized)
                         .font(.system(size: 10))
                         .foregroundColor(.secondary)
                 }

--- a/Claude Usage/MenuBar/PopoverContentView.swift
+++ b/Claude Usage/MenuBar/PopoverContentView.swift
@@ -705,6 +705,18 @@ struct SmartUsageDashboard: View {
                 }
             }
 
+            // Personal usage — this member's own month-to-date spend (the number
+            // shown on claude.ai/settings/usage), distinct from the org-wide
+            // Extra Usage above. Only rendered when the endpoint returned a value.
+            if let personalUsed = usage.personalSpendUsed {
+                PersonalUsageRow(
+                    usedMinorUnits: personalUsed,
+                    currency: usage.personalSpendCurrency ?? "USD",
+                    limitCents: profileManager.activeProfile?.monthlySpendLimitCents,
+                    showRemaining: showRemainingPercentage
+                )
+            }
+
             // API Usage
             if let apiUsage = apiUsage {
                 APIUsageCard(apiUsage: apiUsage, showRemaining: showRemainingPercentage, timeDisplay: timeDisplay)
@@ -873,6 +885,58 @@ struct UsageRow: View {
 }
 
 // MARK: - Contextual Insights
+// MARK: - Personal Usage Row
+
+/// The authenticated member's own month-to-date spend. When a monthly target is
+/// set on the profile this renders as a progress bar (matching Extra Usage);
+/// otherwise it shows just the amount, since the API exposes no per-member limit.
+struct PersonalUsageRow: View {
+    let usedMinorUnits: Double
+    let currency: String
+    let limitCents: Double?
+    let showRemaining: Bool
+
+    private var usedDollars: Double { usedMinorUnits / 100.0 }
+
+    var body: some View {
+        if let limit = limitCents, limit > 0 {
+            UsageRow(
+                title: "menubar.personal_usage".localized,
+                subtitle: String(format: "%.2f / %.2f %@", usedDollars, limit / 100.0, currency),
+                usedPercentage: (usedMinorUnits / limit) * 100.0,
+                showRemaining: showRemaining,
+                resetTime: nil,
+                periodDuration: nil
+            )
+        } else {
+            HStack(alignment: .firstTextBaseline) {
+                VStack(alignment: .leading, spacing: 1) {
+                    Text("menubar.personal_usage".localized)
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundColor(.primary)
+                    Text("popover.personal_usage_period".localized)
+                        .font(.system(size: 10))
+                        .foregroundColor(.secondary)
+                }
+
+                Spacer()
+
+                Text(String(format: "%.2f %@", usedDollars, currency))
+                    .font(.system(size: 13, weight: .semibold, design: .rounded))
+                    .foregroundColor(.adaptiveGreen)
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .strokeBorder(Color.primary.opacity(0.1), lineWidth: 0.5)
+            )
+        }
+    }
+}
+
+// MARK: - Contextual Insights
+
 struct ContextualInsights: View {
     let usage: ClaudeUsage
 

--- a/Claude Usage/MenuBar/PopoverContentView.swift
+++ b/Claude Usage/MenuBar/PopoverContentView.swift
@@ -102,9 +102,8 @@ struct PopoverContentView: View {
         return viewingProfile?.provider ?? .anthropic
     }
 
-    /// Monthly spend target of the profile being viewed. Read from the viewed
-    /// profile rather than the active one so multi-profile mode pairs each
-    /// profile's spend with its own target.
+    /// Monthly spend target of the profile being viewed (clicked profile in
+    /// multi-profile mode, else the active profile).
     private var displayMonthlySpendLimitCents: Double? {
         let viewingProfile = manager.clickedProfileId.flatMap { id in
             profileManager.profiles.first(where: { $0.id == id })
@@ -748,9 +747,7 @@ struct SmartUsageDashboard: View {
                 }
             }
 
-            // Monthly spend — this member's own month-to-date spend (the number
-            // shown on claude.ai/settings/usage), distinct from the org-wide
-            // Extra Usage above. Only rendered when the endpoint returned a value.
+            // Monthly spend (member's own month-to-date; distinct from org-wide Extra Usage)
             if capabilities.personalSpend, let personalUsed = usage.personalSpendUsed {
                 MonthlySpendRow(
                     usedMinorUnits: personalUsed,
@@ -952,9 +949,8 @@ struct UsageRow: View {
 
 // MARK: - Monthly Spend Row
 
-/// The authenticated member's own month-to-date spend. When a monthly target is
-/// set on the profile this renders as a progress bar (matching Extra Usage);
-/// otherwise it shows just the amount, since the API exposes no per-member limit.
+/// The member's own month-to-date spend. Renders as a progress bar when the
+/// profile has a monthly target; otherwise shows just the amount.
 struct MonthlySpendRow: View {
     let usedMinorUnits: Double
     let currency: String

--- a/Claude Usage/MenuBar/PopoverContentView.swift
+++ b/Claude Usage/MenuBar/PopoverContentView.swift
@@ -102,6 +102,16 @@ struct PopoverContentView: View {
         return viewingProfile?.provider ?? .anthropic
     }
 
+    /// Monthly spend target of the profile being viewed. Read from the viewed
+    /// profile rather than the active one so multi-profile mode pairs each
+    /// profile's spend with its own target.
+    private var displayMonthlySpendLimitCents: Double? {
+        let viewingProfile = manager.clickedProfileId.flatMap { id in
+            profileManager.profiles.first(where: { $0.id == id })
+        } ?? profileManager.activeProfile
+        return viewingProfile?.monthlySpendLimitCents
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             // Header
@@ -208,7 +218,12 @@ struct PopoverContentView: View {
             }
 
             // Usage
-            SmartUsageDashboard(usage: displayUsage, apiUsage: displayAPIUsage, provider: displayProvider)
+            SmartUsageDashboard(
+                usage: displayUsage,
+                apiUsage: displayAPIUsage,
+                provider: displayProvider,
+                monthlySpendLimitCents: displayMonthlySpendLimitCents
+            )
 
             // Contextual Insights
             if showInsights {
@@ -588,6 +603,7 @@ struct SmartUsageDashboard: View {
     let usage: ClaudeUsage
     let apiUsage: APIUsage?
     var provider: Provider = .anthropic
+    var monthlySpendLimitCents: Double? = nil
     @StateObject private var profileManager = ProfileManager.shared
     private var capabilities: ProviderCapabilities {
         provider.descriptor.capabilities
@@ -730,6 +746,18 @@ struct SmartUsageDashboard: View {
                             .foregroundColor(.adaptiveGreen)
                     }
                 }
+            }
+
+            // Monthly spend — this member's own month-to-date spend (the number
+            // shown on claude.ai/settings/usage), distinct from the org-wide
+            // Extra Usage above. Only rendered when the endpoint returned a value.
+            if capabilities.personalSpend, let personalUsed = usage.personalSpendUsed {
+                MonthlySpendRow(
+                    usedMinorUnits: personalUsed,
+                    currency: usage.personalSpendCurrency ?? "USD",
+                    limitCents: monthlySpendLimitCents,
+                    showRemaining: showRemainingPercentage
+                )
             }
 
             // Plan / credits (providers that report them, e.g. Codex)
@@ -918,6 +946,56 @@ struct UsageRow: View {
             return "menubar.resets_in".localized(with: reset.timeRemainingString())
         case .both:
             return "menubar.resets_both".localized(with: reset.timeRemainingString(), reset.resetTimeString())
+        }
+    }
+}
+
+// MARK: - Monthly Spend Row
+
+/// The authenticated member's own month-to-date spend. When a monthly target is
+/// set on the profile this renders as a progress bar (matching Extra Usage);
+/// otherwise it shows just the amount, since the API exposes no per-member limit.
+struct MonthlySpendRow: View {
+    let usedMinorUnits: Double
+    let currency: String
+    let limitCents: Double?
+    let showRemaining: Bool
+
+    private var usedDollars: Double { usedMinorUnits / 100.0 }
+
+    var body: some View {
+        if let limit = limitCents, limit > 0 {
+            UsageRow(
+                title: "menubar.monthly_spend".localized,
+                subtitle: String(format: "%.2f / %.2f %@", usedDollars, limit / 100.0, currency),
+                usedPercentage: (usedMinorUnits / limit) * 100.0,
+                showRemaining: showRemaining,
+                resetTime: nil,
+                periodDuration: nil
+            )
+        } else {
+            HStack(alignment: .firstTextBaseline) {
+                VStack(alignment: .leading, spacing: 1) {
+                    Text("menubar.monthly_spend".localized)
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundColor(.primary)
+                    Text("popover.monthly_spend_period".localized)
+                        .font(.system(size: 10))
+                        .foregroundColor(.secondary)
+                }
+
+                Spacer()
+
+                Text(String(format: "%.2f %@", usedDollars, currency))
+                    .font(.system(size: 13, weight: .semibold, design: .rounded))
+                    .foregroundColor(.adaptiveGreen)
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .strokeBorder(Color.primary.opacity(0.1), lineWidth: 0.5)
+            )
         }
     }
 }

--- a/Claude Usage/Resources/de.lproj/Localizable.strings
+++ b/Claude Usage/Resources/de.lproj/Localizable.strings
@@ -1031,9 +1031,9 @@
 "sponsor.slot_title" = "Dieser Platz ist für Sponsoren verfügbar";
 "sponsor.slot_cta" = "Kontakt aufnehmen";
 
-// MARK: - Personal Usage (English fallback — pending translation)
-"menubar.personal_usage" = "Personal Usage";
-"popover.personal_usage_period" = "This month";
-"general.spend_target_title" = "Monthly Spend Target";
-"general.spend_target_subtitle" = "Optional personal budget for the month. Set it to show a Personal Usage bar in the popover; leave blank to just show the amount.";
-"general.spend_target_placeholder" = "e.g. 1500";
+// MARK: - Personal Usage
+"menubar.personal_usage" = "Persönliche Nutzung";
+"popover.personal_usage_period" = "Diesen Monat";
+"general.spend_target_title" = "Monatliches Ausgabenziel";
+"general.spend_target_subtitle" = "Optionales persönliches Monatsbudget. Festlegen, um im Popover einen Balken für die persönliche Nutzung anzuzeigen; leer lassen, um nur den Betrag anzuzeigen.";
+"general.spend_target_placeholder" = "z. B. 1500";

--- a/Claude Usage/Resources/de.lproj/Localizable.strings
+++ b/Claude Usage/Resources/de.lproj/Localizable.strings
@@ -1031,9 +1031,9 @@
 "sponsor.slot_title" = "Dieser Platz ist für Sponsoren verfügbar";
 "sponsor.slot_cta" = "Kontakt aufnehmen";
 
-// MARK: - Personal Usage
-"menubar.personal_usage" = "Persönliche Nutzung";
-"popover.personal_usage_period" = "Diesen Monat";
+// MARK: - Monthly Spend
+"menubar.monthly_spend" = "Monatliche Ausgaben";
+"popover.monthly_spend_period" = "Diesen Monat";
 "general.spend_target_title" = "Monatliches Ausgabenziel";
-"general.spend_target_subtitle" = "Optionales persönliches Monatsbudget. Festlegen, um im Popover einen Balken für die persönliche Nutzung anzuzeigen; leer lassen, um nur den Betrag anzuzeigen.";
+"general.spend_target_subtitle" = "Optionales persönliches Monatsbudget. Festlegen, um im Popover einen Balken für die monatlichen Ausgaben anzuzeigen; leer lassen, um nur den Betrag anzuzeigen.";
 "general.spend_target_placeholder" = "z. B. 1500";

--- a/Claude Usage/Resources/de.lproj/Localizable.strings
+++ b/Claude Usage/Resources/de.lproj/Localizable.strings
@@ -1030,3 +1030,10 @@
 /* Sponsor slot */
 "sponsor.slot_title" = "Dieser Platz ist für Sponsoren verfügbar";
 "sponsor.slot_cta" = "Kontakt aufnehmen";
+
+// MARK: - Personal Usage (English fallback — pending translation)
+"menubar.personal_usage" = "Personal Usage";
+"popover.personal_usage_period" = "This month";
+"general.spend_target_title" = "Monthly Spend Target";
+"general.spend_target_subtitle" = "Optional personal budget for the month. Set it to show a Personal Usage bar in the popover; leave blank to just show the amount.";
+"general.spend_target_placeholder" = "e.g. 1500";

--- a/Claude Usage/Resources/de.lproj/Localizable.strings
+++ b/Claude Usage/Resources/de.lproj/Localizable.strings
@@ -961,9 +961,9 @@
 // MARK: - Overage Balance
 "popover.overage_balance" = "Guthaben";
 
-
 // MARK: - Monthly Spend
 "popover.monthly_spend_period" = "Diesen Monat";
+
 // MARK: - Setup Wizard CLI Detection
 "setup.cli_detecting" = "CLI-Anmeldedaten werden gesucht...";
 "setup.cli_detected.title" = "CLI Erkannt!";

--- a/Claude Usage/Resources/de.lproj/Localizable.strings
+++ b/Claude Usage/Resources/de.lproj/Localizable.strings
@@ -64,6 +64,7 @@
 "menubar.fable_usage" = "Fable";
 "menubar.design_usage" = "Design";
 "menubar.extra_usage" = "Zusätzliche Nutzung";
+"menubar.monthly_spend" = "Monatliche Ausgaben";
 "menubar.api_credits" = "API-Guthaben";
 "menubar.5_hour_window" = "5-Stunden-Gleitfenster";
 "menubar.all_models" = "Alle Modelle";
@@ -572,6 +573,9 @@
 "general.refresh_seconds" = "%d Sekunden";
 "general.refresh_min" = "10s";
 "general.refresh_max" = "300s";
+"general.spend_target_title" = "Monatliches Ausgabenziel";
+"general.spend_target_subtitle" = "Optionales persönliches Monatsbudget. Festlegen, um im Popover einen Balken für die monatlichen Ausgaben anzuzeigen; leer lassen, um nur den Betrag anzuzeigen.";
+"general.spend_target_placeholder" = "z. B. 1500";
 "general.autostart_title" = "Sitzungs-Auto-Start";
 "general.autostart_subtitle" = "Automatisch eine neue Sitzung bei Bedarf starten";
 "general.autostart_toggle" = "Neue Sitzung Automatisch Starten";
@@ -957,6 +961,9 @@
 // MARK: - Overage Balance
 "popover.overage_balance" = "Guthaben";
 
+
+// MARK: - Monthly Spend
+"popover.monthly_spend_period" = "Diesen Monat";
 // MARK: - Setup Wizard CLI Detection
 "setup.cli_detecting" = "CLI-Anmeldedaten werden gesucht...";
 "setup.cli_detected.title" = "CLI Erkannt!";

--- a/Claude Usage/Resources/en.lproj/Localizable.strings
+++ b/Claude Usage/Resources/en.lproj/Localizable.strings
@@ -64,6 +64,7 @@
 "menubar.fable_usage" = "Fable";
 "menubar.design_usage" = "Design";
 "menubar.extra_usage" = "Extra Usage";
+"menubar.personal_usage" = "Personal Usage";
 "menubar.api_credits" = "API Credits";
 "menubar.api_cost" = "API Cost";
 "menubar.this_month" = "This Month";
@@ -550,6 +551,9 @@
 "general.refresh_seconds" = "%d seconds";
 "general.refresh_min" = "10s";
 "general.refresh_max" = "300s";
+"general.spend_target_title" = "Monthly Spend Target";
+"general.spend_target_subtitle" = "Optional personal budget for the month. Set it to show a Personal Usage bar in the popover; leave blank to just show the amount.";
+"general.spend_target_placeholder" = "e.g. 1500";
 "general.autostart_title" = "Auto-Start Session";
 "general.autostart_subtitle" = "Automatically start a new session when needed";
 "general.autostart_toggle" = "Auto-Start New Session";
@@ -970,6 +974,9 @@
 
 // MARK: - Overage Balance
 "popover.overage_balance" = "Balance";
+
+// MARK: - Personal Usage
+"popover.personal_usage_period" = "This month";
 
 // MARK: - Setup Wizard CLI Detection
 "setup.cli_detecting" = "Checking for CLI credentials...";

--- a/Claude Usage/Resources/en.lproj/Localizable.strings
+++ b/Claude Usage/Resources/en.lproj/Localizable.strings
@@ -64,7 +64,7 @@
 "menubar.fable_usage" = "Fable";
 "menubar.design_usage" = "Design";
 "menubar.extra_usage" = "Extra Usage";
-"menubar.personal_usage" = "Personal Usage";
+"menubar.monthly_spend" = "Monthly Spend";
 "menubar.api_credits" = "API Credits";
 "menubar.api_cost" = "API Cost";
 "menubar.this_month" = "This Month";
@@ -552,7 +552,7 @@
 "general.refresh_min" = "10s";
 "general.refresh_max" = "300s";
 "general.spend_target_title" = "Monthly Spend Target";
-"general.spend_target_subtitle" = "Optional personal budget for the month. Set it to show a Personal Usage bar in the popover; leave blank to just show the amount.";
+"general.spend_target_subtitle" = "Optional personal budget for the month. Set it to show a Monthly Spend bar in the popover; leave blank to just show the amount.";
 "general.spend_target_placeholder" = "e.g. 1500";
 "general.autostart_title" = "Auto-Start Session";
 "general.autostart_subtitle" = "Automatically start a new session when needed";
@@ -975,8 +975,8 @@
 // MARK: - Overage Balance
 "popover.overage_balance" = "Balance";
 
-// MARK: - Personal Usage
-"popover.personal_usage_period" = "This month";
+// MARK: - Monthly Spend
+"popover.monthly_spend_period" = "This month";
 
 // MARK: - Setup Wizard CLI Detection
 "setup.cli_detecting" = "Checking for CLI credentials...";

--- a/Claude Usage/Resources/en.lproj/Localizable.strings
+++ b/Claude Usage/Resources/en.lproj/Localizable.strings
@@ -64,6 +64,7 @@
 "menubar.fable_usage" = "Fable";
 "menubar.design_usage" = "Design";
 "menubar.extra_usage" = "Extra Usage";
+"menubar.monthly_spend" = "Monthly Spend";
 "menubar.api_credits" = "API Credits";
 "menubar.api_cost" = "API Cost";
 "menubar.this_month" = "This Month";
@@ -550,6 +551,9 @@
 "general.refresh_seconds" = "%d seconds";
 "general.refresh_min" = "10s";
 "general.refresh_max" = "300s";
+"general.spend_target_title" = "Monthly Spend Target";
+"general.spend_target_subtitle" = "Optional personal budget for the month. Set it to show a Monthly Spend bar in the popover; leave blank to just show the amount.";
+"general.spend_target_placeholder" = "e.g. 1500";
 "general.autostart_title" = "Auto-Start Session";
 "general.autostart_subtitle" = "Automatically start a new session when needed";
 "general.autostart_toggle" = "Auto-Start New Session";
@@ -965,6 +969,9 @@
 // MARK: - Overage Balance
 "popover.overage_balance" = "Balance";
 
+
+// MARK: - Monthly Spend
+"popover.monthly_spend_period" = "This month";
 // MARK: - Setup Wizard CLI Detection
 "setup.cli_detecting" = "Checking for CLI credentials...";
 "setup.cli_detected.title" = "CLI Detected!";

--- a/Claude Usage/Resources/en.lproj/Localizable.strings
+++ b/Claude Usage/Resources/en.lproj/Localizable.strings
@@ -969,9 +969,9 @@
 // MARK: - Overage Balance
 "popover.overage_balance" = "Balance";
 
-
 // MARK: - Monthly Spend
 "popover.monthly_spend_period" = "This month";
+
 // MARK: - Setup Wizard CLI Detection
 "setup.cli_detecting" = "Checking for CLI credentials...";
 "setup.cli_detected.title" = "CLI Detected!";

--- a/Claude Usage/Resources/es.lproj/Localizable.strings
+++ b/Claude Usage/Resources/es.lproj/Localizable.strings
@@ -1012,9 +1012,9 @@
 "sponsor.slot_title" = "Este espacio está disponible para patrocinadores";
 "sponsor.slot_cta" = "Contáctame";
 
-// MARK: - Personal Usage
-"menubar.personal_usage" = "Uso Personal";
-"popover.personal_usage_period" = "Este mes";
+// MARK: - Monthly Spend
+"menubar.monthly_spend" = "Gasto Mensual";
+"popover.monthly_spend_period" = "Este mes";
 "general.spend_target_title" = "Objetivo de Gasto Mensual";
-"general.spend_target_subtitle" = "Presupuesto personal opcional para el mes. Configúralo para mostrar una barra de Uso Personal en la ventana emergente; déjalo en blanco para mostrar solo el importe.";
+"general.spend_target_subtitle" = "Presupuesto personal opcional para el mes. Configúralo para mostrar una barra de Gasto Mensual en la ventana emergente; déjalo en blanco para mostrar solo el importe.";
 "general.spend_target_placeholder" = "p. ej. 1500";

--- a/Claude Usage/Resources/es.lproj/Localizable.strings
+++ b/Claude Usage/Resources/es.lproj/Localizable.strings
@@ -1011,3 +1011,10 @@
 /* Sponsor slot */
 "sponsor.slot_title" = "Este espacio está disponible para patrocinadores";
 "sponsor.slot_cta" = "Contáctame";
+
+// MARK: - Personal Usage (English fallback — pending translation)
+"menubar.personal_usage" = "Personal Usage";
+"popover.personal_usage_period" = "This month";
+"general.spend_target_title" = "Monthly Spend Target";
+"general.spend_target_subtitle" = "Optional personal budget for the month. Set it to show a Personal Usage bar in the popover; leave blank to just show the amount.";
+"general.spend_target_placeholder" = "e.g. 1500";

--- a/Claude Usage/Resources/es.lproj/Localizable.strings
+++ b/Claude Usage/Resources/es.lproj/Localizable.strings
@@ -1012,9 +1012,9 @@
 "sponsor.slot_title" = "Este espacio está disponible para patrocinadores";
 "sponsor.slot_cta" = "Contáctame";
 
-// MARK: - Personal Usage (English fallback — pending translation)
-"menubar.personal_usage" = "Personal Usage";
-"popover.personal_usage_period" = "This month";
-"general.spend_target_title" = "Monthly Spend Target";
-"general.spend_target_subtitle" = "Optional personal budget for the month. Set it to show a Personal Usage bar in the popover; leave blank to just show the amount.";
-"general.spend_target_placeholder" = "e.g. 1500";
+// MARK: - Personal Usage
+"menubar.personal_usage" = "Uso Personal";
+"popover.personal_usage_period" = "Este mes";
+"general.spend_target_title" = "Objetivo de Gasto Mensual";
+"general.spend_target_subtitle" = "Presupuesto personal opcional para el mes. Configúralo para mostrar una barra de Uso Personal en la ventana emergente; déjalo en blanco para mostrar solo el importe.";
+"general.spend_target_placeholder" = "p. ej. 1500";

--- a/Claude Usage/Resources/es.lproj/Localizable.strings
+++ b/Claude Usage/Resources/es.lproj/Localizable.strings
@@ -64,6 +64,7 @@
 "menubar.fable_usage" = "Fable";
 "menubar.design_usage" = "Design";
 "menubar.extra_usage" = "Uso Extra";
+"menubar.monthly_spend" = "Gasto Mensual";
 "menubar.api_credits" = "Créditos API";
 "menubar.5_hour_window" = "Ventana móvil de 5 horas";
 "menubar.all_models" = "Todos los modelos";
@@ -553,6 +554,9 @@
 "general.refresh_seconds" = "%d segundos";
 "general.refresh_min" = "10s";
 "general.refresh_max" = "300s";
+"general.spend_target_title" = "Objetivo de Gasto Mensual";
+"general.spend_target_subtitle" = "Presupuesto personal opcional para el mes. Configúralo para mostrar una barra de Gasto Mensual en la ventana emergente; déjalo en blanco para mostrar solo el importe.";
+"general.spend_target_placeholder" = "p. ej. 1500";
 "general.autostart_title" = "Inicio Automático de Sesión";
 "general.autostart_subtitle" = "Iniciar automáticamente una nueva sesión cuando sea necesario";
 "general.autostart_toggle" = "Inicio Automático de Nueva Sesión";
@@ -938,6 +942,9 @@
 // MARK: - Overage Balance
 "popover.overage_balance" = "Saldo";
 
+
+// MARK: - Monthly Spend
+"popover.monthly_spend_period" = "Este mes";
 // MARK: - Setup Wizard CLI Detection
 "setup.cli_detecting" = "Buscando credenciales CLI...";
 "setup.cli_detected.title" = "CLI Detectado!";

--- a/Claude Usage/Resources/es.lproj/Localizable.strings
+++ b/Claude Usage/Resources/es.lproj/Localizable.strings
@@ -942,9 +942,9 @@
 // MARK: - Overage Balance
 "popover.overage_balance" = "Saldo";
 
-
 // MARK: - Monthly Spend
 "popover.monthly_spend_period" = "Este mes";
+
 // MARK: - Setup Wizard CLI Detection
 "setup.cli_detecting" = "Buscando credenciales CLI...";
 "setup.cli_detected.title" = "CLI Detectado!";

--- a/Claude Usage/Resources/fr.lproj/Localizable.strings
+++ b/Claude Usage/Resources/fr.lproj/Localizable.strings
@@ -1008,3 +1008,10 @@
 /* Sponsor slot */
 "sponsor.slot_title" = "Cet emplacement est disponible pour les sponsors";
 "sponsor.slot_cta" = "Me contacter";
+
+// MARK: - Personal Usage (English fallback — pending translation)
+"menubar.personal_usage" = "Personal Usage";
+"popover.personal_usage_period" = "This month";
+"general.spend_target_title" = "Monthly Spend Target";
+"general.spend_target_subtitle" = "Optional personal budget for the month. Set it to show a Personal Usage bar in the popover; leave blank to just show the amount.";
+"general.spend_target_placeholder" = "e.g. 1500";

--- a/Claude Usage/Resources/fr.lproj/Localizable.strings
+++ b/Claude Usage/Resources/fr.lproj/Localizable.strings
@@ -1009,9 +1009,9 @@
 "sponsor.slot_title" = "Cet emplacement est disponible pour les sponsors";
 "sponsor.slot_cta" = "Me contacter";
 
-// MARK: - Personal Usage
-"menubar.personal_usage" = "Utilisation Personnelle";
-"popover.personal_usage_period" = "Ce mois-ci";
+// MARK: - Monthly Spend
+"menubar.monthly_spend" = "Dépenses Mensuelles";
+"popover.monthly_spend_period" = "Ce mois-ci";
 "general.spend_target_title" = "Objectif de Dépense Mensuel";
-"general.spend_target_subtitle" = "Budget personnel mensuel facultatif. Définissez-le pour afficher une barre d'Utilisation Personnelle dans le popover ; laissez vide pour n'afficher que le montant.";
+"general.spend_target_subtitle" = "Budget personnel mensuel facultatif. Définissez-le pour afficher une barre de Dépenses Mensuelles dans le popover ; laissez vide pour n'afficher que le montant.";
 "general.spend_target_placeholder" = "p. ex. 1500";

--- a/Claude Usage/Resources/fr.lproj/Localizable.strings
+++ b/Claude Usage/Resources/fr.lproj/Localizable.strings
@@ -1009,9 +1009,9 @@
 "sponsor.slot_title" = "Cet emplacement est disponible pour les sponsors";
 "sponsor.slot_cta" = "Me contacter";
 
-// MARK: - Personal Usage (English fallback — pending translation)
-"menubar.personal_usage" = "Personal Usage";
-"popover.personal_usage_period" = "This month";
-"general.spend_target_title" = "Monthly Spend Target";
-"general.spend_target_subtitle" = "Optional personal budget for the month. Set it to show a Personal Usage bar in the popover; leave blank to just show the amount.";
-"general.spend_target_placeholder" = "e.g. 1500";
+// MARK: - Personal Usage
+"menubar.personal_usage" = "Utilisation Personnelle";
+"popover.personal_usage_period" = "Ce mois-ci";
+"general.spend_target_title" = "Objectif de Dépense Mensuel";
+"general.spend_target_subtitle" = "Budget personnel mensuel facultatif. Définissez-le pour afficher une barre d'Utilisation Personnelle dans le popover ; laissez vide pour n'afficher que le montant.";
+"general.spend_target_placeholder" = "p. ex. 1500";

--- a/Claude Usage/Resources/fr.lproj/Localizable.strings
+++ b/Claude Usage/Resources/fr.lproj/Localizable.strings
@@ -64,6 +64,7 @@
 "menubar.fable_usage" = "Fable";
 "menubar.design_usage" = "Design";
 "menubar.extra_usage" = "Utilisation Supplémentaire";
+"menubar.monthly_spend" = "Dépenses Mensuelles";
 "menubar.api_credits" = "Crédits API";
 "menubar.5_hour_window" = "Fenêtre glissante de 5 heures";
 "menubar.all_models" = "Tous les modèles";
@@ -550,6 +551,9 @@
 "general.refresh_seconds" = "%d secondes";
 "general.refresh_min" = "10s";
 "general.refresh_max" = "300s";
+"general.spend_target_title" = "Objectif de Dépense Mensuel";
+"general.spend_target_subtitle" = "Budget personnel mensuel facultatif. Définissez-le pour afficher une barre de Dépenses Mensuelles dans le popover ; laissez vide pour n'afficher que le montant.";
+"general.spend_target_placeholder" = "p. ex. 1500";
 "general.autostart_title" = "Démarrage Automatique de Session";
 "general.autostart_subtitle" = "Démarrer automatiquement une nouvelle session si nécessaire";
 "general.autostart_toggle" = "Démarrage Automatique de Nouvelle Session";
@@ -935,6 +939,9 @@
 // MARK: - Overage Balance
 "popover.overage_balance" = "Solde";
 
+
+// MARK: - Monthly Spend
+"popover.monthly_spend_period" = "Ce mois-ci";
 // MARK: - Setup Wizard CLI Detection
 "setup.cli_detecting" = "Recherche des identifiants CLI...";
 "setup.cli_detected.title" = "CLI Détecté !";

--- a/Claude Usage/Resources/fr.lproj/Localizable.strings
+++ b/Claude Usage/Resources/fr.lproj/Localizable.strings
@@ -939,9 +939,9 @@
 // MARK: - Overage Balance
 "popover.overage_balance" = "Solde";
 
-
 // MARK: - Monthly Spend
 "popover.monthly_spend_period" = "Ce mois-ci";
+
 // MARK: - Setup Wizard CLI Detection
 "setup.cli_detecting" = "Recherche des identifiants CLI...";
 "setup.cli_detected.title" = "CLI Détecté !";

--- a/Claude Usage/Resources/it.lproj/Localizable.strings
+++ b/Claude Usage/Resources/it.lproj/Localizable.strings
@@ -1031,9 +1031,9 @@
 "sponsor.slot_title" = "Questo spazio è disponibile per gli sponsor";
 "sponsor.slot_cta" = "Contattami";
 
-// MARK: - Personal Usage (English fallback — pending translation)
-"menubar.personal_usage" = "Personal Usage";
-"popover.personal_usage_period" = "This month";
-"general.spend_target_title" = "Monthly Spend Target";
-"general.spend_target_subtitle" = "Optional personal budget for the month. Set it to show a Personal Usage bar in the popover; leave blank to just show the amount.";
-"general.spend_target_placeholder" = "e.g. 1500";
+// MARK: - Personal Usage
+"menubar.personal_usage" = "Utilizzo Personale";
+"popover.personal_usage_period" = "Questo mese";
+"general.spend_target_title" = "Obiettivo di Spesa Mensile";
+"general.spend_target_subtitle" = "Budget personale mensile opzionale. Impostalo per mostrare una barra di Utilizzo Personale nel popover; lascia vuoto per mostrare solo l'importo.";
+"general.spend_target_placeholder" = "es. 1500";

--- a/Claude Usage/Resources/it.lproj/Localizable.strings
+++ b/Claude Usage/Resources/it.lproj/Localizable.strings
@@ -1031,9 +1031,9 @@
 "sponsor.slot_title" = "Questo spazio è disponibile per gli sponsor";
 "sponsor.slot_cta" = "Contattami";
 
-// MARK: - Personal Usage
-"menubar.personal_usage" = "Utilizzo Personale";
-"popover.personal_usage_period" = "Questo mese";
+// MARK: - Monthly Spend
+"menubar.monthly_spend" = "Spesa Mensile";
+"popover.monthly_spend_period" = "Questo mese";
 "general.spend_target_title" = "Obiettivo di Spesa Mensile";
-"general.spend_target_subtitle" = "Budget personale mensile opzionale. Impostalo per mostrare una barra di Utilizzo Personale nel popover; lascia vuoto per mostrare solo l'importo.";
+"general.spend_target_subtitle" = "Budget personale mensile opzionale. Impostalo per mostrare una barra di Spesa Mensile nel popover; lascia vuoto per mostrare solo l'importo.";
 "general.spend_target_placeholder" = "es. 1500";

--- a/Claude Usage/Resources/it.lproj/Localizable.strings
+++ b/Claude Usage/Resources/it.lproj/Localizable.strings
@@ -1030,3 +1030,10 @@
 /* Sponsor slot */
 "sponsor.slot_title" = "Questo spazio è disponibile per gli sponsor";
 "sponsor.slot_cta" = "Contattami";
+
+// MARK: - Personal Usage (English fallback — pending translation)
+"menubar.personal_usage" = "Personal Usage";
+"popover.personal_usage_period" = "This month";
+"general.spend_target_title" = "Monthly Spend Target";
+"general.spend_target_subtitle" = "Optional personal budget for the month. Set it to show a Personal Usage bar in the popover; leave blank to just show the amount.";
+"general.spend_target_placeholder" = "e.g. 1500";

--- a/Claude Usage/Resources/it.lproj/Localizable.strings
+++ b/Claude Usage/Resources/it.lproj/Localizable.strings
@@ -959,9 +959,9 @@
 // MARK: - Overage Balance
 "popover.overage_balance" = "Saldo";
 
-
 // MARK: - Monthly Spend
 "popover.monthly_spend_period" = "Questo mese";
+
 // MARK: - Setup Wizard CLI Detection
 "setup.cli_detecting" = "Ricerca credenziali CLI...";
 "setup.cli_detected.title" = "CLI Rilevato!";

--- a/Claude Usage/Resources/it.lproj/Localizable.strings
+++ b/Claude Usage/Resources/it.lproj/Localizable.strings
@@ -62,6 +62,7 @@
 "menubar.fable_usage" = "Fable";
 "menubar.design_usage" = "Design";
 "menubar.extra_usage" = "Utilizzo Extra";
+"menubar.monthly_spend" = "Spesa Mensile";
 "menubar.api_credits" = "Crediti API";
 "menubar.5_hour_window" = "finestra mobile di 5 ore";
 "menubar.all_models" = "Tutti i modelli";
@@ -570,6 +571,9 @@
 "general.refresh_seconds" = "%d secondi";
 "general.refresh_min" = "10s";
 "general.refresh_max" = "300s";
+"general.spend_target_title" = "Obiettivo di Spesa Mensile";
+"general.spend_target_subtitle" = "Budget personale mensile opzionale. Impostalo per mostrare una barra di Spesa Mensile nel popover; lascia vuoto per mostrare solo l'importo.";
+"general.spend_target_placeholder" = "es. 1500";
 "general.autostart_title" = "Avvio Automatico Sessione";
 "general.autostart_subtitle" = "Avvia automaticamente una nuova sessione quando necessario";
 "general.autostart_toggle" = "Avvio Automatico Nuova Sessione";
@@ -955,6 +959,9 @@
 // MARK: - Overage Balance
 "popover.overage_balance" = "Saldo";
 
+
+// MARK: - Monthly Spend
+"popover.monthly_spend_period" = "Questo mese";
 // MARK: - Setup Wizard CLI Detection
 "setup.cli_detecting" = "Ricerca credenziali CLI...";
 "setup.cli_detected.title" = "CLI Rilevato!";

--- a/Claude Usage/Resources/ja.lproj/Localizable.strings
+++ b/Claude Usage/Resources/ja.lproj/Localizable.strings
@@ -1031,9 +1031,9 @@
 "sponsor.slot_title" = "スポンサー募集中のスペースです";
 "sponsor.slot_cta" = "お問い合わせ";
 
-// MARK: - Personal Usage (English fallback — pending translation)
-"menubar.personal_usage" = "Personal Usage";
-"popover.personal_usage_period" = "This month";
-"general.spend_target_title" = "Monthly Spend Target";
-"general.spend_target_subtitle" = "Optional personal budget for the month. Set it to show a Personal Usage bar in the popover; leave blank to just show the amount.";
-"general.spend_target_placeholder" = "e.g. 1500";
+// MARK: - Personal Usage
+"menubar.personal_usage" = "個人の使用量";
+"popover.personal_usage_period" = "今月";
+"general.spend_target_title" = "月間支出目標";
+"general.spend_target_subtitle" = "任意の月間個人予算。設定するとポップオーバーに個人の使用量バーが表示されます。空欄の場合は金額のみ表示されます。";
+"general.spend_target_placeholder" = "例: 1500";

--- a/Claude Usage/Resources/ja.lproj/Localizable.strings
+++ b/Claude Usage/Resources/ja.lproj/Localizable.strings
@@ -1031,9 +1031,9 @@
 "sponsor.slot_title" = "スポンサー募集中のスペースです";
 "sponsor.slot_cta" = "お問い合わせ";
 
-// MARK: - Personal Usage
-"menubar.personal_usage" = "個人の使用量";
-"popover.personal_usage_period" = "今月";
+// MARK: - Monthly Spend
+"menubar.monthly_spend" = "月間支出";
+"popover.monthly_spend_period" = "今月";
 "general.spend_target_title" = "月間支出目標";
-"general.spend_target_subtitle" = "任意の月間個人予算。設定するとポップオーバーに個人の使用量バーが表示されます。空欄の場合は金額のみ表示されます。";
+"general.spend_target_subtitle" = "任意の月間個人予算。設定するとポップオーバーに月間支出バーが表示されます。空欄の場合は金額のみ表示されます。";
 "general.spend_target_placeholder" = "例: 1500";

--- a/Claude Usage/Resources/ja.lproj/Localizable.strings
+++ b/Claude Usage/Resources/ja.lproj/Localizable.strings
@@ -1030,3 +1030,10 @@
 /* Sponsor slot */
 "sponsor.slot_title" = "スポンサー募集中のスペースです";
 "sponsor.slot_cta" = "お問い合わせ";
+
+// MARK: - Personal Usage (English fallback — pending translation)
+"menubar.personal_usage" = "Personal Usage";
+"popover.personal_usage_period" = "This month";
+"general.spend_target_title" = "Monthly Spend Target";
+"general.spend_target_subtitle" = "Optional personal budget for the month. Set it to show a Personal Usage bar in the popover; leave blank to just show the amount.";
+"general.spend_target_placeholder" = "e.g. 1500";

--- a/Claude Usage/Resources/ja.lproj/Localizable.strings
+++ b/Claude Usage/Resources/ja.lproj/Localizable.strings
@@ -961,9 +961,9 @@
 // MARK: - Overage Balance
 "popover.overage_balance" = "残高";
 
-
 // MARK: - Monthly Spend
 "popover.monthly_spend_period" = "今月";
+
 // MARK: - Setup Wizard CLI Detection
 "setup.cli_detecting" = "CLI認証情報を確認中...";
 "setup.cli_detected.title" = "CLIを検出しました！";

--- a/Claude Usage/Resources/ja.lproj/Localizable.strings
+++ b/Claude Usage/Resources/ja.lproj/Localizable.strings
@@ -64,6 +64,7 @@
 "menubar.fable_usage" = "Fable";
 "menubar.design_usage" = "デザイン";
 "menubar.extra_usage" = "追加使用";
+"menubar.monthly_spend" = "月間支出";
 "menubar.api_credits" = "APIクレジット";
 "menubar.5_hour_window" = "5時間ローリングウィンドウ";
 "menubar.all_models" = "すべてのモデル";
@@ -572,6 +573,9 @@
 "general.refresh_seconds" = "%d秒";
 "general.refresh_min" = "10秒";
 "general.refresh_max" = "300秒";
+"general.spend_target_title" = "月間支出目標";
+"general.spend_target_subtitle" = "任意の月間個人予算。設定するとポップオーバーに月間支出バーが表示されます。空欄の場合は金額のみ表示されます。";
+"general.spend_target_placeholder" = "例: 1500";
 "general.autostart_title" = "セッション自動開始";
 "general.autostart_subtitle" = "必要に応じて自動的に新しいセッションを開始";
 "general.autostart_toggle" = "新しいセッションを自動開始";
@@ -957,6 +961,9 @@
 // MARK: - Overage Balance
 "popover.overage_balance" = "残高";
 
+
+// MARK: - Monthly Spend
+"popover.monthly_spend_period" = "今月";
 // MARK: - Setup Wizard CLI Detection
 "setup.cli_detecting" = "CLI認証情報を確認中...";
 "setup.cli_detected.title" = "CLIを検出しました！";

--- a/Claude Usage/Resources/ko.lproj/Localizable.strings
+++ b/Claude Usage/Resources/ko.lproj/Localizable.strings
@@ -1039,3 +1039,10 @@
 /* Sponsor slot */
 "sponsor.slot_title" = "이 공간은 스폰서에게 제공됩니다";
 "sponsor.slot_cta" = "문의하기";
+
+// MARK: - Personal Usage (English fallback — pending translation)
+"menubar.personal_usage" = "Personal Usage";
+"popover.personal_usage_period" = "This month";
+"general.spend_target_title" = "Monthly Spend Target";
+"general.spend_target_subtitle" = "Optional personal budget for the month. Set it to show a Personal Usage bar in the popover; leave blank to just show the amount.";
+"general.spend_target_placeholder" = "e.g. 1500";

--- a/Claude Usage/Resources/ko.lproj/Localizable.strings
+++ b/Claude Usage/Resources/ko.lproj/Localizable.strings
@@ -1040,9 +1040,9 @@
 "sponsor.slot_title" = "이 공간은 스폰서에게 제공됩니다";
 "sponsor.slot_cta" = "문의하기";
 
-// MARK: - Personal Usage (English fallback — pending translation)
-"menubar.personal_usage" = "Personal Usage";
-"popover.personal_usage_period" = "This month";
-"general.spend_target_title" = "Monthly Spend Target";
-"general.spend_target_subtitle" = "Optional personal budget for the month. Set it to show a Personal Usage bar in the popover; leave blank to just show the amount.";
-"general.spend_target_placeholder" = "e.g. 1500";
+// MARK: - Personal Usage
+"menubar.personal_usage" = "개인 사용량";
+"popover.personal_usage_period" = "이번 달";
+"general.spend_target_title" = "월간 지출 목표";
+"general.spend_target_subtitle" = "선택적 월간 개인 예산. 설정하면 팝오버에 개인 사용량 막대가 표시됩니다. 비워두면 금액만 표시됩니다.";
+"general.spend_target_placeholder" = "예: 1500";

--- a/Claude Usage/Resources/ko.lproj/Localizable.strings
+++ b/Claude Usage/Resources/ko.lproj/Localizable.strings
@@ -1040,9 +1040,9 @@
 "sponsor.slot_title" = "이 공간은 스폰서에게 제공됩니다";
 "sponsor.slot_cta" = "문의하기";
 
-// MARK: - Personal Usage
-"menubar.personal_usage" = "개인 사용량";
-"popover.personal_usage_period" = "이번 달";
+// MARK: - Monthly Spend
+"menubar.monthly_spend" = "월간 지출";
+"popover.monthly_spend_period" = "이번 달";
 "general.spend_target_title" = "월간 지출 목표";
-"general.spend_target_subtitle" = "선택적 월간 개인 예산. 설정하면 팝오버에 개인 사용량 막대가 표시됩니다. 비워두면 금액만 표시됩니다.";
+"general.spend_target_subtitle" = "선택적 월간 개인 예산. 설정하면 팝오버에 월간 지출 막대가 표시됩니다. 비워두면 금액만 표시됩니다.";
 "general.spend_target_placeholder" = "예: 1500";

--- a/Claude Usage/Resources/ko.lproj/Localizable.strings
+++ b/Claude Usage/Resources/ko.lproj/Localizable.strings
@@ -73,6 +73,7 @@
 "menubar.fable_usage" = "Fable";
 "menubar.design_usage" = "디자인";
 "menubar.extra_usage" = "추가 사용량";
+"menubar.monthly_spend" = "월간 지출";
 "menubar.api_credits" = "API 크레딧";
 "menubar.5_hour_window" = "5시간 롤링 윈도우";
 "menubar.all_models" = "모든 모델";
@@ -157,6 +158,9 @@
 "general.refresh_seconds" = "%d초";
 "general.refresh_min" = "10초";
 "general.refresh_max" = "300초";
+"general.spend_target_title" = "월간 지출 목표";
+"general.spend_target_subtitle" = "선택적 월간 개인 예산. 설정하면 팝오버에 월간 지출 막대가 표시됩니다. 비워두면 금액만 표시됩니다.";
+"general.spend_target_placeholder" = "예: 1500";
 "general.autostart_title" = "세션 자동 시작";
 "general.autostart_subtitle" = "필요 시 자동으로 새 세션 시작";
 "general.autostart_toggle" = "새 세션 자동 시작";
@@ -968,6 +972,9 @@
 // MARK: - Overage Balance
 "popover.overage_balance" = "잔액";
 
+
+// MARK: - Monthly Spend
+"popover.monthly_spend_period" = "이번 달";
 // MARK: - Setup Wizard CLI Detection
 "setup.cli_detecting" = "CLI 자격 증명 확인 중...";
 "setup.cli_detected.title" = "CLI 감지됨!";

--- a/Claude Usage/Resources/ko.lproj/Localizable.strings
+++ b/Claude Usage/Resources/ko.lproj/Localizable.strings
@@ -972,9 +972,9 @@
 // MARK: - Overage Balance
 "popover.overage_balance" = "잔액";
 
-
 // MARK: - Monthly Spend
 "popover.monthly_spend_period" = "이번 달";
+
 // MARK: - Setup Wizard CLI Detection
 "setup.cli_detecting" = "CLI 자격 증명 확인 중...";
 "setup.cli_detected.title" = "CLI 감지됨!";

--- a/Claude Usage/Resources/pt-BR.lproj/Localizable.strings
+++ b/Claude Usage/Resources/pt-BR.lproj/Localizable.strings
@@ -1031,9 +1031,9 @@
 "sponsor.slot_title" = "Este espaço está disponível para patrocinadores";
 "sponsor.slot_cta" = "Entre em contato";
 
-// MARK: - Personal Usage (English fallback — pending translation)
-"menubar.personal_usage" = "Personal Usage";
-"popover.personal_usage_period" = "This month";
-"general.spend_target_title" = "Monthly Spend Target";
-"general.spend_target_subtitle" = "Optional personal budget for the month. Set it to show a Personal Usage bar in the popover; leave blank to just show the amount.";
-"general.spend_target_placeholder" = "e.g. 1500";
+// MARK: - Personal Usage
+"menubar.personal_usage" = "Uso Pessoal";
+"popover.personal_usage_period" = "Este mês";
+"general.spend_target_title" = "Meta de Gasto Mensal";
+"general.spend_target_subtitle" = "Orçamento pessoal opcional para o mês. Defina para mostrar uma barra de Uso Pessoal no popover; deixe em branco para mostrar apenas o valor.";
+"general.spend_target_placeholder" = "ex.: 1500";

--- a/Claude Usage/Resources/pt-BR.lproj/Localizable.strings
+++ b/Claude Usage/Resources/pt-BR.lproj/Localizable.strings
@@ -1030,3 +1030,10 @@
 /* Sponsor slot */
 "sponsor.slot_title" = "Este espaço está disponível para patrocinadores";
 "sponsor.slot_cta" = "Entre em contato";
+
+// MARK: - Personal Usage (English fallback — pending translation)
+"menubar.personal_usage" = "Personal Usage";
+"popover.personal_usage_period" = "This month";
+"general.spend_target_title" = "Monthly Spend Target";
+"general.spend_target_subtitle" = "Optional personal budget for the month. Set it to show a Personal Usage bar in the popover; leave blank to just show the amount.";
+"general.spend_target_placeholder" = "e.g. 1500";

--- a/Claude Usage/Resources/pt-BR.lproj/Localizable.strings
+++ b/Claude Usage/Resources/pt-BR.lproj/Localizable.strings
@@ -1031,9 +1031,9 @@
 "sponsor.slot_title" = "Este espaço está disponível para patrocinadores";
 "sponsor.slot_cta" = "Entre em contato";
 
-// MARK: - Personal Usage
-"menubar.personal_usage" = "Uso Pessoal";
-"popover.personal_usage_period" = "Este mês";
+// MARK: - Monthly Spend
+"menubar.monthly_spend" = "Gasto Mensal";
+"popover.monthly_spend_period" = "Este mês";
 "general.spend_target_title" = "Meta de Gasto Mensal";
-"general.spend_target_subtitle" = "Orçamento pessoal opcional para o mês. Defina para mostrar uma barra de Uso Pessoal no popover; deixe em branco para mostrar apenas o valor.";
+"general.spend_target_subtitle" = "Orçamento pessoal opcional para o mês. Defina para mostrar uma barra de Gasto Mensal no popover; deixe em branco para mostrar apenas o valor.";
 "general.spend_target_placeholder" = "ex.: 1500";

--- a/Claude Usage/Resources/pt-BR.lproj/Localizable.strings
+++ b/Claude Usage/Resources/pt-BR.lproj/Localizable.strings
@@ -955,9 +955,9 @@
 // MARK: - Overage Balance
 "popover.overage_balance" = "Saldo";
 
-
 // MARK: - Monthly Spend
 "popover.monthly_spend_period" = "Este mês";
+
 // MARK: - Setup Wizard CLI Detection
 "setup.cli_detecting" = "Verificando credenciais CLI...";
 "setup.cli_detected.title" = "CLI Detectado!";

--- a/Claude Usage/Resources/pt-BR.lproj/Localizable.strings
+++ b/Claude Usage/Resources/pt-BR.lproj/Localizable.strings
@@ -62,6 +62,7 @@
 "menubar.fable_usage" = "Fable";
 "menubar.design_usage" = "Design";
 "menubar.extra_usage" = "Uso Extra";
+"menubar.monthly_spend" = "Gasto Mensal";
 "menubar.api_credits" = "Créditos da API";
 "menubar.5_hour_window" = "Janela móvel de 5 horas";
 "menubar.all_models" = "Todos os modelos";
@@ -566,6 +567,9 @@
 "general.refresh_seconds" = "%d segundos";
 "general.refresh_min" = "10s";
 "general.refresh_max" = "300s";
+"general.spend_target_title" = "Meta de Gasto Mensal";
+"general.spend_target_subtitle" = "Orçamento pessoal opcional para o mês. Defina para mostrar uma barra de Gasto Mensal no popover; deixe em branco para mostrar apenas o valor.";
+"general.spend_target_placeholder" = "ex.: 1500";
 "general.autostart_title" = "Início Automático de Sessão";
 "general.autostart_subtitle" = "Iniciar automaticamente uma nova sessão quando necessário";
 "general.autostart_toggle" = "Início Automático de Nova Sessão";
@@ -951,6 +955,9 @@
 // MARK: - Overage Balance
 "popover.overage_balance" = "Saldo";
 
+
+// MARK: - Monthly Spend
+"popover.monthly_spend_period" = "Este mês";
 // MARK: - Setup Wizard CLI Detection
 "setup.cli_detecting" = "Verificando credenciais CLI...";
 "setup.cli_detected.title" = "CLI Detectado!";

--- a/Claude Usage/Resources/pt.lproj/Localizable.strings
+++ b/Claude Usage/Resources/pt.lproj/Localizable.strings
@@ -1031,9 +1031,9 @@
 "sponsor.slot_title" = "Este espaço está disponível para patrocinadores";
 "sponsor.slot_cta" = "Entre em contato";
 
-// MARK: - Personal Usage (English fallback — pending translation)
-"menubar.personal_usage" = "Personal Usage";
-"popover.personal_usage_period" = "This month";
-"general.spend_target_title" = "Monthly Spend Target";
-"general.spend_target_subtitle" = "Optional personal budget for the month. Set it to show a Personal Usage bar in the popover; leave blank to just show the amount.";
-"general.spend_target_placeholder" = "e.g. 1500";
+// MARK: - Personal Usage
+"menubar.personal_usage" = "Uso Pessoal";
+"popover.personal_usage_period" = "Este mês";
+"general.spend_target_title" = "Meta de Gasto Mensal";
+"general.spend_target_subtitle" = "Orçamento pessoal opcional para o mês. Defina-o para mostrar uma barra de Uso Pessoal no popover; deixe em branco para mostrar apenas o valor.";
+"general.spend_target_placeholder" = "ex.: 1500";

--- a/Claude Usage/Resources/pt.lproj/Localizable.strings
+++ b/Claude Usage/Resources/pt.lproj/Localizable.strings
@@ -1031,9 +1031,9 @@
 "sponsor.slot_title" = "Este espaço está disponível para patrocinadores";
 "sponsor.slot_cta" = "Entre em contato";
 
-// MARK: - Personal Usage
-"menubar.personal_usage" = "Uso Pessoal";
-"popover.personal_usage_period" = "Este mês";
+// MARK: - Monthly Spend
+"menubar.monthly_spend" = "Gasto Mensal";
+"popover.monthly_spend_period" = "Este mês";
 "general.spend_target_title" = "Meta de Gasto Mensal";
-"general.spend_target_subtitle" = "Orçamento pessoal opcional para o mês. Defina-o para mostrar uma barra de Uso Pessoal no popover; deixe em branco para mostrar apenas o valor.";
+"general.spend_target_subtitle" = "Orçamento pessoal opcional para o mês. Defina-o para mostrar uma barra de Gasto Mensal no popover; deixe em branco para mostrar apenas o valor.";
 "general.spend_target_placeholder" = "ex.: 1500";

--- a/Claude Usage/Resources/pt.lproj/Localizable.strings
+++ b/Claude Usage/Resources/pt.lproj/Localizable.strings
@@ -1030,3 +1030,10 @@
 /* Sponsor slot */
 "sponsor.slot_title" = "Este espaço está disponível para patrocinadores";
 "sponsor.slot_cta" = "Entre em contato";
+
+// MARK: - Personal Usage (English fallback — pending translation)
+"menubar.personal_usage" = "Personal Usage";
+"popover.personal_usage_period" = "This month";
+"general.spend_target_title" = "Monthly Spend Target";
+"general.spend_target_subtitle" = "Optional personal budget for the month. Set it to show a Personal Usage bar in the popover; leave blank to just show the amount.";
+"general.spend_target_placeholder" = "e.g. 1500";

--- a/Claude Usage/Resources/pt.lproj/Localizable.strings
+++ b/Claude Usage/Resources/pt.lproj/Localizable.strings
@@ -959,9 +959,9 @@
 // MARK: - Overage Balance
 "popover.overage_balance" = "Saldo";
 
-
 // MARK: - Monthly Spend
 "popover.monthly_spend_period" = "Este mês";
+
 // MARK: - Setup Wizard CLI Detection
 "setup.cli_detecting" = "Verificando credenciais CLI...";
 "setup.cli_detected.title" = "CLI Detectado!";

--- a/Claude Usage/Resources/pt.lproj/Localizable.strings
+++ b/Claude Usage/Resources/pt.lproj/Localizable.strings
@@ -62,6 +62,7 @@
 "menubar.fable_usage" = "Fable";
 "menubar.design_usage" = "Design";
 "menubar.extra_usage" = "Uso Extra";
+"menubar.monthly_spend" = "Gasto Mensal";
 "menubar.api_credits" = "Créditos da API";
 "menubar.5_hour_window" = "Janela móvel de 5 horas";
 "menubar.all_models" = "Todos os modelos";
@@ -570,6 +571,9 @@
 "general.refresh_seconds" = "%d segundos";
 "general.refresh_min" = "10s";
 "general.refresh_max" = "300s";
+"general.spend_target_title" = "Meta de Gasto Mensal";
+"general.spend_target_subtitle" = "Orçamento pessoal opcional para o mês. Defina-o para mostrar uma barra de Gasto Mensal no popover; deixe em branco para mostrar apenas o valor.";
+"general.spend_target_placeholder" = "ex.: 1500";
 "general.autostart_title" = "Início Automático de Sessão";
 "general.autostart_subtitle" = "Iniciar automaticamente uma nova sessão quando necessário";
 "general.autostart_toggle" = "Início Automático de Nova Sessão";
@@ -955,6 +959,9 @@
 // MARK: - Overage Balance
 "popover.overage_balance" = "Saldo";
 
+
+// MARK: - Monthly Spend
+"popover.monthly_spend_period" = "Este mês";
 // MARK: - Setup Wizard CLI Detection
 "setup.cli_detecting" = "Verificando credenciais CLI...";
 "setup.cli_detected.title" = "CLI Detectado!";

--- a/Claude Usage/Resources/tr.lproj/Localizable.strings
+++ b/Claude Usage/Resources/tr.lproj/Localizable.strings
@@ -1022,3 +1022,10 @@
 /* Sponsor slot */
 "sponsor.slot_title" = "Bu alan sponsorlara açıktır";
 "sponsor.slot_cta" = "İletişime geçin";
+
+// MARK: - Personal Usage (English fallback — pending translation)
+"menubar.personal_usage" = "Personal Usage";
+"popover.personal_usage_period" = "This month";
+"general.spend_target_title" = "Monthly Spend Target";
+"general.spend_target_subtitle" = "Optional personal budget for the month. Set it to show a Personal Usage bar in the popover; leave blank to just show the amount.";
+"general.spend_target_placeholder" = "e.g. 1500";

--- a/Claude Usage/Resources/tr.lproj/Localizable.strings
+++ b/Claude Usage/Resources/tr.lproj/Localizable.strings
@@ -1023,9 +1023,9 @@
 "sponsor.slot_title" = "Bu alan sponsorlara açıktır";
 "sponsor.slot_cta" = "İletişime geçin";
 
-// MARK: - Personal Usage
-"menubar.personal_usage" = "Kişisel Kullanım";
-"popover.personal_usage_period" = "Bu ay";
+// MARK: - Monthly Spend
+"menubar.monthly_spend" = "Aylık Harcama";
+"popover.monthly_spend_period" = "Bu ay";
 "general.spend_target_title" = "Aylık Harcama Hedefi";
-"general.spend_target_subtitle" = "İsteğe bağlı aylık kişisel bütçe. Açılır pencerede bir Kişisel Kullanım çubuğu göstermek için ayarlayın; yalnızca tutarı göstermek için boş bırakın.";
+"general.spend_target_subtitle" = "İsteğe bağlı aylık kişisel bütçe. Açılır pencerede bir Aylık Harcama çubuğu göstermek için ayarlayın; yalnızca tutarı göstermek için boş bırakın.";
 "general.spend_target_placeholder" = "örn. 1500";

--- a/Claude Usage/Resources/tr.lproj/Localizable.strings
+++ b/Claude Usage/Resources/tr.lproj/Localizable.strings
@@ -1023,9 +1023,9 @@
 "sponsor.slot_title" = "Bu alan sponsorlara açıktır";
 "sponsor.slot_cta" = "İletişime geçin";
 
-// MARK: - Personal Usage (English fallback — pending translation)
-"menubar.personal_usage" = "Personal Usage";
-"popover.personal_usage_period" = "This month";
-"general.spend_target_title" = "Monthly Spend Target";
-"general.spend_target_subtitle" = "Optional personal budget for the month. Set it to show a Personal Usage bar in the popover; leave blank to just show the amount.";
-"general.spend_target_placeholder" = "e.g. 1500";
+// MARK: - Personal Usage
+"menubar.personal_usage" = "Kişisel Kullanım";
+"popover.personal_usage_period" = "Bu ay";
+"general.spend_target_title" = "Aylık Harcama Hedefi";
+"general.spend_target_subtitle" = "İsteğe bağlı aylık kişisel bütçe. Açılır pencerede bir Kişisel Kullanım çubuğu göstermek için ayarlayın; yalnızca tutarı göstermek için boş bırakın.";
+"general.spend_target_placeholder" = "örn. 1500";

--- a/Claude Usage/Resources/tr.lproj/Localizable.strings
+++ b/Claude Usage/Resources/tr.lproj/Localizable.strings
@@ -64,6 +64,7 @@
 "menubar.fable_usage" = "Fable";
 "menubar.design_usage" = "Tasarım";
 "menubar.extra_usage" = "Ek Kullanım";
+"menubar.monthly_spend" = "Aylık Harcama";
 "menubar.api_credits" = "API Kredileri";
 "menubar.api_cost" = "API Maliyeti";
 "menubar.this_month" = "Bu Ay";
@@ -550,6 +551,9 @@
 "general.refresh_seconds" = "%d saniye";
 "general.refresh_min" = "10sn";
 "general.refresh_max" = "300sn";
+"general.spend_target_title" = "Aylık Harcama Hedefi";
+"general.spend_target_subtitle" = "İsteğe bağlı aylık kişisel bütçe. Açılır pencerede bir Aylık Harcama çubuğu göstermek için ayarlayın; yalnızca tutarı göstermek için boş bırakın.";
+"general.spend_target_placeholder" = "örn. 1500";
 "general.autostart_title" = "Oturumu Otomatik Başlat";
 "general.autostart_subtitle" = "Gerektiğinde otomatik olarak yeni bir oturum başlat";
 "general.autostart_toggle" = "Yeni Oturumu Otomatik Başlat";
@@ -961,6 +965,9 @@
 // MARK: - Overage Balance
 "popover.overage_balance" = "Bakiye";
 
+
+// MARK: - Monthly Spend
+"popover.monthly_spend_period" = "Bu ay";
 // MARK: - Setup Wizard CLI Detection
 "setup.cli_detecting" = "CLI kimlik bilgileri kontrol ediliyor...";
 "setup.cli_detected.title" = "CLI Tespit Edildi!";

--- a/Claude Usage/Resources/tr.lproj/Localizable.strings
+++ b/Claude Usage/Resources/tr.lproj/Localizable.strings
@@ -965,9 +965,9 @@
 // MARK: - Overage Balance
 "popover.overage_balance" = "Bakiye";
 
-
 // MARK: - Monthly Spend
 "popover.monthly_spend_period" = "Bu ay";
+
 // MARK: - Setup Wizard CLI Detection
 "setup.cli_detecting" = "CLI kimlik bilgileri kontrol ediliyor...";
 "setup.cli_detected.title" = "CLI Tespit Edildi!";

--- a/Claude Usage/Resources/uk.lproj/Localizable.strings
+++ b/Claude Usage/Resources/uk.lproj/Localizable.strings
@@ -1026,9 +1026,9 @@
 "sponsor.slot_title" = "Це місце доступне для спонсорів";
 "sponsor.slot_cta" = "Звʼязатися";
 
-// MARK: - Personal Usage
-"menubar.personal_usage" = "Особисте використання";
-"popover.personal_usage_period" = "Цей місяць";
+// MARK: - Monthly Spend
+"menubar.monthly_spend" = "Місячні витрати";
+"popover.monthly_spend_period" = "Цей місяць";
 "general.spend_target_title" = "Місячна ціль витрат";
-"general.spend_target_subtitle" = "Необов'язковий особистий бюджет на місяць. Установіть, щоб показати смугу особистого використання у спливаючому вікні; залиште порожнім, щоб показувати лише суму.";
+"general.spend_target_subtitle" = "Необов'язковий особистий бюджет на місяць. Установіть, щоб показати смугу місячних витрат у спливаючому вікні; залиште порожнім, щоб показувати лише суму.";
 "general.spend_target_placeholder" = "напр. 1500";

--- a/Claude Usage/Resources/uk.lproj/Localizable.strings
+++ b/Claude Usage/Resources/uk.lproj/Localizable.strings
@@ -1025,3 +1025,10 @@
 /* Sponsor slot */
 "sponsor.slot_title" = "Це місце доступне для спонсорів";
 "sponsor.slot_cta" = "Звʼязатися";
+
+// MARK: - Personal Usage (English fallback — pending translation)
+"menubar.personal_usage" = "Personal Usage";
+"popover.personal_usage_period" = "This month";
+"general.spend_target_title" = "Monthly Spend Target";
+"general.spend_target_subtitle" = "Optional personal budget for the month. Set it to show a Personal Usage bar in the popover; leave blank to just show the amount.";
+"general.spend_target_placeholder" = "e.g. 1500";

--- a/Claude Usage/Resources/uk.lproj/Localizable.strings
+++ b/Claude Usage/Resources/uk.lproj/Localizable.strings
@@ -1026,9 +1026,9 @@
 "sponsor.slot_title" = "Це місце доступне для спонсорів";
 "sponsor.slot_cta" = "Звʼязатися";
 
-// MARK: - Personal Usage (English fallback — pending translation)
-"menubar.personal_usage" = "Personal Usage";
-"popover.personal_usage_period" = "This month";
-"general.spend_target_title" = "Monthly Spend Target";
-"general.spend_target_subtitle" = "Optional personal budget for the month. Set it to show a Personal Usage bar in the popover; leave blank to just show the amount.";
-"general.spend_target_placeholder" = "e.g. 1500";
+// MARK: - Personal Usage
+"menubar.personal_usage" = "Особисте використання";
+"popover.personal_usage_period" = "Цей місяць";
+"general.spend_target_title" = "Місячна ціль витрат";
+"general.spend_target_subtitle" = "Необов'язковий особистий бюджет на місяць. Установіть, щоб показати смугу особистого використання у спливаючому вікні; залиште порожнім, щоб показувати лише суму.";
+"general.spend_target_placeholder" = "напр. 1500";

--- a/Claude Usage/Resources/uk.lproj/Localizable.strings
+++ b/Claude Usage/Resources/uk.lproj/Localizable.strings
@@ -920,6 +920,7 @@
 
 // MARK: - Monthly Spend
 "popover.monthly_spend_period" = "Цей місяць";
+
 "popover.banner.credentials_expired" = "Облікові дані застаріли. Оновіть у Налаштуваннях.";
 "popover.banner.refresh_failed" = "Оновлення не вдалося %d разів";
 "popover.banner.updated_ago" = "Оновлено %dхв тому";

--- a/Claude Usage/Resources/uk.lproj/Localizable.strings
+++ b/Claude Usage/Resources/uk.lproj/Localizable.strings
@@ -64,6 +64,7 @@
 "menubar.fable_usage" = "Fable";
 "menubar.design_usage" = "Дизайн";
 "menubar.extra_usage" = "Додаткове використання";
+"menubar.monthly_spend" = "Місячні витрати";
 "menubar.api_credits" = "Кредити API";
 "menubar.api_cost" = "Вартість API";
 "menubar.this_month" = "Цього місяця";
@@ -550,6 +551,9 @@
 "general.refresh_seconds" = "%d секунд";
 "general.refresh_min" = "10с";
 "general.refresh_max" = "300с";
+"general.spend_target_title" = "Місячна ціль витрат";
+"general.spend_target_subtitle" = "Необов'язковий особистий бюджет на місяць. Установіть, щоб показати смугу місячних витрат у спливаючому вікні; залиште порожнім, щоб показувати лише суму.";
+"general.spend_target_placeholder" = "напр. 1500";
 "general.autostart_title" = "Автозапуск сесії";
 "general.autostart_subtitle" = "Автоматично запускати нову сесію за потреби";
 "general.autostart_toggle" = "Автозапуск нової сесії";
@@ -913,6 +917,9 @@
 "popover.time_format_24h" = "24-годинний";
 "popover.time_format_system" = "Системний";
 "popover.overage_balance" = "Баланс";
+
+// MARK: - Monthly Spend
+"popover.monthly_spend_period" = "Цей місяць";
 "popover.banner.credentials_expired" = "Облікові дані застаріли. Оновіть у Налаштуваннях.";
 "popover.banner.refresh_failed" = "Оновлення не вдалося %d разів";
 "popover.banner.updated_ago" = "Оновлено %dхв тому";

--- a/Claude Usage/Resources/vi.lproj/Localizable.strings
+++ b/Claude Usage/Resources/vi.lproj/Localizable.strings
@@ -64,6 +64,7 @@
 "menubar.fable_usage" = "Fable";
 "menubar.design_usage" = "Thiết kế";
 "menubar.extra_usage" = "Mức dùng thêm";
+"menubar.monthly_spend" = "Chi tiêu hàng tháng";
 "menubar.api_credits" = "Tín dụng API";
 "menubar.api_cost" = "Chi phí API";
 "menubar.this_month" = "Tháng này";
@@ -550,6 +551,9 @@
 "general.refresh_seconds" = "%d giây";
 "general.refresh_min" = "10s";
 "general.refresh_max" = "300s";
+"general.spend_target_title" = "Mục tiêu chi tiêu hàng tháng";
+"general.spend_target_subtitle" = "Ngân sách cá nhân tùy chọn cho tháng. Đặt giá trị để hiện thanh Chi tiêu hàng tháng trong cửa sổ bật lên; để trống để chỉ hiện số tiền.";
+"general.spend_target_placeholder" = "ví dụ: 1500";
 "general.autostart_title" = "Tự động bắt đầu phiên";
 "general.autostart_subtitle" = "Tự động bắt đầu phiên mới khi cần";
 "general.autostart_toggle" = "Tự động bắt đầu phiên mới";
@@ -965,6 +969,9 @@
 // MARK: - Overage Balance
 "popover.overage_balance" = "Số dư";
 
+
+// MARK: - Monthly Spend
+"popover.monthly_spend_period" = "Tháng này";
 // MARK: - Setup Wizard CLI Detection
 "setup.cli_detecting" = "Đang kiểm tra thông tin đăng nhập CLI...";
 "setup.cli_detected.title" = "Đã phát hiện CLI!";

--- a/Claude Usage/Resources/vi.lproj/Localizable.strings
+++ b/Claude Usage/Resources/vi.lproj/Localizable.strings
@@ -969,9 +969,9 @@
 // MARK: - Overage Balance
 "popover.overage_balance" = "Số dư";
 
-
 // MARK: - Monthly Spend
 "popover.monthly_spend_period" = "Tháng này";
+
 // MARK: - Setup Wizard CLI Detection
 "setup.cli_detecting" = "Đang kiểm tra thông tin đăng nhập CLI...";
 "setup.cli_detected.title" = "Đã phát hiện CLI!";

--- a/Claude Usage/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Claude Usage/Resources/zh-Hant.lproj/Localizable.strings
@@ -1017,9 +1017,9 @@
 "sponsor.slot_title" = "此位置開放贊助";
 "sponsor.slot_cta" = "與我聯繫";
 
-// MARK: - Personal Usage (English fallback — pending translation)
-"menubar.personal_usage" = "Personal Usage";
-"popover.personal_usage_period" = "This month";
-"general.spend_target_title" = "Monthly Spend Target";
-"general.spend_target_subtitle" = "Optional personal budget for the month. Set it to show a Personal Usage bar in the popover; leave blank to just show the amount.";
-"general.spend_target_placeholder" = "e.g. 1500";
+// MARK: - Personal Usage
+"menubar.personal_usage" = "個人使用量";
+"popover.personal_usage_period" = "本月";
+"general.spend_target_title" = "每月支出目標";
+"general.spend_target_subtitle" = "選填的每月個人預算。設定後會在彈出視窗中顯示個人使用量進度條；留空則僅顯示金額。";
+"general.spend_target_placeholder" = "例如 1500";

--- a/Claude Usage/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Claude Usage/Resources/zh-Hant.lproj/Localizable.strings
@@ -1016,3 +1016,10 @@
 /* Sponsor slot */
 "sponsor.slot_title" = "此位置開放贊助";
 "sponsor.slot_cta" = "與我聯繫";
+
+// MARK: - Personal Usage (English fallback — pending translation)
+"menubar.personal_usage" = "Personal Usage";
+"popover.personal_usage_period" = "This month";
+"general.spend_target_title" = "Monthly Spend Target";
+"general.spend_target_subtitle" = "Optional personal budget for the month. Set it to show a Personal Usage bar in the popover; leave blank to just show the amount.";
+"general.spend_target_placeholder" = "e.g. 1500";

--- a/Claude Usage/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Claude Usage/Resources/zh-Hant.lproj/Localizable.strings
@@ -1017,9 +1017,9 @@
 "sponsor.slot_title" = "此位置開放贊助";
 "sponsor.slot_cta" = "與我聯繫";
 
-// MARK: - Personal Usage
-"menubar.personal_usage" = "個人使用量";
-"popover.personal_usage_period" = "本月";
+// MARK: - Monthly Spend
+"menubar.monthly_spend" = "每月支出";
+"popover.monthly_spend_period" = "本月";
 "general.spend_target_title" = "每月支出目標";
-"general.spend_target_subtitle" = "選填的每月個人預算。設定後會在彈出視窗中顯示個人使用量進度條；留空則僅顯示金額。";
+"general.spend_target_subtitle" = "選填的每月個人預算。設定後會在彈出視窗中顯示每月支出進度條；留空則僅顯示金額。";
 "general.spend_target_placeholder" = "例如 1500";

--- a/Claude Usage/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Claude Usage/Resources/zh-Hant.lproj/Localizable.strings
@@ -65,6 +65,7 @@
 "menubar.fable_usage" = "Fable";
 "menubar.design_usage" = "設計";
 "menubar.extra_usage" = "額外使用量";
+"menubar.monthly_spend" = "每月支出";
 "menubar.api_credits" = "API 額度";
 "menubar.5_hour_window" = "5 小時滑動視窗";
 "menubar.all_models" = "所有模型";
@@ -551,6 +552,9 @@
 "general.refresh_seconds" = "%d 秒";
 "general.refresh_min" = "10 秒";
 "general.refresh_max" = "300 秒";
+"general.spend_target_title" = "每月支出目標";
+"general.spend_target_subtitle" = "選填的每月個人預算。設定後會在彈出視窗中顯示每月支出進度條；留空則僅顯示金額。";
+"general.spend_target_placeholder" = "例如 1500";
 "general.autostart_title" = "自動啟動 Session";
 "general.autostart_subtitle" = "需要時自動啟動新 Session";
 "general.autostart_toggle" = "自動啟動新 Session";
@@ -955,6 +959,9 @@
 // MARK: - Overage Balance
 "popover.overage_balance" = "餘額";
 
+
+// MARK: - Monthly Spend
+"popover.monthly_spend_period" = "本月";
 // MARK: - Setup Wizard CLI Detection
 "setup.cli_detecting" = "正在檢查 CLI 憑證...";
 "setup.cli_detected.title" = "偵測到 CLI！";

--- a/Claude Usage/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Claude Usage/Resources/zh-Hant.lproj/Localizable.strings
@@ -959,9 +959,9 @@
 // MARK: - Overage Balance
 "popover.overage_balance" = "餘額";
 
-
 // MARK: - Monthly Spend
 "popover.monthly_spend_period" = "本月";
+
 // MARK: - Setup Wizard CLI Detection
 "setup.cli_detecting" = "正在檢查 CLI 憑證...";
 "setup.cli_detected.title" = "偵測到 CLI！";

--- a/Claude Usage/Resources/zh-ch.lproj/Localizable.strings
+++ b/Claude Usage/Resources/zh-ch.lproj/Localizable.strings
@@ -1017,9 +1017,9 @@
 "sponsor.slot_title" = "此位置开放赞助";
 "sponsor.slot_cta" = "与我联系";
 
-// MARK: - Personal Usage (English fallback — pending translation)
-"menubar.personal_usage" = "Personal Usage";
-"popover.personal_usage_period" = "This month";
-"general.spend_target_title" = "Monthly Spend Target";
-"general.spend_target_subtitle" = "Optional personal budget for the month. Set it to show a Personal Usage bar in the popover; leave blank to just show the amount.";
-"general.spend_target_placeholder" = "e.g. 1500";
+// MARK: - Personal Usage
+"menubar.personal_usage" = "个人使用量";
+"popover.personal_usage_period" = "本月";
+"general.spend_target_title" = "每月支出目标";
+"general.spend_target_subtitle" = "可选的每月个人预算。设置后会在弹出窗口中显示个人使用量进度条；留空则仅显示金额。";
+"general.spend_target_placeholder" = "例如 1500";

--- a/Claude Usage/Resources/zh-ch.lproj/Localizable.strings
+++ b/Claude Usage/Resources/zh-ch.lproj/Localizable.strings
@@ -1017,9 +1017,9 @@
 "sponsor.slot_title" = "此位置开放赞助";
 "sponsor.slot_cta" = "与我联系";
 
-// MARK: - Personal Usage
-"menubar.personal_usage" = "个人使用量";
-"popover.personal_usage_period" = "本月";
+// MARK: - Monthly Spend
+"menubar.monthly_spend" = "每月支出";
+"popover.monthly_spend_period" = "本月";
 "general.spend_target_title" = "每月支出目标";
-"general.spend_target_subtitle" = "可选的每月个人预算。设置后会在弹出窗口中显示个人使用量进度条；留空则仅显示金额。";
+"general.spend_target_subtitle" = "可选的每月个人预算。设置后会在弹出窗口中显示每月支出进度条；留空则仅显示金额。";
 "general.spend_target_placeholder" = "例如 1500";

--- a/Claude Usage/Resources/zh-ch.lproj/Localizable.strings
+++ b/Claude Usage/Resources/zh-ch.lproj/Localizable.strings
@@ -1016,3 +1016,10 @@
 /* Sponsor slot */
 "sponsor.slot_title" = "此位置开放赞助";
 "sponsor.slot_cta" = "与我联系";
+
+// MARK: - Personal Usage (English fallback — pending translation)
+"menubar.personal_usage" = "Personal Usage";
+"popover.personal_usage_period" = "This month";
+"general.spend_target_title" = "Monthly Spend Target";
+"general.spend_target_subtitle" = "Optional personal budget for the month. Set it to show a Personal Usage bar in the popover; leave blank to just show the amount.";
+"general.spend_target_placeholder" = "e.g. 1500";

--- a/Claude Usage/Resources/zh-ch.lproj/Localizable.strings
+++ b/Claude Usage/Resources/zh-ch.lproj/Localizable.strings
@@ -959,9 +959,9 @@
 // MARK: - Overage Balance
 "popover.overage_balance" = "余额";
 
-
 // MARK: - Monthly Spend
 "popover.monthly_spend_period" = "本月";
+
 // MARK: - Setup Wizard CLI Detection
 "setup.cli_detecting" = "正在检查CLI凭证...";
 "setup.cli_detected.title" = "检测到CLI！";

--- a/Claude Usage/Resources/zh-ch.lproj/Localizable.strings
+++ b/Claude Usage/Resources/zh-ch.lproj/Localizable.strings
@@ -65,6 +65,7 @@
 "menubar.fable_usage" = "Fable";
 "menubar.design_usage" = "设计";
 "menubar.extra_usage" = "额外使用量";
+"menubar.monthly_spend" = "每月支出";
 "menubar.api_credits" = "API 积分";
 "menubar.5_hour_window" = "5小时滚动窗口";
 "menubar.all_models" = "所有模型";
@@ -551,6 +552,9 @@
 "general.refresh_seconds" = "%d 秒";
 "general.refresh_min" = "10秒";
 "general.refresh_max" = "300秒";
+"general.spend_target_title" = "每月支出目标";
+"general.spend_target_subtitle" = "可选的每月个人预算。设置后会在弹出窗口中显示每月支出进度条；留空则仅显示金额。";
+"general.spend_target_placeholder" = "例如 1500";
 "general.autostart_title" = "自动启动会话";
 "general.autostart_subtitle" = "需要时自动启动新会话";
 "general.autostart_toggle" = "自动启动新会话";
@@ -955,6 +959,9 @@
 // MARK: - Overage Balance
 "popover.overage_balance" = "余额";
 
+
+// MARK: - Monthly Spend
+"popover.monthly_spend_period" = "本月";
 // MARK: - Setup Wizard CLI Detection
 "setup.cli_detecting" = "正在检查CLI凭证...";
 "setup.cli_detected.title" = "检测到CLI！";

--- a/Claude Usage/Shared/Models/ClaudeUsage.swift
+++ b/Claude Usage/Shared/Models/ClaudeUsage.swift
@@ -47,6 +47,15 @@ struct ClaudeUsage: Codable, Equatable {
     var overageBalance: Double?
     var overageBalanceCurrency: String?
 
+    // Personal usage — the authenticated member's OWN month-to-date spend, from
+    // the /usage/spend endpoint. Minor units (cents) of `personalSpendCurrency`.
+    // Distinct from the org-wide `costUsed`/`costLimit` overage figures above:
+    // this is what *this account* has spent, matching the number shown on
+    // claude.ai/settings/usage. Declared last (with defaults) so the synthesized
+    // memberwise initializer stays source-compatible with existing call sites.
+    var personalSpendUsed: Double? = nil
+    var personalSpendCurrency: String? = nil
+
     // Metadata
     var lastUpdated: Date
     var userTimezone: TimeZone
@@ -136,6 +145,7 @@ extension ClaudeUsage {
         case fableWeeklyTokensUsed, fableWeeklyPercentage, fableWeeklyResetTime
         case costUsed, costLimit, costCurrency
         case overageBalance, overageBalanceCurrency
+        case personalSpendUsed, personalSpendCurrency
         case lastUpdated, userTimezone
     }
 
@@ -166,6 +176,8 @@ extension ClaudeUsage {
             costCurrency: try c.decodeIfPresent(String.self, forKey: .costCurrency),
             overageBalance: try c.decodeIfPresent(Double.self, forKey: .overageBalance),
             overageBalanceCurrency: try c.decodeIfPresent(String.self, forKey: .overageBalanceCurrency),
+            personalSpendUsed: try c.decodeIfPresent(Double.self, forKey: .personalSpendUsed),
+            personalSpendCurrency: try c.decodeIfPresent(String.self, forKey: .personalSpendCurrency),
             lastUpdated: try c.decodeIfPresent(Date.self, forKey: .lastUpdated) ?? Date(),
             userTimezone: try c.decodeIfPresent(TimeZone.self, forKey: .userTimezone) ?? .current
         )

--- a/Claude Usage/Shared/Models/ClaudeUsage.swift
+++ b/Claude Usage/Shared/Models/ClaudeUsage.swift
@@ -47,6 +47,14 @@ struct ClaudeUsage: Codable, Equatable {
     var overageBalance: Double?
     var overageBalanceCurrency: String?
 
+    // The authenticated member's OWN month-to-date spend, from the claude.ai
+    // /usage/spend endpoint. Minor units (cents) of `personalSpendCurrency`.
+    // Distinct from the org-wide `costUsed`/`costLimit` figures above: this is
+    // what *this account* spent, matching claude.ai/settings/usage. Gated by the
+    // `personalSpend` provider capability.
+    var personalSpendUsed: Double?
+    var personalSpendCurrency: String?
+
     // Provider plan/credits (populated by providers that report them, e.g. Codex)
     var planType: String?
     var creditsBalance: Double?
@@ -141,6 +149,7 @@ extension ClaudeUsage {
         case fableWeeklyTokensUsed, fableWeeklyPercentage, fableWeeklyResetTime
         case costUsed, costLimit, costCurrency
         case overageBalance, overageBalanceCurrency
+        case personalSpendUsed, personalSpendCurrency
         case planType, creditsBalance, creditsUnlimited
         case lastUpdated, userTimezone
     }
@@ -172,6 +181,8 @@ extension ClaudeUsage {
             costCurrency: try c.decodeIfPresent(String.self, forKey: .costCurrency),
             overageBalance: try c.decodeIfPresent(Double.self, forKey: .overageBalance),
             overageBalanceCurrency: try c.decodeIfPresent(String.self, forKey: .overageBalanceCurrency),
+            personalSpendUsed: try c.decodeIfPresent(Double.self, forKey: .personalSpendUsed),
+            personalSpendCurrency: try c.decodeIfPresent(String.self, forKey: .personalSpendCurrency),
             planType: try c.decodeIfPresent(String.self, forKey: .planType),
             creditsBalance: try c.decodeIfPresent(Double.self, forKey: .creditsBalance),
             creditsUnlimited: try c.decodeIfPresent(Bool.self, forKey: .creditsUnlimited),

--- a/Claude Usage/Shared/Models/ClaudeUsage.swift
+++ b/Claude Usage/Shared/Models/ClaudeUsage.swift
@@ -47,11 +47,8 @@ struct ClaudeUsage: Codable, Equatable {
     var overageBalance: Double?
     var overageBalanceCurrency: String?
 
-    // The authenticated member's OWN month-to-date spend, from the claude.ai
-    // /usage/spend endpoint. Minor units (cents) of `personalSpendCurrency`.
-    // Distinct from the org-wide `costUsed`/`costLimit` figures above: this is
-    // what *this account* spent, matching claude.ai/settings/usage. Gated by the
-    // `personalSpend` provider capability.
+    // Member's own month-to-date spend from /usage/spend, in minor units
+    // (see ClaudeAPIService.fetchPersonalSpend)
     var personalSpendUsed: Double?
     var personalSpendCurrency: String?
 

--- a/Claude Usage/Shared/Models/Profile.swift
+++ b/Claude Usage/Shared/Models/Profile.swift
@@ -53,7 +53,7 @@ struct Profile: Codable, Identifiable, Equatable {
     var checkOverageLimitEnabled: Bool
 
     /// Optional personal monthly spend target, in minor units (cents), used as the
-    /// denominator for the "Personal Usage" bar in the popover. `nil` (or 0) means
+    /// denominator for the "Monthly Spend" bar in the popover. `nil` (or 0) means
     /// no target set — the popover then shows the spend amount without a bar.
     var monthlySpendLimitCents: Double?
 

--- a/Claude Usage/Shared/Models/Profile.swift
+++ b/Claude Usage/Shared/Models/Profile.swift
@@ -52,6 +52,11 @@ struct Profile: Codable, Identifiable, Equatable {
     var autoStartSessionEnabled: Bool
     var checkOverageLimitEnabled: Bool
 
+    /// Optional personal monthly spend target, in minor units (cents), used as the
+    /// denominator for the "Personal Usage" bar in the popover. `nil` (or 0) means
+    /// no target set — the popover then shows the spend amount without a bar.
+    var monthlySpendLimitCents: Double?
+
     // MARK: - Notification Settings (Per-Profile)
     var notificationSettings: NotificationSettings
 
@@ -81,6 +86,7 @@ struct Profile: Codable, Identifiable, Equatable {
         refreshInterval: TimeInterval = 30.0,
         autoStartSessionEnabled: Bool = false,
         checkOverageLimitEnabled: Bool = true,
+        monthlySpendLimitCents: Double? = nil,
         notificationSettings: NotificationSettings = NotificationSettings(),
         isSelectedForDisplay: Bool = true,
         createdAt: Date = Date(),
@@ -104,6 +110,7 @@ struct Profile: Codable, Identifiable, Equatable {
         self.refreshInterval = refreshInterval
         self.autoStartSessionEnabled = autoStartSessionEnabled
         self.checkOverageLimitEnabled = checkOverageLimitEnabled
+        self.monthlySpendLimitCents = monthlySpendLimitCents
         self.notificationSettings = notificationSettings
         self.isSelectedForDisplay = isSelectedForDisplay
         self.createdAt = createdAt
@@ -128,6 +135,7 @@ struct Profile: Codable, Identifiable, Equatable {
         case claudeUsage, apiUsage
         case iconConfig
         case refreshInterval, autoStartSessionEnabled, checkOverageLimitEnabled
+        case monthlySpendLimitCents
         case notificationSettings
         case isSelectedForDisplay
         case createdAt, lastUsedAt
@@ -158,6 +166,7 @@ struct Profile: Codable, Identifiable, Equatable {
         refreshInterval = try c.decodeIfPresent(TimeInterval.self, forKey: .refreshInterval) ?? 30.0
         autoStartSessionEnabled = try c.decodeIfPresent(Bool.self, forKey: .autoStartSessionEnabled) ?? false
         checkOverageLimitEnabled = try c.decodeIfPresent(Bool.self, forKey: .checkOverageLimitEnabled) ?? true
+        monthlySpendLimitCents = try c.decodeIfPresent(Double.self, forKey: .monthlySpendLimitCents)
         notificationSettings = try c.decodeIfPresent(NotificationSettings.self, forKey: .notificationSettings) ?? NotificationSettings()
         isSelectedForDisplay = try c.decodeIfPresent(Bool.self, forKey: .isSelectedForDisplay) ?? true
         createdAt = try c.decodeIfPresent(Date.self, forKey: .createdAt) ?? Date()
@@ -188,6 +197,7 @@ struct Profile: Codable, Identifiable, Equatable {
         try c.encode(refreshInterval, forKey: .refreshInterval)
         try c.encode(autoStartSessionEnabled, forKey: .autoStartSessionEnabled)
         try c.encode(checkOverageLimitEnabled, forKey: .checkOverageLimitEnabled)
+        try c.encodeIfPresent(monthlySpendLimitCents, forKey: .monthlySpendLimitCents)
         try c.encode(notificationSettings, forKey: .notificationSettings)
         try c.encode(isSelectedForDisplay, forKey: .isSelectedForDisplay)
         try c.encode(createdAt, forKey: .createdAt)

--- a/Claude Usage/Shared/Models/Profile.swift
+++ b/Claude Usage/Shared/Models/Profile.swift
@@ -68,6 +68,11 @@ struct Profile: Codable, Identifiable, Equatable {
     var autoStartSessionEnabled: Bool
     var checkOverageLimitEnabled: Bool
 
+    /// Optional personal monthly spend target, in minor units (cents), used as
+    /// the denominator for the "Monthly Spend" bar in the popover. `nil` (or 0)
+    /// means no target — the popover then shows the amount without a bar.
+    var monthlySpendLimitCents: Double?
+
     // MARK: - Notification Settings (Per-Profile)
     var notificationSettings: NotificationSettings
 
@@ -100,6 +105,7 @@ struct Profile: Codable, Identifiable, Equatable {
         refreshInterval: TimeInterval = 30.0,
         autoStartSessionEnabled: Bool = false,
         checkOverageLimitEnabled: Bool = true,
+        monthlySpendLimitCents: Double? = nil,
         notificationSettings: NotificationSettings = NotificationSettings(),
         isSelectedForDisplay: Bool = true,
         createdAt: Date = Date(),
@@ -126,6 +132,7 @@ struct Profile: Codable, Identifiable, Equatable {
         self.refreshInterval = refreshInterval
         self.autoStartSessionEnabled = autoStartSessionEnabled
         self.checkOverageLimitEnabled = checkOverageLimitEnabled
+        self.monthlySpendLimitCents = monthlySpendLimitCents
         self.notificationSettings = notificationSettings
         self.isSelectedForDisplay = isSelectedForDisplay
         self.createdAt = createdAt
@@ -153,6 +160,7 @@ struct Profile: Codable, Identifiable, Equatable {
         case claudeUsage, apiUsage
         case iconConfig
         case refreshInterval, autoStartSessionEnabled, checkOverageLimitEnabled
+        case monthlySpendLimitCents
         case notificationSettings
         case isSelectedForDisplay
         case createdAt, lastUsedAt
@@ -189,6 +197,7 @@ struct Profile: Codable, Identifiable, Equatable {
         refreshInterval = try c.decodeIfPresent(TimeInterval.self, forKey: .refreshInterval) ?? 30.0
         autoStartSessionEnabled = try c.decodeIfPresent(Bool.self, forKey: .autoStartSessionEnabled) ?? false
         checkOverageLimitEnabled = try c.decodeIfPresent(Bool.self, forKey: .checkOverageLimitEnabled) ?? true
+        monthlySpendLimitCents = try c.decodeIfPresent(Double.self, forKey: .monthlySpendLimitCents)
         notificationSettings = try c.decodeIfPresent(NotificationSettings.self, forKey: .notificationSettings) ?? NotificationSettings()
         isSelectedForDisplay = try c.decodeIfPresent(Bool.self, forKey: .isSelectedForDisplay) ?? true
         createdAt = try c.decodeIfPresent(Date.self, forKey: .createdAt) ?? Date()
@@ -222,6 +231,7 @@ struct Profile: Codable, Identifiable, Equatable {
         try c.encode(refreshInterval, forKey: .refreshInterval)
         try c.encode(autoStartSessionEnabled, forKey: .autoStartSessionEnabled)
         try c.encode(checkOverageLimitEnabled, forKey: .checkOverageLimitEnabled)
+        try c.encodeIfPresent(monthlySpendLimitCents, forKey: .monthlySpendLimitCents)
         try c.encode(notificationSettings, forKey: .notificationSettings)
         try c.encode(isSelectedForDisplay, forKey: .isSelectedForDisplay)
         try c.encode(createdAt, forKey: .createdAt)

--- a/Claude Usage/Shared/Models/ProviderDescriptor.swift
+++ b/Claude Usage/Shared/Models/ProviderDescriptor.swift
@@ -63,6 +63,11 @@ struct ProviderCapabilities {
     /// Provider supports overage/extra-usage spend checks.
     let overageChecks: Bool
 
+    /// Provider reports the authenticated member's own month-to-date spend
+    /// (separate from any org-wide overage figure). Gates the Monthly Spend
+    /// popover row and its per-profile target field in General settings.
+    let personalSpend: Bool
+
     /// Provider reports a prepaid credits balance.
     let credits: Bool
 }

--- a/Claude Usage/Shared/Services/ClaudeAPIService+Types.swift
+++ b/Claude Usage/Shared/Services/ClaudeAPIService+Types.swift
@@ -57,6 +57,25 @@ extension ClaudeAPIService {
         }
     }
 
+    /// Response from `/organizations/{org}/usage/spend`. Although the URL is
+    /// org-scoped, claude.ai returns only the calling member's own figures when
+    /// the org has "individual usage analytics" enabled — the same data shown on
+    /// the Settings → Usage page. `totals` holds one entry per group (e.g. per
+    /// product surface); summing their `cost_minor_units` gives the member's
+    /// spend for the requested date range, in minor units of `currency`.
+    struct UsageSpendResponse: Codable {
+        let currency: String?
+        let totals: [Total]?
+
+        struct Total: Codable {
+            let costMinorUnits: Double?
+
+            enum CodingKeys: String, CodingKey {
+                case costMinorUnits = "cost_minor_units"
+            }
+        }
+    }
+
     struct CurrentSpendResponse: Codable {
         let amount: Int
         let resetsAt: String

--- a/Claude Usage/Shared/Services/ClaudeAPIService+Types.swift
+++ b/Claude Usage/Shared/Services/ClaudeAPIService+Types.swift
@@ -57,6 +57,28 @@ extension ClaudeAPIService {
         }
     }
 
+    /// Response from `/organizations/{org}/usage/spend`. Although the URL is
+    /// org-scoped, claude.ai returns only the calling member's own figures when
+    /// the org has "individual usage analytics" enabled — the same data shown on
+    /// the Settings → Usage page. `totals` holds one entry per group (e.g. per
+    /// product surface); summing their `cost_minor_units` gives the member's
+    /// spend for the requested date range, in minor units of `currency`.
+    ///
+    /// Every field is optional so a new or renamed server field degrades to a
+    /// hidden row rather than failing the whole decode.
+    struct UsageSpendResponse: Codable {
+        let currency: String?
+        let totals: [Total]?
+
+        struct Total: Codable {
+            let costMinorUnits: Double?
+
+            enum CodingKeys: String, CodingKey {
+                case costMinorUnits = "cost_minor_units"
+            }
+        }
+    }
+
     struct CurrentSpendResponse: Codable {
         let amount: Int
         let resetsAt: String

--- a/Claude Usage/Shared/Services/ClaudeAPIService.swift
+++ b/Claude Usage/Shared/Services/ClaudeAPIService.swift
@@ -426,6 +426,7 @@ class ClaudeAPIService: APIServiceProtocol {
         async let usageDataTask = performRequest(endpoint: "/organizations/\(organizationId)/usage", sessionKey: sessionKey)
         async let overageDataTask: Data? = performRequest(endpoint: "/organizations/\(organizationId)/overage_spend_limit", sessionKey: sessionKey)
         async let creditGrantTask: Data? = performRequest(endpoint: "/organizations/\(organizationId)/overage_credit_grant", sessionKey: sessionKey)
+        async let personalSpendTask = fetchPersonalSpend(organizationId: organizationId, sessionKey: sessionKey)
 
         let usageData = try await usageDataTask
         var claudeUsage = try parseUsageResponse(usageData)
@@ -442,6 +443,11 @@ class ClaudeAPIService: APIServiceProtocol {
            let creditGrant = try? JSONDecoder().decode(OverageCreditGrantResponse.self, from: creditData) {
             claudeUsage.overageBalance = creditGrant.remainingBalance
             claudeUsage.overageBalanceCurrency = creditGrant.currency
+        }
+
+        if let personal = await personalSpendTask {
+            claudeUsage.personalSpendUsed = personal.usedMinorUnits
+            claudeUsage.personalSpendCurrency = personal.currency
         }
 
         return claudeUsage
@@ -490,6 +496,7 @@ class ClaudeAPIService: APIServiceProtocol {
             let checkOverage = ProfileManager.shared.activeProfile?.checkOverageLimitEnabled ?? true
             async let overageDataTask: Data? = checkOverage ? performRequest(endpoint: "/organizations/\(orgId)/overage_spend_limit", sessionKey: sessionKey) : nil
             async let creditGrantTask: Data? = checkOverage ? performRequest(endpoint: "/organizations/\(orgId)/overage_credit_grant", sessionKey: sessionKey) : nil
+            async let personalSpendTask = fetchPersonalSpend(organizationId: orgId, sessionKey: sessionKey)
 
             let usageData = try await usageDataTask
             var claudeUsage = try parseUsageResponse(usageData)
@@ -508,6 +515,11 @@ class ClaudeAPIService: APIServiceProtocol {
                let creditGrant = try? JSONDecoder().decode(OverageCreditGrantResponse.self, from: creditData) {
                 claudeUsage.overageBalance = creditGrant.remainingBalance
                 claudeUsage.overageBalanceCurrency = creditGrant.currency
+            }
+
+            if let personal = await personalSpendTask {
+                claudeUsage.personalSpendUsed = personal.usedMinorUnits
+                claudeUsage.personalSpendCurrency = personal.currency
             }
 
             return claudeUsage
@@ -760,6 +772,60 @@ class ClaudeAPIService: APIServiceProtocol {
     }
 
     // MARK: - Response Parsing
+
+    /// Fetches the authenticated member's OWN month-to-date spend from
+    /// `/organizations/{org}/usage/spend`. The URL is org-scoped but claude.ai
+    /// returns only the calling member's figures (the same number shown on
+    /// claude.ai/settings/usage), provided the org has "individual usage
+    /// analytics" enabled. Non-throwing: any failure (no such endpoint for the
+    /// plan, analytics disabled, network/parse error) resolves to `nil` so it can
+    /// never break the primary usage fetch. Returns spend in minor units (cents).
+    func fetchPersonalSpend(organizationId: String, sessionKey: String) async -> (usedMinorUnits: Double, currency: String)? {
+        do {
+            let calendar = Calendar.current
+            let now = Date()
+            guard let startOfMonth = calendar.date(from: calendar.dateComponents([.year, .month], from: now)) else {
+                return nil
+            }
+
+            // Match claude.ai's Settings → Usage query: calendar month-to-date.
+            let dateFormatter = DateFormatter()
+            dateFormatter.calendar = Calendar(identifier: .gregorian)
+            dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+            dateFormatter.dateFormat = "yyyy-MM-dd"
+
+            let url = try URLBuilder(baseURL: baseURL)
+                .appendingPathComponents(["/organizations", organizationId, "/usage/spend"])
+                .addingQueryParameter(name: "start_date", value: dateFormatter.string(from: startOfMonth))
+                .addingQueryParameter(name: "end_date", value: dateFormatter.string(from: now))
+                .addingQueryParameter(name: "group_by", value: "product_surface")
+                .addingQueryParameter(name: "granularity", value: "daily")
+                .build()
+
+            var request = buildAuthenticatedRequest(url: url, auth: .claudeAISession(sessionKey))
+            request.httpMethod = "GET"
+            request.timeoutInterval = 30
+
+            LoggingService.shared.logAPIRequest("/organizations/\(organizationId)/usage/spend")
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+                return nil
+            }
+
+            guard let spend = try? JSONDecoder().decode(UsageSpendResponse.self, from: data),
+                  let totals = spend.totals, !totals.isEmpty else {
+                return nil
+            }
+
+            // Sum across every group (e.g. all product surfaces) for the grand total.
+            let usedMinorUnits = totals.reduce(0.0) { $0 + ($1.costMinorUnits ?? 0) }
+            return (usedMinorUnits, spend.currency?.uppercased() ?? "USD")
+        } catch {
+            LoggingService.shared.logAPIError("/organizations/\(organizationId)/usage/spend", error: error)
+            return nil
+        }
+    }
 
     private func parseUsageResponse(_ data: Data) throws -> ClaudeUsage {
         // Parse Claude's actual API response structure

--- a/Claude Usage/Shared/Services/ClaudeAPIService.swift
+++ b/Claude Usage/Shared/Services/ClaudeAPIService.swift
@@ -771,7 +771,7 @@ class ClaudeAPIService: APIServiceProtocol {
         }
     }
 
-    // MARK: - Response Parsing
+    // MARK: - Personal Spend
 
     /// Fetches the authenticated member's OWN month-to-date spend from
     /// `/organizations/{org}/usage/spend`. The URL is org-scoped but claude.ai
@@ -780,7 +780,7 @@ class ClaudeAPIService: APIServiceProtocol {
     /// analytics" enabled. Non-throwing: any failure (no such endpoint for the
     /// plan, analytics disabled, network/parse error) resolves to `nil` so it can
     /// never break the primary usage fetch. Returns spend in minor units (cents).
-    func fetchPersonalSpend(organizationId: String, sessionKey: String) async -> (usedMinorUnits: Double, currency: String)? {
+    private func fetchPersonalSpend(organizationId: String, sessionKey: String) async -> (usedMinorUnits: Double, currency: String)? {
         do {
             let calendar = Calendar.current
             let now = Date()
@@ -806,6 +806,17 @@ class ClaudeAPIService: APIServiceProtocol {
             request.httpMethod = "GET"
             request.timeoutInterval = 30
 
+            // Include Cloudflare clearance cookies captured by the sign-in webview
+            // (shared cookie storage) — without them claude.ai intermittently
+            // answers with a 403 "Just a moment..." challenge page.
+            var cookiePairs = ["sessionKey=\(sessionKey)"]
+            if let stored = HTTPCookieStorage.shared.cookies(for: url) {
+                for cookie in stored where ["cf_clearance", "__cf_bm"].contains(cookie.name) {
+                    cookiePairs.append("\(cookie.name)=\(cookie.value)")
+                }
+            }
+            request.setValue(cookiePairs.joined(separator: "; "), forHTTPHeaderField: "Cookie")
+
             LoggingService.shared.logAPIRequest("/organizations/\(organizationId)/usage/spend")
             let (data, response) = try await URLSession.shared.data(for: request)
 
@@ -826,6 +837,8 @@ class ClaudeAPIService: APIServiceProtocol {
             return nil
         }
     }
+
+    // MARK: - Response Parsing
 
     private func parseUsageResponse(_ data: Data) throws -> ClaudeUsage {
         // Parse Claude's actual API response structure

--- a/Claude Usage/Shared/Services/ClaudeAPIService.swift
+++ b/Claude Usage/Shared/Services/ClaudeAPIService.swift
@@ -455,6 +455,7 @@ class ClaudeAPIService: APIServiceProtocol {
         async let usageDataTask = performRequest(endpoint: "/organizations/\(organizationId)/usage", sessionKey: sessionKey)
         async let overageDataTask: Data? = performRequest(endpoint: "/organizations/\(organizationId)/overage_spend_limit", sessionKey: sessionKey)
         async let creditGrantTask: Data? = performRequest(endpoint: "/organizations/\(organizationId)/overage_credit_grant", sessionKey: sessionKey)
+        async let personalSpendTask = fetchPersonalSpend(organizationId: organizationId, sessionKey: sessionKey)
 
         let usageData = try await usageDataTask
         var claudeUsage = try parseUsageResponse(usageData)
@@ -471,6 +472,11 @@ class ClaudeAPIService: APIServiceProtocol {
            let creditGrant = try? JSONDecoder().decode(OverageCreditGrantResponse.self, from: creditData) {
             claudeUsage.overageBalance = creditGrant.remainingBalance
             claudeUsage.overageBalanceCurrency = creditGrant.currency
+        }
+
+        if let personal = await personalSpendTask {
+            claudeUsage.personalSpendUsed = personal.usedMinorUnits
+            claudeUsage.personalSpendCurrency = personal.currency
         }
 
         return claudeUsage
@@ -519,6 +525,7 @@ class ClaudeAPIService: APIServiceProtocol {
             let checkOverage = ProfileManager.shared.activeProfile?.checkOverageLimitEnabled ?? true
             async let overageDataTask: Data? = checkOverage ? performRequest(endpoint: "/organizations/\(orgId)/overage_spend_limit", sessionKey: sessionKey) : nil
             async let creditGrantTask: Data? = checkOverage ? performRequest(endpoint: "/organizations/\(orgId)/overage_credit_grant", sessionKey: sessionKey) : nil
+            async let personalSpendTask = fetchPersonalSpend(organizationId: orgId, sessionKey: sessionKey)
 
             let usageData = try await usageDataTask
             var claudeUsage = try parseUsageResponse(usageData)
@@ -537,6 +544,11 @@ class ClaudeAPIService: APIServiceProtocol {
                let creditGrant = try? JSONDecoder().decode(OverageCreditGrantResponse.self, from: creditData) {
                 claudeUsage.overageBalance = creditGrant.remainingBalance
                 claudeUsage.overageBalanceCurrency = creditGrant.currency
+            }
+
+            if let personal = await personalSpendTask {
+                claudeUsage.personalSpendUsed = personal.usedMinorUnits
+                claudeUsage.personalSpendCurrency = personal.currency
             }
 
             return claudeUsage
@@ -783,6 +795,68 @@ class ClaudeAPIService: APIServiceProtocol {
                 technicalDetails: "Endpoint: \(endpoint)\nStatus: \(httpResponse.statusCode)\nResponse: \(responsePreview)",
                 isRecoverable: true
             )
+        }
+    }
+
+    // MARK: - Personal Spend
+
+    /// Fetches the authenticated member's OWN month-to-date spend from
+    /// `/organizations/{org}/usage/spend`. The URL is org-scoped but claude.ai
+    /// returns only the calling member's figures (the same number shown on
+    /// claude.ai/settings/usage), provided the org has "individual usage
+    /// analytics" enabled.
+    ///
+    /// Non-throwing by design: any failure (endpoint absent for the plan,
+    /// analytics disabled, network or parse error) resolves to `nil` so this can
+    /// never break the primary usage fetch.
+    ///
+    /// - Returns: Spend in minor units (cents) plus its currency, or `nil`.
+    private func fetchPersonalSpend(organizationId: String, sessionKey: String) async -> (usedMinorUnits: Double, currency: String)? {
+        do {
+            let calendar = Calendar.current
+            let now = Date()
+            guard let startOfMonth = calendar.date(from: calendar.dateComponents([.year, .month], from: now)) else {
+                return nil
+            }
+
+            // Match claude.ai's Settings → Usage query: calendar month-to-date.
+            let dateFormatter = DateFormatter()
+            dateFormatter.calendar = Calendar(identifier: .gregorian)
+            dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+            dateFormatter.dateFormat = "yyyy-MM-dd"
+
+            let url = try URLBuilder(baseURL: baseURL)
+                .appendingPathComponents(["/organizations", organizationId, "/usage/spend"])
+                .addingQueryParameter(name: "start_date", value: dateFormatter.string(from: startOfMonth))
+                .addingQueryParameter(name: "end_date", value: dateFormatter.string(from: now))
+                .addingQueryParameter(name: "group_by", value: "product_surface")
+                .addingQueryParameter(name: "granularity", value: "daily")
+                .build()
+
+            // buildAuthenticatedRequest applies `sessionCookieHeader`, so the
+            // Cloudflare clearance and device cookies travel with this call too.
+            var request = buildAuthenticatedRequest(url: url, auth: .claudeAISession(sessionKey))
+            request.httpMethod = "GET"
+            request.timeoutInterval = 30
+
+            LoggingService.shared.logAPIRequest("/organizations/\(organizationId)/usage/spend")
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+                return nil
+            }
+
+            guard let spend = try? JSONDecoder().decode(UsageSpendResponse.self, from: data),
+                  let totals = spend.totals, !totals.isEmpty else {
+                return nil
+            }
+
+            // Sum across every group (e.g. all product surfaces) for the grand total.
+            let usedMinorUnits = totals.reduce(0.0) { $0 + ($1.costMinorUnits ?? 0) }
+            return (usedMinorUnits, spend.currency?.uppercased() ?? "USD")
+        } catch {
+            LoggingService.shared.logAPIError("/organizations/\(organizationId)/usage/spend", error: error)
+            return nil
         }
     }
 

--- a/Claude Usage/Shared/Services/Providers/ProviderRegistry.swift
+++ b/Claude Usage/Shared/Services/Providers/ProviderRegistry.swift
@@ -31,6 +31,7 @@ enum ProviderRegistry {
                 cliAccountSync: true,
                 autoStartSession: true,
                 overageChecks: true,
+                personalSpend: true,
                 credits: false
             ),
             credentialSections: [.claudeAI, .apiConsole, .cliAccount],
@@ -50,6 +51,7 @@ enum ProviderRegistry {
                 cliAccountSync: false,
                 autoStartSession: false,
                 overageChecks: false,
+                personalSpend: false,
                 credits: true
             ),
             credentialSections: [.codexAccount],

--- a/Claude Usage/Views/Settings/Profile/GeneralSettingsView.swift
+++ b/Claude Usage/Views/Settings/Profile/GeneralSettingsView.swift
@@ -65,6 +65,50 @@ struct GeneralSettingsView: View {
                         }
                     }
 
+                    // Monthly Spend Target (denominator for the Personal Usage bar)
+                    SettingsSectionCard(
+                        title: "general.spend_target_title".localized,
+                        subtitle: "general.spend_target_subtitle".localized
+                    ) {
+                        HStack(spacing: DesignTokens.Spacing.iconText) {
+                            Image(systemName: "dollarsign.circle")
+                                .font(.system(size: DesignTokens.Icons.standard))
+                                .foregroundColor(DesignTokens.Colors.accent)
+                                .frame(width: DesignTokens.Spacing.iconFrame)
+
+                            TextField(
+                                "general.spend_target_placeholder".localized,
+                                text: Binding(
+                                    get: {
+                                        guard let cents = profile.monthlySpendLimitCents, cents > 0 else { return "" }
+                                        return String(format: "%.2f", cents / 100.0)
+                                    },
+                                    set: { newValue in
+                                        var updated = profile
+                                        let cleaned = newValue
+                                            .replacingOccurrences(of: ",", with: "")
+                                            .replacingOccurrences(of: "$", with: "")
+                                            .trimmingCharacters(in: .whitespaces)
+                                        if let dollars = Double(cleaned), dollars > 0 {
+                                            updated.monthlySpendLimitCents = dollars * 100.0
+                                        } else {
+                                            updated.monthlySpendLimitCents = nil
+                                        }
+                                        profileManager.updateProfile(updated)
+                                    }
+                                )
+                            )
+                            .textFieldStyle(.roundedBorder)
+                            .frame(width: 120)
+
+                            Text("USD")
+                                .font(DesignTokens.Typography.caption)
+                                .foregroundColor(.secondary)
+
+                            Spacer()
+                        }
+                    }
+
                     // Auto-Start Session
                     SettingsSectionCard(
                         title: "general.autostart_title".localized,

--- a/Claude Usage/Views/Settings/Profile/GeneralSettingsView.swift
+++ b/Claude Usage/Views/Settings/Profile/GeneralSettingsView.swift
@@ -11,6 +11,7 @@ import UserNotifications
 /// General profile settings: Refresh interval, Auto-start, Notifications
 struct GeneralSettingsView: View {
     @StateObject private var profileManager = ProfileManager.shared
+    @State private var spendTargetText = ""
 
     var body: some View {
         ScrollView {
@@ -65,7 +66,7 @@ struct GeneralSettingsView: View {
                         }
                     }
 
-                    // Monthly Spend Target (denominator for the Personal Usage bar)
+                    // Monthly Spend Target (denominator for the Monthly Spend bar)
                     SettingsSectionCard(
                         title: "general.spend_target_title".localized,
                         subtitle: "general.spend_target_subtitle".localized
@@ -76,32 +77,19 @@ struct GeneralSettingsView: View {
                                 .foregroundColor(DesignTokens.Colors.accent)
                                 .frame(width: DesignTokens.Spacing.iconFrame)
 
-                            TextField(
-                                "general.spend_target_placeholder".localized,
-                                text: Binding(
-                                    get: {
-                                        guard let cents = profile.monthlySpendLimitCents, cents > 0 else { return "" }
-                                        return String(format: "%.2f", cents / 100.0)
-                                    },
-                                    set: { newValue in
-                                        var updated = profile
-                                        let cleaned = newValue
-                                            .replacingOccurrences(of: ",", with: "")
-                                            .replacingOccurrences(of: "$", with: "")
-                                            .trimmingCharacters(in: .whitespaces)
-                                        if let dollars = Double(cleaned), dollars > 0 {
-                                            updated.monthlySpendLimitCents = dollars * 100.0
-                                        } else {
-                                            updated.monthlySpendLimitCents = nil
-                                        }
-                                        profileManager.updateProfile(updated)
+                            TextField("general.spend_target_placeholder".localized, text: $spendTargetText)
+                                .textFieldStyle(.roundedBorder)
+                                .frame(width: 120)
+                                .onAppear {
+                                    if let cents = profile.monthlySpendLimitCents, cents > 0 {
+                                        spendTargetText = String(Int(cents / 100))
                                     }
-                                )
-                            )
-                            .textFieldStyle(.roundedBorder)
-                            .frame(width: 120)
+                                }
+                                .onChange(of: spendTargetText) { _, newValue in
+                                    saveSpendTarget(newValue)
+                                }
 
-                            Text("USD")
+                            Text(profile.claudeUsage?.personalSpendCurrency ?? "USD")
                                 .font(DesignTokens.Typography.caption)
                                 .foregroundColor(.secondary)
 
@@ -266,6 +254,23 @@ struct GeneralSettingsView: View {
     }
 
     // MARK: - Helper Methods
+
+    /// Parses the spend-target field as whole dollars and stores it as cents
+    /// (matching the minor-units convention of `costUsed`/`costLimit`).
+    /// Anything non-numeric or zero clears the target.
+    private func saveSpendTarget(_ text: String) {
+        guard var updated = profileManager.activeProfile else { return }
+        let cleaned = text
+            .replacingOccurrences(of: ",", with: "")
+            .replacingOccurrences(of: "$", with: "")
+            .trimmingCharacters(in: .whitespaces)
+        if let dollars = Int(cleaned), dollars > 0 {
+            updated.monthlySpendLimitCents = Double(dollars) * 100.0
+        } else {
+            updated.monthlySpendLimitCents = nil
+        }
+        profileManager.updateProfile(updated)
+    }
 
     private func requestNotificationPermission() {
         Task {

--- a/Claude Usage/Views/Settings/Profile/GeneralSettingsView.swift
+++ b/Claude Usage/Views/Settings/Profile/GeneralSettingsView.swift
@@ -12,6 +12,10 @@ import UserNotifications
 struct GeneralSettingsView: View {
     @StateObject private var profileManager = ProfileManager.shared
 
+    /// Spend target as typed, in whole units of the display currency. Kept as
+    /// text so a part-typed value isn't rounded away mid-edit.
+    @State private var spendTargetText = ""
+
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: DesignTokens.Spacing.section) {
@@ -63,6 +67,40 @@ struct GeneralSettingsView: View {
                                     .foregroundColor(.secondary)
                             }
                         }
+                    }
+
+                    // Monthly Spend Target — denominator for the popover's
+                    // Monthly Spend bar. Only providers that report a per-member
+                    // spend figure can use it.
+                    if profile.provider.descriptor.capabilities.personalSpend {
+                        SettingsSectionCard(
+                            title: "general.spend_target_title".localized,
+                            subtitle: "general.spend_target_subtitle".localized
+                        ) {
+                            HStack(spacing: DesignTokens.Spacing.iconText) {
+                                Image(systemName: "dollarsign.circle")
+                                    .font(.system(size: DesignTokens.Icons.standard))
+                                    .foregroundColor(DesignTokens.Colors.accent)
+                                    .frame(width: DesignTokens.Spacing.iconFrame)
+
+                                TextField("general.spend_target_placeholder".localized, text: $spendTargetText)
+                                    .textFieldStyle(.roundedBorder)
+                                    .frame(width: 120)
+                                    .onChange(of: spendTargetText) { _, newValue in
+                                        saveSpendTarget(newValue, on: profile)
+                                    }
+
+                                Text(profile.claudeUsage?.personalSpendCurrency ?? "USD")
+                                    .font(DesignTokens.Typography.caption)
+                                    .foregroundColor(.secondary)
+
+                                Spacer()
+                            }
+                        }
+                        // Load on first show and whenever the edited profile
+                        // changes, so the field never shows another profile's target.
+                        .onAppear { loadSpendTarget(from: profile) }
+                        .onChange(of: profile.id) { _, _ in loadSpendTarget(from: profile) }
                     }
 
                     // Auto-Start Session (capability-gated: burns tokens via
@@ -231,6 +269,42 @@ struct GeneralSettingsView: View {
     }
 
     // MARK: - Helper Methods
+
+    /// Mirrors the stored target (cents) into the text field as whole units.
+    /// Formats the Double directly — converting to Int first traps for values
+    /// beyond Int.max, which a large typed target can reach.
+    private func loadSpendTarget(from profile: Profile) {
+        if let cents = profile.monthlySpendLimitCents, cents > 0, cents.isFinite {
+            spendTargetText = String(format: "%.0f", cents / 100)
+        } else {
+            spendTargetText = ""
+        }
+    }
+
+    /// Parses the spend-target field as whole units and stores it as cents
+    /// (matching the minor-units convention of `costUsed`/`costLimit`).
+    /// Anything non-numeric or zero clears the target.
+    private func saveSpendTarget(_ text: String, on profile: Profile) {
+        let cleaned = text
+            .replacingOccurrences(of: ",", with: "")
+            .replacingOccurrences(of: "$", with: "")
+            .trimmingCharacters(in: .whitespaces)
+
+        let newValue: Double?
+        if let units = Int(cleaned), units > 0, Double(units).isFinite {
+            newValue = Double(units) * 100.0
+        } else {
+            newValue = nil
+        }
+
+        // Skip the write when nothing changed — loading the field on appear
+        // fires onChange too, and updateProfile persists and re-publishes.
+        guard newValue != profile.monthlySpendLimitCents else { return }
+
+        var updated = profile
+        updated.monthlySpendLimitCents = newValue
+        profileManager.updateProfile(updated)
+    }
 
     private func requestNotificationPermission() {
         Task {

--- a/Claude UsageTests/UsageSpendResponseTests.swift
+++ b/Claude UsageTests/UsageSpendResponseTests.swift
@@ -1,0 +1,60 @@
+//
+//  UsageSpendResponseTests.swift
+//  Claude Usage Tests
+//
+//  Created on 2026-07-21.
+//
+
+import XCTest
+@testable import Claude_Usage
+
+/// Decoding tests for the `/organizations/{org}/usage/spend` response, which
+/// backs the Monthly Spend row in the popover.
+@MainActor
+final class UsageSpendResponseTests: XCTestCase {
+
+    private func decode(_ json: String) throws -> ClaudeAPIService.UsageSpendResponse {
+        try JSONDecoder().decode(ClaudeAPIService.UsageSpendResponse.self, from: Data(json.utf8))
+    }
+
+    // MARK: - Decoding Tests
+
+    func testDecodesCurrencyAndTotals() throws {
+        let response = try decode("""
+        {
+            "currency": "usd",
+            "totals": [
+                { "product_surface": "claude_ai", "cost_minor_units": 123456.78 },
+                { "product_surface": "claude_code", "cost_minor_units": 100 }
+            ]
+        }
+        """)
+
+        XCTAssertEqual(response.currency, "usd")
+        XCTAssertEqual(response.totals?.count, 2)
+
+        let grandTotal = response.totals?.reduce(0.0) { $0 + ($1.costMinorUnits ?? 0) } ?? 0
+        XCTAssertEqual(grandTotal, 123556.78, accuracy: 0.001)
+    }
+
+    func testToleratesUnknownFieldsAndMissingCost() throws {
+        let response = try decode("""
+        {
+            "currency": "usd",
+            "totals": [
+                { "product_surface": "claude_ai", "unexpected_field": true }
+            ]
+        }
+        """)
+
+        XCTAssertEqual(response.totals?.count, 1)
+        XCTAssertNil(response.totals?.first?.costMinorUnits)
+    }
+
+    func testDecodesEmptyResponse() throws {
+        let response = try decode("{}")
+
+        XCTAssertNil(response.currency)
+        XCTAssertNil(response.totals)
+    }
+}

--- a/Claude UsageTests/UsageSpendResponseTests.swift
+++ b/Claude UsageTests/UsageSpendResponseTests.swift
@@ -2,7 +2,7 @@
 //  UsageSpendResponseTests.swift
 //  Claude Usage Tests
 //
-//  Created on 2026-07-21.
+//  Created on 2026-09-03.
 //
 
 import XCTest

--- a/Claude UsageTests/UsageSpendResponseTests.swift
+++ b/Claude UsageTests/UsageSpendResponseTests.swift
@@ -1,0 +1,148 @@
+//
+//  UsageSpendResponseTests.swift
+//  Claude Usage Tests
+//
+//  Created on 2026-07-21.
+//
+
+import XCTest
+@testable import Claude_Usage
+
+/// Coverage for the Monthly Spend feature: the `/organizations/{org}/usage/spend`
+/// response decoding, the model fields that carry it, and the capability flag
+/// that gates its UI.
+@MainActor
+final class UsageSpendResponseTests: XCTestCase {
+
+    private func decode(_ json: String) throws -> ClaudeAPIService.UsageSpendResponse {
+        try JSONDecoder().decode(ClaudeAPIService.UsageSpendResponse.self, from: Data(json.utf8))
+    }
+
+    // MARK: - Response decoding
+
+    func testDecodesCurrencyAndTotals() throws {
+        let response = try decode("""
+        {
+            "currency": "usd",
+            "totals": [
+                { "product_surface": "claude_ai", "cost_minor_units": 123456.78 },
+                { "product_surface": "claude_code", "cost_minor_units": 100 }
+            ]
+        }
+        """)
+
+        XCTAssertEqual(response.currency, "usd")
+        XCTAssertEqual(response.totals?.count, 2)
+
+        let grandTotal = response.totals?.reduce(0.0) { $0 + ($1.costMinorUnits ?? 0) } ?? 0
+        XCTAssertEqual(grandTotal, 123556.78, accuracy: 0.001)
+    }
+
+    func testToleratesUnknownFieldsAndMissingCost() throws {
+        let response = try decode("""
+        {
+            "currency": "usd",
+            "totals": [
+                { "product_surface": "claude_ai", "unexpected_field": true }
+            ]
+        }
+        """)
+
+        XCTAssertEqual(response.totals?.count, 1)
+        XCTAssertNil(response.totals?.first?.costMinorUnits)
+    }
+
+    func testDecodesEmptyResponse() throws {
+        let response = try decode("{}")
+
+        XCTAssertNil(response.currency)
+        XCTAssertNil(response.totals)
+    }
+
+    /// A server-side type change throws here; `fetchPersonalSpend` decodes with
+    /// `try?`, so the failure surfaces as a hidden row, never a broken fetch.
+    func testMalformedTotalsTypeFailsDecodeRatherThanYieldingGarbage() {
+        XCTAssertThrowsError(try decode("{ \"totals\": \"not-an-array\" }"))
+        XCTAssertNil(try? decode("{ \"totals\": \"not-an-array\" }"))
+    }
+
+    // MARK: - ClaudeUsage carrying the spend
+
+    func testClaudeUsageRoundTripsPersonalSpend() throws {
+        var usage = ClaudeUsage.empty
+        usage.personalSpendUsed = 4237
+        usage.personalSpendCurrency = "USD"
+
+        let data = try JSONEncoder().encode(usage)
+        let decoded = try JSONDecoder().decode(ClaudeUsage.self, from: data)
+
+        XCTAssertEqual(decoded.personalSpendUsed, 4237)
+        XCTAssertEqual(decoded.personalSpendCurrency, "USD")
+    }
+
+    /// Usage written by an older app version has no spend keys at all; it must
+    /// still decode, leaving the row hidden.
+    func testClaudeUsageWithoutPersonalSpendDecodesToNil() throws {
+        let usage = try JSONDecoder().decode(
+            ClaudeUsage.self,
+            from: Data("{ \"sessionPercentage\": 12 }".utf8)
+        )
+
+        XCTAssertNil(usage.personalSpendUsed)
+        XCTAssertNil(usage.personalSpendCurrency)
+    }
+
+    // MARK: - Profile spend target
+
+    func testProfileRoundTripsMonthlySpendTarget() throws {
+        var profile = Profile(name: "Work")
+        profile.monthlySpendLimitCents = 150_000
+
+        let data = try JSONEncoder().encode(profile)
+        let decoded = try JSONDecoder().decode(Profile.self, from: data)
+
+        XCTAssertEqual(decoded.monthlySpendLimitCents, 150_000)
+    }
+
+    func testLegacyProfileWithoutSpendTargetDecodesToNil() throws {
+        let profile = try JSONDecoder().decode(
+            Profile.self,
+            from: Data("""
+            {
+                "id": "11111111-2222-3333-4444-555555555555",
+                "name": "Legacy"
+            }
+            """.utf8)
+        )
+
+        XCTAssertNil(profile.monthlySpendLimitCents)
+    }
+
+    /// A very large target must survive the persist/reload round trip. Rendering
+    /// it via `Int(cents / 100)` traps once the value passes Int.max, which
+    /// crashed the settings view on reopen.
+    func testVeryLargeSpendTargetFormatsWithoutTrapping() throws {
+        var profile = Profile(name: "Whale")
+        profile.monthlySpendLimitCents = Double(Int.max) * 100.0
+
+        let decoded = try JSONDecoder().decode(Profile.self, from: JSONEncoder().encode(profile))
+        let cents = try XCTUnwrap(decoded.monthlySpendLimitCents)
+
+        XCTAssertTrue(cents.isFinite)
+        // The formatting the settings field performs on load.
+        XCTAssertFalse(String(format: "%.0f", cents / 100).isEmpty)
+    }
+
+    // MARK: - Capability gate
+
+    func testOnlyProvidersReportingSpendDeclareTheCapability() {
+        XCTAssertTrue(
+            Provider.anthropic.descriptor.capabilities.personalSpend,
+            "claude.ai exposes a per-member spend figure"
+        )
+        XCTAssertFalse(
+            Provider.codex.descriptor.capabilities.personalSpend,
+            "Codex reports no per-member spend; the row must stay hidden"
+        )
+    }
+}


### PR DESCRIPTION
## Description

On Enterprise/spend-billed plans, the session and per-model weekly rows don't apply, and the only cost figure the app can show is the org-wide "Extra Usage" total. Which is meaningless to an individual member of a large org. This PR adds a **Monthly Spend** row to the popover showing the authenticated member's own month-to-date spend, fetched from the same endpoint the claude.ai Settings → Usage page uses (`/api/organizations/{org}/usage/spend`, same sessionKey auth as existing calls).

By default the row shows just the amount. Setting the new optional **Monthly Spend Target** field in Profile → General turns it into a progress bar styled like the existing Extra Usage row (the API exposes no per-member limit, hence the user-supplied target).

The fetch runs in parallel with the existing usage requests and is fail-silent: on plans/orgs where the endpoint isn't available it resolves to `nil`, the row simply doesn't render, and nothing changes for Free/Pro/Max users. The row is named "Monthly Spend" to avoid colliding with the existing "Personal Usage" settings tab.

Closes #287. Related to #274: this gives Enterprise members a meaningful number, but doesn't restore session/weekly token data; I'm thinking about hiding those inapplicable rows in a follow-up PR but haven't done so yet.

No breaking changes: all model fields are optional with backwards-compatible decoding, so existing stored profiles load unchanged.

## Changes

- `ClaudeUsage`: optional `personalSpendUsed` / `personalSpendCurrency` fields (minor units, matching the `costUsed`/`costLimit` convention)
- `Profile`: optional `monthlySpendLimitCents` per-profile budget target
- `ClaudeAPIService`: private `fetchPersonalSpend()`. Non-throwing, runs alongside the existing usage/overage fetches in both claude.ai auth paths; includes the Cloudflare clearance cookies the same way `performRequest` does
- `PopoverContentView`: new `MonthlySpendRow` (plain amount, or Extra-Usage-style bar when a target is set)
- `GeneralSettingsView`: whole-dollar Monthly Spend Target field; currency label follows the fetched spend currency
- Localization: new strings translated in all 13 supported languages
- Tests: `UsageSpendResponseTests` covering response decoding

## Screenshots / Screen Recordings

<img width="604" height="770" alt="popover row, amount-only variant" src="https://github.com/user-attachments/assets/e43562e3-eb3c-4402-965d-a47d4ee79e01" />
<img width="604" height="770" alt="popover row, progress-bar variant with target set" src="https://github.com/user-attachments/assets/924c4b13-95cc-4ef3-9434-2203d624749c" />
<img width="1472" height="1540" alt="Settings → General, Monthly Spend Target field" src="https://github.com/user-attachments/assets/3fc618b8-e4c4-4de2-a0b5-fd8380b22923" />

## Checklist

- [x] I have tested these changes on a running build
- [x] I have attached screenshots/recordings for any visual changes
- [x] I have not introduced App Group or grouped Keychain usage
- [x] I have added localization keys for any new user-facing strings