### PR TITLE
fix(profiles): refresh token on explicit switch — kill transient E1000

### DIFF
--- a/Claude Usage/MenuBar/MenuBarManager.swift
+++ b/Claude Usage/MenuBar/MenuBarManager.swift
@@ -1210,6 +1210,17 @@ class MenuBarManager: NSObject, ObservableObject {
             return try await apiService.fetchUsageData(oauthAccessToken: accessToken)
         }
 
+        // No usable live credential (e.g. a non-active profile whose CLI token expired and
+        // must not be refreshed independently — that would rotate a token another tool such as
+        // `cux` owns). Rather than surfacing a blocking "session key not found" dialog on every
+        // profile switch, fall back to the profile's last-known usage snapshot. Per-model weekly
+        // quotas (Fable/Opus/Sonnet) change slowly, so a slightly stale reading is far better UX
+        // than an error popup — and the active profile still refreshes live every cycle.
+        if let cached = profile.claudeUsage {
+            LoggingService.shared.log("fetchUsageForProfile: no live credential for '\(profile.name)'; showing last-known cached usage")
+            return cached
+        }
+
         throw AppError(
             code: .sessionKeyNotFound,
             message: "Missing credentials for profile '\(profile.name)'",

--- a/Claude Usage/Shared/Services/ClaudeCodeSyncService.swift
+++ b/Claude Usage/Shared/Services/ClaudeCodeSyncService.swift
@@ -1091,6 +1091,20 @@ class ClaudeCodeSyncService {
             return cliJSON
         }
 
+        // At this point the profile is EITHER pinned to a keychain entry (customSvc != nil)
+        // OR non-active & unpinned — the active/unpinned case already returned above via the
+        // system-keychain branch. For a non-active, unpinned profile the refresh_token lineage
+        // is owned by an external tool (e.g. the `cux` account switcher, or Claude Code's own
+        // keychain rotation). Refreshing here would consume that refresh token out from under
+        // the other tool, forcing its next use to fail with invalid_grant ("Please run /login").
+        // Never rotate a lineage we don't own: return the cached snapshot (even if expired) and
+        // let the display fall back to last-known usage. Pinned profiles are safe to refresh
+        // because we write the rotated tokens back to the shared keychain entry below.
+        if customSvc == nil {
+            LoggingService.shared.log("ensureFreshCredentials: '\(profile.name)' is non-active & unpinned; skipping refresh to avoid rotating an externally-owned token")
+            return cliJSON
+        }
+
         guard let refreshToken = extractRefreshToken(from: cliJSON) else {
             LoggingService.shared.log("ensureFreshCredentials: profile '\(profile.name)' has no refresh token; cannot auto-refresh")
             return nil

--- a/Claude Usage/Shared/Services/ClaudeCodeSyncService.swift
+++ b/Claude Usage/Shared/Services/ClaudeCodeSyncService.swift
@@ -1001,7 +1001,7 @@ class ClaudeCodeSyncService {
     /// On a successful refresh, the new credentials are written back to BOTH the profile's
     /// cached JSON AND (when applicable) the custom keychain entry, so Claude Code and the
     /// Tracker stay in sync.
-    func ensureFreshCredentials(for profileId: UUID) async -> String? {
+    func ensureFreshCredentials(for profileId: UUID, allowRotation: Bool = false) async -> String? {
         let profiles = ProfileStore.shared.loadProfiles()
         guard let profile = profiles.first(where: { $0.id == profileId }) else {
             return nil
@@ -1100,7 +1100,15 @@ class ClaudeCodeSyncService {
         // Never rotate a lineage we don't own: return the cached snapshot (even if expired) and
         // let the display fall back to last-known usage. Pinned profiles are safe to refresh
         // because we write the rotated tokens back to the shared keychain entry below.
-        if customSvc == nil {
+        // Exception: an *explicit* activation (allowRotation) must refresh even here.
+        // When the user switches to this profile, activateProfile() calls us before the
+        // profile becomes the active one, so it lands in this non-active branch. Skipping
+        // the refresh there applies a stale access token and surfaces a transient E1000
+        // ("session key not found") on every switch. Rotating is fine for an explicit
+        // switch — applyProfileCredentials writes the fresh token straight to the system
+        // keychain that Claude Code / cux read. Only *background* monitoring passes
+        // allowRotation=false to avoid churning idle accounts.
+        if customSvc == nil && !allowRotation {
             LoggingService.shared.log("ensureFreshCredentials: '\(profile.name)' is non-active & unpinned; skipping refresh to avoid rotating an externally-owned token")
             return cliJSON
         }

--- a/Claude Usage/Shared/Services/ProfileManager.swift
+++ b/Claude Usage/Shared/Services/ProfileManager.swift
@@ -224,7 +224,7 @@ class ProfileManager: ObservableObject {
             // keychain and Claude Code would 401 ("Please run /login"). This refreshes
             // via the refresh_token grant and persists the rotated tokens back to the
             // profile, so applyProfileCredentials below writes a valid token.
-            if let refreshed = await cliSyncService.ensureFreshCredentials(for: updatedProfile.id) {
+            if let refreshed = await cliSyncService.ensureFreshCredentials(for: updatedProfile.id, allowRotation: true) {
                 LoggingService.shared.log("✓ Ensured fresh credentials before apply for: \(updatedProfile.name)")
                 _ = refreshed
                 // Reload so applyProfileCredentials picks up the refreshed token.


### PR DESCRIPTION
Builds on #278 (includes its commit; will reduce to a single commit once #278 lands).

#278 skips refreshing non-active, unpinned profiles to avoid rotating an externally-owned refresh_token during background monitoring. But `activateProfile()` calls `ensureFreshCredentials` *before* the target becomes the active profile, so an explicit switch also landed in that skip branch: it applied the stale (expired) access token and surfaced a transient `E1000` ("session key not found") on every account switch, which cleared once the next background cycle refreshed it.

Add an `allowRotation` flag: `activateProfile` passes `true` so an explicit switch refreshes and applies a valid token immediately; background monitoring keeps the default (`false`) and still won't churn idle accounts.