### PR TITLE
fix(auto-start): don't restart a session window that is already open

### DIFF
--- a/Claude Usage/Shared/Services/AutoStartSessionService.swift
+++ b/Claude Usage/Shared/Services/AutoStartSessionService.swift
@@ -143,13 +143,20 @@ final class AutoStartSessionService {
 
         do {
             // Fetch current usage for this profile
-            let usage = try await fetchUsageForProfile(profile)
+            let (usage, hasOpenWindow) = try await fetchUsageForProfile(profile)
 
             let currentPercentage = usage.effectiveSessionPercentage
 
-            // Simple logic (like v1.1.0): If session is at 0%, start it
-            // The initialization message will bring usage above 0%, preventing repeated starts
-            if currentPercentage == 0.0 {
+            // A session window that is open but unused reads 0% — often for
+            // hours, because the initialization message (and light real usage)
+            // rounds down to zero. Starting one then spends a request, and
+            // leaves an empty conversation behind, to open something already
+            // running. The in-memory `lastCapturedResetTime` guard below covers
+            // the same run, but is lost across app restarts and never set for
+            // windows the user opened themselves. Gating on the live reset time
+            // from the API closes both gaps: only a window with no current
+            // `resets_at` is genuinely waiting to be opened.
+            if currentPercentage == 0.0 && !hasOpenWindow {
                 // Check if we recently auto-started and should wait for reset
                 if let lastResetTime = lastCapturedResetTime[profile.id],
                    Date() < lastResetTime {
@@ -165,7 +172,7 @@ final class AutoStartSessionService {
             } else {
                 // Session is active, clear any tracked reset time since usage endpoint is now showing correct data
                 lastCapturedResetTime.removeValue(forKey: profile.id)
-                LoggingService.shared.logDebug("Profile '\(profile.name)': session at \(currentPercentage)% (active)")
+                LoggingService.shared.logDebug("Profile '\(profile.name)': session at \(currentPercentage)% (window \(hasOpenWindow ? "open" : "closed"))")
             }
 
         } catch {
@@ -173,19 +180,19 @@ final class AutoStartSessionService {
         }
     }
 
-    private func fetchUsageForProfile(_ profile: Profile) async throws -> ClaudeUsage {
+    private func fetchUsageForProfile(_ profile: Profile) async throws -> (usage: ClaudeUsage, hasOpenWindow: Bool) {
         // Fetch usage data using the profile's specific credentials
-        let usage = try await fetchUsageData(for: profile)
+        let (usage, hasOpenWindow) = try await fetchUsageData(for: profile)
 
         // Save usage to profile
         await MainActor.run {
             profileManager.saveClaudeUsage(usage, for: profile.id)
         }
 
-        return usage
+        return (usage, hasOpenWindow)
     }
 
-    private func fetchUsageData(for profile: Profile) async throws -> ClaudeUsage {
+    private func fetchUsageData(for profile: Profile) async throws -> (usage: ClaudeUsage, hasOpenWindow: Bool) {
         // Get credentials from the specific profile
         guard let sessionKey = profile.claudeSessionKey,
               let orgId = profile.organizationId else {
@@ -222,10 +229,10 @@ final class AutoStartSessionService {
         }
 
         // Parse usage response
-        return try parseUsageResponse(data)
+        return try parseUsageResponse(data)  // (usage, hasOpenWindow)
     }
 
-    private func parseUsageResponse(_ data: Data) throws -> ClaudeUsage {
+    private func parseUsageResponse(_ data: Data) throws -> (usage: ClaudeUsage, hasOpenWindow: Bool) {
         guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
             throw AppError(code: .apiParsingFailed, message: "Failed to parse usage data", isRecoverable: false)
         }
@@ -233,6 +240,14 @@ final class AutoStartSessionService {
         // Extract session usage (five_hour)
         var sessionPercentage = 0.0
         var sessionResetTime = Date().addingTimeInterval(5 * 3600)
+
+        // Whether a window is currently open, as opposed to merely unused. The
+        // API omits `resets_at` when no window is running; when one is running
+        // it is present and in the future. Percentage alone cannot tell these
+        // apart, since an open window reads 0% until usage accrues past
+        // rounding. `sessionResetTime` above is synthesised when absent, so it
+        // cannot carry this signal — hence a separate flag.
+        var hasOpenWindow = false
 
         if let fiveHour = json["five_hour"] as? [String: Any] {
             if let utilization = fiveHour["utilization"] {
@@ -242,6 +257,7 @@ final class AutoStartSessionService {
                 let formatter = ISO8601DateFormatter()
                 formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
                 sessionResetTime = formatter.date(from: resetsAt) ?? sessionResetTime
+                hasOpenWindow = sessionResetTime > Date()
             }
         }
 
@@ -287,7 +303,7 @@ final class AutoStartSessionService {
         let opusTokens = Int(Double(weeklyLimit) * (opusPercentage / 100.0))
         let sonnetTokens = Int(Double(weeklyLimit) * (sonnetPercentage / 100.0))
 
-        return ClaudeUsage(
+        let usage = ClaudeUsage(
             sessionTokensUsed: 0,
             sessionLimit: 0,
             sessionPercentage: sessionPercentage,
@@ -313,6 +329,7 @@ final class AutoStartSessionService {
             lastUpdated: Date(),
             userTimezone: .current
         )
+        return (usage, hasOpenWindow)
     }
 
     private func parseUtilization(_ value: Any) -> Double {


### PR DESCRIPTION
## Problem

`AutoStartSessionService.checkProfile` treats a session utilization of 0% as "idle — open a window":

```swift
if currentPercentage == 0.0 {
    ...
    await autoStartSession(for: profile)
}
```

But an **open** window also reads 0% until usage accrues past rounding — the initialization message itself, and light real usage, round down to zero. So a window that is already running gets a redundant auto-start on the next check, which spends an initialization request and leaves an empty conversation behind to open something that is already open.

The existing `lastCapturedResetTime` guard mitigates this within a single run, but:

- it lives in an in-memory dictionary, so it is lost across app restarts — after a relaunch, an open-but-0% window triggers a redundant start;
- it is only set for windows this service opened, so a window the **user** opened themselves (then left near-idle) still triggers one.

## Fix

Gate the trigger on the live reset time from the usage API in addition to the percentage. The API omits `five_hour.resets_at` when no window is running; when one is running it is present and in the future. So its presence-and-in-the-future is a reliable "already open" signal:

```swift
if currentPercentage == 0.0 && !hasOpenWindow {
```

`ClaudeUsage.sessionResetTime` can't carry this signal because it is synthesised to `now + 5h` when the field is absent, so `parseUsageResponse` now returns a separate `hasOpenWindow` flag, threaded through the two private fetch helpers.

## Scope

- One file, +29 / −12.
- No public API change — `fetchUsageForProfile`, `fetchUsageData`, and `parseUsageResponse` are all `private` to the service.
- No behavioural change when a window is genuinely closed (no `resets_at`): the trigger fires exactly as before.

Found while running three auto-start profiles side by side; happy to adjust naming or fold the flag differently if you'd prefer.
