### PR TITLE
feat(menubar): Total Tokens metrics from Claude Code stats

### DIFF
--- a/Claude Usage/MenuBar/MenuBarIconRenderer.swift
+++ b/Claude Usage/MenuBar/MenuBarIconRenderer.swift
@@ -19,6 +19,7 @@ final class MenuBarIconRenderer {
         globalConfig: MenuBarIconConfiguration,
         usage: ClaudeUsage,
         apiUsage: APIUsage?,
+        tokenStats: TokenStats?,
         isDarkMode: Bool,
         colorMode: MenuBarColorMode,
         singleColorHex: String,
@@ -31,6 +32,7 @@ final class MenuBarIconRenderer {
             config: config,
             usage: usage,
             apiUsage: apiUsage,
+            tokenStats: tokenStats,
             showRemaining: globalConfig.showRemainingPercentage,
             usePaceColoring: globalConfig.usePaceColoring
         )
@@ -46,7 +48,7 @@ final class MenuBarIconRenderer {
 
         // Compute pace status from RAW values (not display-adjusted)
         let paceStatus: PaceStatus? = {
-            guard globalConfig.showPaceMarker, metricType != .api else { return nil }
+            guard globalConfig.showPaceMarker, metricType != .api, !metricType.isTokenMetric else { return nil }
             // Get raw elapsed fraction (always non-inverted)
             guard let rawElapsed = calculateTimeMarkerFraction(
                 metricType: metricType, usage: usage, showRemaining: false
@@ -69,6 +71,16 @@ final class MenuBarIconRenderer {
                 isDarkMode: isDarkMode,
                 colorMode: colorMode,
                 singleColorHex: singleColorHex,
+                showIconName: showIconName
+            )
+        }
+
+        // Token metrics are ALWAYS text-based numbers (no icon styles)
+        if metricType.isTokenMetric {
+            return createPrefixedTextStyle(
+                prefix: metricType.prefixText,
+                displayText: metricData.displayText,
+                isDarkMode: isDarkMode,
                 showIconName: showIconName
             )
         }
@@ -154,6 +166,7 @@ final class MenuBarIconRenderer {
         config: MetricIconConfig,
         usage: ClaudeUsage,
         apiUsage: APIUsage?,
+        tokenStats: TokenStats?,
         showRemaining: Bool,
         usePaceColoring: Bool = true
     ) -> MetricData {
@@ -252,6 +265,20 @@ final class MenuBarIconRenderer {
                 percentage: displayPercentage,
                 displayText: displayText,
                 statusLevel: statusLevel,
+                sessionResetTime: nil
+            )
+
+        case .tokensAllTime, .tokens7Days, .tokens30Days:
+            let text: String
+            if let stats = tokenStats, stats.isAvailable, let value = stats.value(for: metricType) {
+                text = FormatterHelper.abbreviatedCount(value)
+            } else {
+                text = "—"
+            }
+            return MetricData(
+                percentage: 0,
+                displayText: text,
+                statusLevel: .safe,
                 sessionResetTime: nil
             )
         }
@@ -684,13 +711,15 @@ final class MenuBarIconRenderer {
         return image
     }
 
-    // MARK: - API Text Style (Always Text-Based)
+    // MARK: - Prefixed Text Style (Always Text-Based)
 
-    private func createAPITextStyle(
-        metricData: MetricData,
+    /// Shared text-drawing routine for metrics that are always rendered as plain
+    /// text (API credits, token counts). `prefix` is only prepended when
+    /// `showIconName` is true.
+    private func createPrefixedTextStyle(
+        prefix: String,
+        displayText: String,
         isDarkMode: Bool,
-        colorMode: MenuBarColorMode,
-        singleColorHex: String,
         showIconName: Bool
     ) -> NSImage {
         let font = NSFont.systemFont(ofSize: 11, weight: .medium)
@@ -698,13 +727,7 @@ final class MenuBarIconRenderer {
         // Use isDarkMode to determine correct foreground color for menu bar
         let textColor: NSColor = menuBarForegroundColor(isDarkMode: isDarkMode)
 
-        var fullText = ""
-
-        if showIconName {
-            fullText = "API: \(metricData.displayText)"
-        } else {
-            fullText = metricData.displayText
-        }
+        let fullText = showIconName ? "\(prefix) \(displayText)" : displayText
 
         let attributes: [NSAttributedString.Key: Any] = [
             .font: font,
@@ -721,6 +744,21 @@ final class MenuBarIconRenderer {
         fullText.draw(at: NSPoint(x: 2, y: textY), withAttributes: attributes)
 
         return image
+    }
+
+    private func createAPITextStyle(
+        metricData: MetricData,
+        isDarkMode: Bool,
+        colorMode: MenuBarColorMode,
+        singleColorHex: String,
+        showIconName: Bool
+    ) -> NSImage {
+        return createPrefixedTextStyle(
+            prefix: "API:",
+            displayText: metricData.displayText,
+            isDarkMode: isDarkMode,
+            showIconName: showIconName
+        )
     }
 
     // MARK: - Multi-Profile Concentric Icon
@@ -1404,6 +1442,8 @@ final class MenuBarIconRenderer {
             resetTime = usage.weeklyResetTime
             duration = Constants.weeklyWindow
         case .api:
+            return nil
+        case .tokensAllTime, .tokens7Days, .tokens30Days:
             return nil
         }
 

--- a/Claude Usage/MenuBar/MenuBarIconRenderer.swift
+++ b/Claude Usage/MenuBar/MenuBarIconRenderer.swift
@@ -75,11 +75,11 @@ final class MenuBarIconRenderer {
             )
         }
 
-        // Token metrics are ALWAYS text-based numbers (no icon styles)
+        // Token metrics render as a stacked number (uppercase label above, number below)
         if metricType.isTokenMetric {
-            return createPrefixedTextStyle(
-                prefix: metricType.prefixText,
-                displayText: metricData.displayText,
+            return createStackedTokenStyle(
+                topLabel: metricType.tokenTopLabel,
+                bottomText: metricData.displayText,
                 isDarkMode: isDarkMode,
                 showIconName: showIconName
             )
@@ -759,6 +759,54 @@ final class MenuBarIconRenderer {
             isDarkMode: isDarkMode,
             showIconName: showIconName
         )
+    }
+
+    /// Renders a token metric as a compact vertical stack: a small uppercase
+    /// label on top and the abbreviated number below (CPU/RAM widget style).
+    /// Falls back to a single centered number line when the label is hidden.
+    private func createStackedTokenStyle(
+        topLabel: String,
+        bottomText: String,
+        isDarkMode: Bool,
+        showIconName: Bool
+    ) -> NSImage {
+        let textColor: NSColor = menuBarForegroundColor(isDarkMode: isDarkMode)
+
+        // Label hidden → single centered number line (matches other text styles).
+        guard showIconName else {
+            let font = NSFont.systemFont(ofSize: 11, weight: .medium)
+            let attrs: [NSAttributedString.Key: Any] = [.font: font, .foregroundColor: textColor]
+            let size = bottomText.size(withAttributes: attrs)
+            let image = NSImage(size: NSSize(width: size.width + 4, height: 18))
+            image.lockFocus()
+            defer { image.unlockFocus() }
+            bottomText.draw(at: NSPoint(x: 2, y: (18 - size.height) / 2), withAttributes: attrs)
+            return image
+        }
+
+        // Crisp, legible caption on top; larger number below (CPU/RAM widget style).
+        let labelFont = NSFont.systemFont(ofSize: 7.5, weight: .medium)
+        let valueFont = NSFont.systemFont(ofSize: 11, weight: .medium)
+        let labelAttrs: [NSAttributedString.Key: Any] = [.font: labelFont, .foregroundColor: textColor]
+        let valueAttrs: [NSAttributedString.Key: Any] = [.font: valueFont, .foregroundColor: textColor]
+
+        let labelSize = topLabel.size(withAttributes: labelAttrs)
+        let valueSize = bottomText.size(withAttributes: valueAttrs)
+
+        let height: CGFloat = 22
+        let width = max(labelSize.width, valueSize.width) + 4
+
+        let image = NSImage(size: NSSize(width: width, height: height))
+        image.lockFocus()
+        defer { image.unlockFocus() }
+
+        // Number sits at the bottom (larger, prominent); thin label hugs the top.
+        let labelY = height - labelSize.height + 0.5
+        let valueY: CGFloat = -0.5
+        topLabel.draw(at: NSPoint(x: (width - labelSize.width) / 2, y: labelY), withAttributes: labelAttrs)
+        bottomText.draw(at: NSPoint(x: (width - valueSize.width) / 2, y: valueY), withAttributes: valueAttrs)
+
+        return image
     }
 
     // MARK: - Multi-Profile Concentric Icon

--- a/Claude Usage/MenuBar/MenuBarManager.swift
+++ b/Claude Usage/MenuBar/MenuBarManager.swift
@@ -1443,8 +1443,9 @@ class MenuBarManager: NSObject, ObservableObject {
             }
 
             // Load Claude Code token stats (local stats-cache.json, not a network call)
+            let loadedTokenStats = self.tokenStatsService.load()
             await MainActor.run {
-                self.tokenStats = self.tokenStatsService.load()
+                self.tokenStats = loadedTokenStats
             }
 
             // Clear loading state

--- a/Claude Usage/MenuBar/MenuBarManager.swift
+++ b/Claude Usage/MenuBar/MenuBarManager.swift
@@ -1442,8 +1442,15 @@ class MenuBarManager: NSObject, ObservableObject {
                 }
             }
 
-            // Load Claude Code token stats (local stats-cache.json, not a network call)
-            let loadedTokenStats = self.tokenStatsService.load()
+            // Load Claude Code token stats (local files, not a network call).
+            // Only the enabled frames are computed, to bound the JSONL scan.
+            let enabledTokenFrames: Set<MenuBarMetricType> = await MainActor.run {
+                let cfg = self.profileManager.activeProfile?.iconConfig ?? .default
+                return Set(cfg.enabledMetrics.map { $0.metricType }.filter { $0.isTokenMetric })
+            }
+            let loadedTokenStats = enabledTokenFrames.isEmpty
+                ? TokenStats.unavailable
+                : self.tokenStatsService.load(enabledFrames: enabledTokenFrames)
             await MainActor.run {
                 self.tokenStats = loadedTokenStats
             }

--- a/Claude Usage/MenuBar/MenuBarManager.swift
+++ b/Claude Usage/MenuBar/MenuBarManager.swift
@@ -9,6 +9,8 @@ class MenuBarManager: NSObject, ObservableObject {
     @Published private(set) var usage: ClaudeUsage = .empty
     @Published private(set) var status: ClaudeStatus = .unknown
     @Published private(set) var apiUsage: APIUsage?
+    @Published private(set) var tokenStats: TokenStats?
+    private let tokenStatsService = TokenStatsService()
     @Published private(set) var isRefreshing: Bool = false
 
     // Error tracking for stale data / credential banners
@@ -735,7 +737,8 @@ class MenuBarManager: NSObject, ObservableObject {
             // Single profile mode - use the standard update
             statusBarUIManager?.updateAllButtons(
                 usage: usage,
-                apiUsage: apiUsage
+                apiUsage: apiUsage,
+                tokenStats: tokenStats
             )
         }
     }
@@ -745,7 +748,8 @@ class MenuBarManager: NSObject, ObservableObject {
         statusBarUIManager?.updateButton(
             for: metricType,
             usage: usage,
-            apiUsage: apiUsage
+            apiUsage: apiUsage,
+            tokenStats: tokenStats
         )
     }
 
@@ -1436,6 +1440,11 @@ class MenuBarManager: NSObject, ObservableObject {
 
                     LoggingService.shared.log("MenuBarManager: Failed to fetch API usage - [\(appError.code.rawValue)] \(appError.message)")
                 }
+            }
+
+            // Load Claude Code token stats (local stats-cache.json, not a network call)
+            await MainActor.run {
+                self.tokenStats = self.tokenStatsService.load()
             }
 
             // Clear loading state

--- a/Claude Usage/MenuBar/StatusBarUIManager.swift
+++ b/Claude Usage/MenuBar/StatusBarUIManager.swift
@@ -623,7 +623,8 @@ final class StatusBarUIManager {
     /// Updates all status bar buttons based on current usage data
     func updateAllButtons(
         usage: ClaudeUsage,
-        apiUsage: APIUsage?
+        apiUsage: APIUsage?,
+        tokenStats: TokenStats?
     ) {
         // Get config from active profile
         let profile = ProfileManager.shared.activeProfile
@@ -663,6 +664,7 @@ final class StatusBarUIManager {
                 globalConfig: config,
                 usage: usage,
                 apiUsage: apiUsage,
+                tokenStats: tokenStats,
                 isDarkMode: menuBarIsDark,
                 colorMode: config.colorMode,
                 singleColorHex: config.singleColorHex,
@@ -679,7 +681,8 @@ final class StatusBarUIManager {
     func updateButton(
         for metricType: MenuBarMetricType,
         usage: ClaudeUsage,
-        apiUsage: APIUsage?
+        apiUsage: APIUsage?,
+        tokenStats: TokenStats?
     ) {
         guard let statusItem = statusItems[metricType],
               let button = statusItem.button else {
@@ -702,6 +705,7 @@ final class StatusBarUIManager {
             globalConfig: config,
             usage: usage,
             apiUsage: apiUsage,
+            tokenStats: tokenStats,
             isDarkMode: menuBarIsDark,
             colorMode: config.colorMode,
             singleColorHex: config.singleColorHex,

--- a/Claude Usage/Shared/Models/MenuBarIconConfig.swift
+++ b/Claude Usage/Shared/Models/MenuBarIconConfig.swift
@@ -12,6 +12,9 @@ enum MenuBarMetricType: String, Codable, CaseIterable, Identifiable {
     case session
     case week
     case api
+    case tokensAllTime
+    case tokens7Days
+    case tokens30Days
 
     var id: String { rawValue }
 
@@ -23,6 +26,12 @@ enum MenuBarMetricType: String, Codable, CaseIterable, Identifiable {
             return "Week Usage"
         case .api:
             return "API Credits"
+        case .tokensAllTime:
+            return "Total Tokens (All Time)"
+        case .tokens7Days:
+            return "Total Tokens (7 Days)"
+        case .tokens30Days:
+            return "Total Tokens (30 Days)"
         }
     }
 
@@ -34,6 +43,12 @@ enum MenuBarMetricType: String, Codable, CaseIterable, Identifiable {
             return "W:"
         case .api:
             return "API:"
+        case .tokensAllTime:
+            return "∑"
+        case .tokens7Days:
+            return "7d"
+        case .tokens30Days:
+            return "30d"
         }
     }
 
@@ -45,6 +60,12 @@ enum MenuBarMetricType: String, Codable, CaseIterable, Identifiable {
             return "Weekly token usage (all models)"
         case .api:
             return "API Console billing credits"
+        case .tokensAllTime:
+            return "Claude Code lifetime tokens (input+output)"
+        case .tokens7Days:
+            return "Claude Code tokens, last 7 days"
+        case .tokens30Days:
+            return "Claude Code tokens, last 30 days"
         }
     }
 
@@ -56,6 +77,22 @@ enum MenuBarMetricType: String, Codable, CaseIterable, Identifiable {
             return "calendar.badge.clock"
         case .api:
             return "dollarsign.circle.fill"
+        case .tokensAllTime:
+            return "sum"
+        case .tokens7Days:
+            return "7.circle"
+        case .tokens30Days:
+            return "30.circle"
+        }
+    }
+
+    /// True for the numeric Claude Code token metrics (text-only, no bar styles).
+    var isTokenMetric: Bool {
+        switch self {
+        case .tokensAllTime, .tokens7Days, .tokens30Days:
+            return true
+        case .session, .week, .api:
+            return false
         }
     }
 }
@@ -219,6 +256,21 @@ struct MetricIconConfig: Codable, Equatable {
             apiDisplayMode: .remaining
         )
     }
+
+    /// Default config for total tokens - all time (disabled by default)
+    static var tokensAllTimeDefault: MetricIconConfig {
+        MetricIconConfig(metricType: .tokensAllTime, isEnabled: false, iconStyle: .percentageOnly, order: 3)
+    }
+
+    /// Default config for total tokens - 7 days (disabled by default)
+    static var tokens7DaysDefault: MetricIconConfig {
+        MetricIconConfig(metricType: .tokens7Days, isEnabled: false, iconStyle: .percentageOnly, order: 4)
+    }
+
+    /// Default config for total tokens - 30 days (disabled by default)
+    static var tokens30DaysDefault: MetricIconConfig {
+        MetricIconConfig(metricType: .tokens30Days, isEnabled: false, iconStyle: .percentageOnly, order: 5)
+    }
 }
 
 /// Icon style for multi-profile display
@@ -372,7 +424,10 @@ struct MenuBarIconConfiguration: Codable, Equatable {
         metrics: [MetricIconConfig] = [
             .sessionDefault,
             .weekDefault,
-            .apiDefault
+            .apiDefault,
+            .tokensAllTimeDefault,
+            .tokens7DaysDefault,
+            .tokens30DaysDefault
         ]
     ) {
         self.colorMode = colorMode
@@ -416,6 +471,11 @@ struct MenuBarIconConfiguration: Codable, Equatable {
         showPaceMarker = try container.decodeIfPresent(Bool.self, forKey: .showPaceMarker) ?? false
         usePaceColoring = try container.decodeIfPresent(Bool.self, forKey: .usePaceColoring) ?? false
         metrics = try container.decode([MetricIconConfig].self, forKey: .metrics)
+        // Backfill token metrics for configs saved before this feature existed.
+        let tokenDefaults: [MetricIconConfig] = [.tokensAllTimeDefault, .tokens7DaysDefault, .tokens30DaysDefault]
+        for def in tokenDefaults where !metrics.contains(where: { $0.metricType == def.metricType }) {
+            metrics.append(def)
+        }
     }
 
     func encode(to encoder: Encoder) throws {

--- a/Claude Usage/Shared/Models/MenuBarIconConfig.swift
+++ b/Claude Usage/Shared/Models/MenuBarIconConfig.swift
@@ -95,6 +95,20 @@ enum MenuBarMetricType: String, Codable, CaseIterable, Identifiable {
             return false
         }
     }
+
+    /// Uppercase caption drawn above the number for stacked token metrics (CPU/RAM widget style).
+    var tokenTopLabel: String {
+        switch self {
+        case .tokensAllTime:
+            return "ALL"
+        case .tokens7Days:
+            return "7D"
+        case .tokens30Days:
+            return "30D"
+        case .session, .week, .api:
+            return prefixText
+        }
+    }
 }
 
 /// Color mode for menu bar icons

--- a/Claude Usage/Shared/Models/TokenStats.swift
+++ b/Claude Usage/Shared/Models/TokenStats.swift
@@ -9,4 +9,14 @@ struct TokenStats: Codable, Equatable {
     let isAvailable: Bool
 
     static let unavailable = TokenStats(allTime: 0, last7Days: 0, last30Days: 0, isAvailable: false)
+
+    /// Token count for a token metric type, or nil for non-token metrics.
+    func value(for metricType: MenuBarMetricType) -> Int? {
+        switch metricType {
+        case .tokensAllTime: return allTime
+        case .tokens7Days: return last7Days
+        case .tokens30Days: return last30Days
+        case .session, .week, .api: return nil
+        }
+    }
 }

--- a/Claude Usage/Shared/Models/TokenStats.swift
+++ b/Claude Usage/Shared/Models/TokenStats.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+/// Aggregated Claude Code CLI token totals (input + output, excluding cache).
+struct TokenStats: Codable, Equatable {
+    let allTime: Int
+    let last7Days: Int
+    let last30Days: Int
+    /// False when the local stats cache is absent or unreadable.
+    let isAvailable: Bool
+
+    static let unavailable = TokenStats(allTime: 0, last7Days: 0, last30Days: 0, isAvailable: false)
+}

--- a/Claude Usage/Shared/Services/TokenStatsService.swift
+++ b/Claude Usage/Shared/Services/TokenStatsService.swift
@@ -158,6 +158,18 @@ struct TokenStatsService {
             return (0, [:], nil, false)
         }
 
+        let lastComputed = cache.lastComputedDate
+            .flatMap { Self.dayFormatter.date(from: $0) }
+            .map(startOfDay)
+
+        // Without a valid cutoff we can't safely combine cache aggregates with a JSONL delta
+        // (every day would route to JSONL while the cache's lifetime total still got added,
+        // double-counting everything). Fail safe to pure JSONL: report no cache aggregates, and
+        // let cacheAvailable be false so availability falls through to "did JSONL parse anything."
+        guard let lastComputed else {
+            return (0, [:], nil, false)
+        }
+
         let allTime = (cache.modelUsage ?? [:]).values.reduce(0) {
             $0 + ($1.inputTokens ?? 0) + ($1.outputTokens ?? 0)
         }
@@ -166,10 +178,6 @@ struct TokenStatsService {
         for entry in cache.dailyModelTokens ?? [] {
             daily[entry.date, default: 0] += entry.tokensByModel.values.reduce(0, +)
         }
-
-        let lastComputed = cache.lastComputedDate
-            .flatMap { Self.dayFormatter.date(from: $0) }
-            .map(startOfDay)
 
         return (allTime, daily, lastComputed, true)
     }
@@ -205,6 +213,8 @@ struct TokenStatsService {
         for case let fileURL as URL in enumerator {
             guard fileURL.pathExtension == "jsonl" else { continue }
 
+            // Assumes a JSONL file's mtime tracks its latest appended line (true for normal CLI
+            // writes); an externally-reset mtime could under-scan.
             if let values = try? fileURL.resourceValues(forKeys: [.contentModificationDateKey]),
                let mtime = values.contentModificationDate,
                mtime < scanFrom {

--- a/Claude Usage/Shared/Services/TokenStatsService.swift
+++ b/Claude Usage/Shared/Services/TokenStatsService.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// Reads and aggregates Claude Code CLI token usage from `~/.claude/stats-cache.json`.
+struct TokenStatsService {
+
+    private struct Cache: Decodable {
+        struct Model: Decodable {
+            let inputTokens: Int?
+            let outputTokens: Int?
+        }
+        struct Daily: Decodable {
+            let date: String
+            let tokensByModel: [String: Int]
+        }
+        let modelUsage: [String: Model]?
+        let dailyModelTokens: [Daily]?
+    }
+
+    /// Loads token stats. Returns `.unavailable` if the file is missing or unreadable.
+    func load(from url: URL = Constants.ClaudePaths.statsCacheFile, referenceDate: Date = Date()) -> TokenStats {
+        guard let data = try? Data(contentsOf: url),
+              let cache = try? JSONDecoder().decode(Cache.self, from: data) else {
+            return .unavailable
+        }
+
+        // All-time: sum input + output across models (exclude cache tokens).
+        let allTime = (cache.modelUsage ?? [:]).values.reduce(0) {
+            $0 + ($1.inputTokens ?? 0) + ($1.outputTokens ?? 0)
+        }
+
+        // Windows from daily per-model token sums.
+        let daily = cache.dailyModelTokens ?? []
+        let last7Days = sumWindow(daily, days: 7, referenceDate: referenceDate)
+        let last30Days = sumWindow(daily, days: 30, referenceDate: referenceDate)
+
+        return TokenStats(allTime: allTime, last7Days: last7Days, last30Days: last30Days, isAvailable: true)
+    }
+
+    private func sumWindow(_ daily: [Cache.Daily], days: Int, referenceDate: Date) -> Int {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = .current
+        let formatter = DateFormatter()
+        formatter.calendar = calendar
+        formatter.timeZone = .current
+        formatter.dateFormat = "yyyy-MM-dd"
+
+        let today = calendar.startOfDay(for: referenceDate)
+        guard let cutoff = calendar.date(byAdding: .day, value: -(days - 1), to: today) else { return 0 }
+
+        return daily.reduce(0) { acc, entry in
+            guard let d = formatter.date(from: entry.date) else { return acc }
+            let day = calendar.startOfDay(for: d)
+            guard day >= cutoff && day <= today else { return acc }
+            return acc + entry.tokensByModel.values.reduce(0, +)
+        }
+    }
+}

--- a/Claude Usage/Shared/Services/TokenStatsService.swift
+++ b/Claude Usage/Shared/Services/TokenStatsService.swift
@@ -1,7 +1,16 @@
 import Foundation
 
-/// Reads and aggregates Claude Code CLI token usage (input + output tokens, excluding all
-/// cache tokens) to match what `claude`'s live "Stats" view reports.
+/// Reads and aggregates Claude Code CLI token usage to match what `claude`'s live "Stats" view
+/// reports: input + output + cache-read + cache-creation tokens.
+///
+/// Including cache tokens is what the CLI does, not an editorial choice. CLI 2.1.221 changed
+/// `stats-cache.json`'s `dailyModelTokens` from `input + output` to all four kinds, and added a
+/// `dailyModelTokensVersion` field whose bump makes the CLI rebuild that history under the new
+/// definition. Since `dailyModelTokens` is the only per-day source available, the 7D/30D windows
+/// are cache-inclusive whether we like it or not - so the all-time aggregate and the JSONL delta
+/// must count the same four kinds, or the frames would report different quantities and a 7-day
+/// window could exceed all-time. Cache reads dominate the total (often >90%); this is a volume
+/// figure, not a proxy for cost, since cache reads bill at a fraction of input tokens.
 ///
 /// `~/.claude/stats-cache.json` is only refreshed periodically by the CLI, so reading it alone
 /// lags behind the live number by however many days have passed since its `lastComputedDate`.
@@ -22,6 +31,13 @@ struct TokenStatsService {
         struct Model: Decodable {
             let inputTokens: Int?
             let outputTokens: Int?
+            let cacheReadInputTokens: Int?
+            let cacheCreationInputTokens: Int?
+
+            var total: Int {
+                (inputTokens ?? 0) + (outputTokens ?? 0)
+                    + (cacheReadInputTokens ?? 0) + (cacheCreationInputTokens ?? 0)
+            }
         }
         struct Daily: Decodable {
             let date: String
@@ -42,6 +58,13 @@ struct TokenStatsService {
             struct Usage: Decodable {
                 let inputTokens: Int?
                 let outputTokens: Int?
+                let cacheReadInputTokens: Int?
+                let cacheCreationInputTokens: Int?
+
+                var total: Int {
+                    (inputTokens ?? 0) + (outputTokens ?? 0)
+                        + (cacheReadInputTokens ?? 0) + (cacheCreationInputTokens ?? 0)
+                }
             }
             let usage: Usage?
         }
@@ -170,9 +193,7 @@ struct TokenStatsService {
             return (0, [:], nil, false)
         }
 
-        let allTime = (cache.modelUsage ?? [:]).values.reduce(0) {
-            $0 + ($1.inputTokens ?? 0) + ($1.outputTokens ?? 0)
-        }
+        let allTime = (cache.modelUsage ?? [:]).values.reduce(0) { $0 + $1.total }
 
         var daily: [String: Int] = [:]
         for entry in cache.dailyModelTokens ?? [] {
@@ -184,7 +205,7 @@ struct TokenStatsService {
 
     // MARK: - JSONL scanning
 
-    /// Walks `projectsDir` for `*.jsonl` files and sums input+output tokens per day, restricted
+    /// Walks `projectsDir` for `*.jsonl` files and sums all four token kinds per day, restricted
     /// to days strictly after `cacheCutoff`, within `[scanFrom, today]`.
     ///
     /// Perf: files whose content-modification date predates `scanFrom` are skipped without being
@@ -235,7 +256,7 @@ struct TokenStatsService {
 
                 guard day > cacheCutoff, day >= scanFrom, day <= today else { continue }
 
-                daily[dayKey(day), default: 0] += (usage.inputTokens ?? 0) + (usage.outputTokens ?? 0)
+                daily[dayKey(day), default: 0] += usage.total
             }
         }
 

--- a/Claude Usage/Shared/Services/TokenStatsService.swift
+++ b/Claude Usage/Shared/Services/TokenStatsService.swift
@@ -1,7 +1,22 @@
 import Foundation
 
-/// Reads and aggregates Claude Code CLI token usage from `~/.claude/stats-cache.json`.
+/// Reads and aggregates Claude Code CLI token usage (input + output tokens, excluding all
+/// cache tokens) to match what `claude`'s live "Stats" view reports.
+///
+/// `~/.claude/stats-cache.json` is only refreshed periodically by the CLI, so reading it alone
+/// lags behind the live number by however many days have passed since its `lastComputedDate`.
+/// The CLI's live total is effectively:
+///
+///     cache totals (authoritative through lastComputedDate)
+///   + input/output tokens from the raw JSONL session logs for days AFTER lastComputedDate
+///
+/// This service reproduces that by treating `lastComputedDate` as a cutoff: days on/before it
+/// are read from the cache (cheap), and only days after it are recomputed from
+/// `~/.claude/projects/**/*.jsonl` (comparatively expensive). To bound that JSONL work, only the
+/// time frames present in `enabledFrames` are scanned for; the rest are left at 0.
 struct TokenStatsService {
+
+    // MARK: - stats-cache.json decoding
 
     private struct Cache: Decodable {
         struct Model: Decodable {
@@ -14,44 +29,226 @@ struct TokenStatsService {
         }
         let modelUsage: [String: Model]?
         let dailyModelTokens: [Daily]?
+        /// "yyyy-MM-dd" - the day through which the cache's totals are authoritative.
+        let lastComputedDate: String?
     }
 
-    /// Loads token stats. Returns `.unavailable` if the file is missing or unreadable.
-    func load(from url: URL = Constants.ClaudePaths.statsCacheFile, referenceDate: Date = Date()) -> TokenStats {
-        guard let data = try? Data(contentsOf: url),
-              let cache = try? JSONDecoder().decode(Cache.self, from: data) else {
-            return .unavailable
+    // MARK: - JSONL line decoding
+
+    /// Minimal shape of one assistant line in a `~/.claude/projects/**/*.jsonl` session file.
+    /// Decoded with `.convertFromSnakeCase` so `input_tokens`/`output_tokens` map directly.
+    private struct Line: Decodable {
+        struct Message: Decodable {
+            struct Usage: Decodable {
+                let inputTokens: Int?
+                let outputTokens: Int?
+            }
+            let usage: Usage?
         }
-
-        // All-time: sum input + output across models (exclude cache tokens).
-        let allTime = (cache.modelUsage ?? [:]).values.reduce(0) {
-            $0 + ($1.inputTokens ?? 0) + ($1.outputTokens ?? 0)
-        }
-
-        // Windows from daily per-model token sums.
-        let daily = cache.dailyModelTokens ?? []
-        let last7Days = sumWindow(daily, days: 7, referenceDate: referenceDate)
-        let last30Days = sumWindow(daily, days: 30, referenceDate: referenceDate)
-
-        return TokenStats(allTime: allTime, last7Days: last7Days, last30Days: last30Days, isAvailable: true)
+        let message: Message?
+        let timestamp: String?
     }
 
-    private func sumWindow(_ daily: [Cache.Daily], days: Int, referenceDate: Date) -> Int {
-        var calendar = Calendar(identifier: .gregorian)
-        calendar.timeZone = .current
+    // MARK: - Calendar / date-key helpers
+
+    private static let calendar: Calendar = {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = .current
+        return cal
+    }()
+
+    private static let dayFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.calendar = calendar
         formatter.timeZone = .current
         formatter.dateFormat = "yyyy-MM-dd"
+        return formatter
+    }()
 
-        let today = calendar.startOfDay(for: referenceDate)
-        guard let cutoff = calendar.date(byAdding: .day, value: -(days - 1), to: today) else { return 0 }
+    private func startOfDay(_ date: Date) -> Date {
+        Self.calendar.startOfDay(for: date)
+    }
 
-        return daily.reduce(0) { acc, entry in
-            guard let d = formatter.date(from: entry.date) else { return acc }
-            let day = calendar.startOfDay(for: d)
-            guard day >= cutoff && day <= today else { return acc }
-            return acc + entry.tokensByModel.values.reduce(0, +)
+    private func dayKey(_ date: Date) -> String {
+        Self.dayFormatter.string(from: date)
+    }
+
+    private func dayAfter(_ date: Date) -> Date {
+        Self.calendar.date(byAdding: .day, value: 1, to: date) ?? date
+    }
+
+    /// Parses the "yyyy-MM-dd" prefix of an ISO8601 timestamp into a start-of-day `Date`.
+    private func dayFromTimestamp(_ timestamp: String) -> Date? {
+        guard timestamp.count >= 10 else { return nil }
+        guard let date = Self.dayFormatter.date(from: String(timestamp.prefix(10))) else { return nil }
+        return startOfDay(date)
+    }
+
+    // MARK: - Public API
+
+    /// Loads token stats for exactly the requested frames.
+    ///
+    /// - Parameters:
+    ///   - enabledFrames: Menu-bar metrics currently enabled. Non-token metrics are ignored.
+    ///     Frames not present here are left at 0 - this is the load-reduction that keeps the
+    ///     JSONL scan bounded to only what's actually displayed.
+    /// - Returns: `.unavailable` when neither the cache nor any JSONL file could be read, or
+    ///   when no token frame is enabled.
+    func load(
+        enabledFrames: Set<MenuBarMetricType>,
+        statsURL: URL = Constants.ClaudePaths.statsCacheFile,
+        projectsDir: URL = Constants.ClaudePaths.projectsDirectory,
+        referenceDate: Date = Date()
+    ) -> TokenStats {
+        let tokenFrames = enabledFrames.filter { $0.isTokenMetric }
+        guard !tokenFrames.isEmpty else { return .unavailable }
+
+        let (cacheAllTime, cacheDaily, lastComputed, cacheAvailable) = readCache(from: statsURL)
+        let today = startOfDay(referenceDate)
+
+        // Days on/before this are authoritative in the cache; days after it need JSONL.
+        // With no usable cache, .distantPast means "nothing is covered - everything from JSONL".
+        let cacheCutoff = lastComputed ?? .distantPast
+
+        // Lower bound for the JSONL scan: the earliest day any enabled frame still needs.
+        // All-time needs every day after the cutoff (the widest possible need), which also
+        // covers any window frame enabled alongside it.
+        let scanFrom: Date
+        if tokenFrames.contains(.tokensAllTime) {
+            scanFrom = dayAfter(cacheCutoff)
+        } else {
+            let maxWindow = tokenFrames.contains(.tokens30Days) ? 30 : 7
+            let windowStart = Self.calendar.date(byAdding: .day, value: -(maxWindow - 1), to: today) ?? today
+            scanFrom = max(dayAfter(cacheCutoff), windowStart)
         }
+
+        let (deltaDaily, anyJSONLParsed) = scanJSONL(
+            projectsDir: projectsDir,
+            cacheCutoff: cacheCutoff,
+            scanFrom: scanFrom,
+            today: today
+        )
+
+        var allTime = 0
+        var last7Days = 0
+        var last30Days = 0
+
+        if tokenFrames.contains(.tokensAllTime) {
+            // deltaDaily only holds days > cacheCutoff (scanFrom = dayAfter(cutoff) above), so
+            // its full sum is exactly the "days after the cache" contribution.
+            allTime = cacheAllTime + deltaDaily.values.reduce(0, +)
+        }
+        if tokenFrames.contains(.tokens7Days) {
+            last7Days = windowSum(days: 7, today: today, cacheCutoff: cacheCutoff, cacheDaily: cacheDaily, deltaDaily: deltaDaily)
+        }
+        if tokenFrames.contains(.tokens30Days) {
+            last30Days = windowSum(days: 30, today: today, cacheCutoff: cacheCutoff, cacheDaily: cacheDaily, deltaDaily: deltaDaily)
+        }
+
+        guard cacheAvailable || anyJSONLParsed else { return .unavailable }
+
+        return TokenStats(allTime: allTime, last7Days: last7Days, last30Days: last30Days, isAvailable: true)
+    }
+
+    // MARK: - Cache reading
+
+    private func readCache(from url: URL) -> (allTime: Int, daily: [String: Int], lastComputed: Date?, available: Bool) {
+        guard let data = try? Data(contentsOf: url),
+              let cache = try? JSONDecoder().decode(Cache.self, from: data) else {
+            return (0, [:], nil, false)
+        }
+
+        let allTime = (cache.modelUsage ?? [:]).values.reduce(0) {
+            $0 + ($1.inputTokens ?? 0) + ($1.outputTokens ?? 0)
+        }
+
+        var daily: [String: Int] = [:]
+        for entry in cache.dailyModelTokens ?? [] {
+            daily[entry.date, default: 0] += entry.tokensByModel.values.reduce(0, +)
+        }
+
+        let lastComputed = cache.lastComputedDate
+            .flatMap { Self.dayFormatter.date(from: $0) }
+            .map(startOfDay)
+
+        return (allTime, daily, lastComputed, true)
+    }
+
+    // MARK: - JSONL scanning
+
+    /// Walks `projectsDir` for `*.jsonl` files and sums input+output tokens per day, restricted
+    /// to days strictly after `cacheCutoff`, within `[scanFrom, today]`.
+    ///
+    /// Perf: files whose content-modification date predates `scanFrom` are skipped without being
+    /// opened. A JSONL file only gains lines for a given day when the CLI writes them that day,
+    /// so if its mtime is older than `scanFrom` it cannot contain any line we need.
+    private func scanJSONL(
+        projectsDir: URL,
+        cacheCutoff: Date,
+        scanFrom: Date,
+        today: Date
+    ) -> (daily: [String: Int], anyParsed: Bool) {
+        var daily: [String: Int] = [:]
+        var anyParsed = false
+
+        guard let enumerator = FileManager.default.enumerator(
+            at: projectsDir,
+            includingPropertiesForKeys: [.contentModificationDateKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return (daily, false)
+        }
+
+        let lineDecoder = JSONDecoder()
+        lineDecoder.keyDecodingStrategy = .convertFromSnakeCase
+
+        for case let fileURL as URL in enumerator {
+            guard fileURL.pathExtension == "jsonl" else { continue }
+
+            if let values = try? fileURL.resourceValues(forKeys: [.contentModificationDateKey]),
+               let mtime = values.contentModificationDate,
+               mtime < scanFrom {
+                continue
+            }
+
+            guard let content = try? String(contentsOf: fileURL, encoding: .utf8) else { continue }
+            anyParsed = true
+
+            for rawLine in content.split(separator: "\n") {
+                // Cheap pre-filter before paying for JSON decoding.
+                guard rawLine.contains("\"usage\""), let lineData = rawLine.data(using: .utf8) else { continue }
+
+                guard let line = try? lineDecoder.decode(Line.self, from: lineData),
+                      let usage = line.message?.usage,
+                      let timestamp = line.timestamp,
+                      let day = dayFromTimestamp(timestamp) else { continue }
+
+                guard day > cacheCutoff, day >= scanFrom, day <= today else { continue }
+
+                daily[dayKey(day), default: 0] += (usage.inputTokens ?? 0) + (usage.outputTokens ?? 0)
+            }
+        }
+
+        return (daily, anyParsed)
+    }
+
+    // MARK: - Window aggregation
+
+    /// Sums the trailing `days`-day window ending at `today`, taking each day from the cache
+    /// when it's on/before `cacheCutoff`, or from the JSONL delta otherwise.
+    private func windowSum(
+        days: Int,
+        today: Date,
+        cacheCutoff: Date,
+        cacheDaily: [String: Int],
+        deltaDaily: [String: Int]
+    ) -> Int {
+        var total = 0
+        for offset in 0..<days {
+            guard let day = Self.calendar.date(byAdding: .day, value: -offset, to: today) else { continue }
+            let key = dayKey(day)
+            total += day <= cacheCutoff ? (cacheDaily[key] ?? 0) : (deltaDaily[key] ?? 0)
+        }
+        return total
     }
 }

--- a/Claude Usage/Shared/Utilities/Constants.swift
+++ b/Claude Usage/Shared/Utilities/Constants.swift
@@ -107,6 +107,10 @@ enum Constants {
             claudeDirectory.appendingPathComponent(".credentials.json")
         }
 
+        static var statsCacheFile: URL {
+            claudeDirectory.appendingPathComponent("stats-cache.json")
+        }
+
         /// Candidate paths for Claude Code's main config file (`.claude.json`),
         /// which holds `oauthAccount` (email, accountUuid, organizationName, etc.)
         /// Claude Code historically stores this at `~/.claude.json`, but when

--- a/Claude Usage/Shared/Utilities/FormatterHelper.swift
+++ b/Claude Usage/Shared/Utilities/FormatterHelper.swift
@@ -9,4 +9,20 @@ enum FormatterHelper {
         formatter.dateTimeStyle = .named
         return formatter.localizedString(for: resetDate, relativeTo: Date())
     }
+
+    /// Abbreviates a non-negative count as K/M/B with one decimal (trailing .0 trimmed).
+    /// e.g. 21_062_418 -> "21.1M", 1_000 -> "1K", 999 -> "999".
+    static func abbreviatedCount(_ n: Int) -> String {
+        func format(_ value: Double, _ suffix: String) -> String {
+            if value.truncatingRemainder(dividingBy: 1.0) == 0 {
+                return "\(Int(value))\(suffix)"
+            }
+            return String(format: "%.1f%@", value, suffix)
+        }
+        let v = Double(n)
+        if n >= 1_000_000_000 { return format(v / 1_000_000_000, "B") }
+        if n >= 1_000_000 { return format(v / 1_000_000, "M") }
+        if n >= 1_000 { return format(v / 1_000, "K") }
+        return "\(n)"
+    }
 }

--- a/Claude Usage/Shared/Utilities/FormatterHelper.swift
+++ b/Claude Usage/Shared/Utilities/FormatterHelper.swift
@@ -14,15 +14,36 @@ enum FormatterHelper {
     /// e.g. 21_062_418 -> "21.1M", 1_000 -> "1K", 999 -> "999".
     static func abbreviatedCount(_ n: Int) -> String {
         func format(_ value: Double, _ suffix: String) -> String {
-            if value.truncatingRemainder(dividingBy: 1.0) == 0 {
-                return "\(Int(value))\(suffix)"
+            let rounded = round(value * 10) / 10
+            if rounded.truncatingRemainder(dividingBy: 1.0) == 0 {
+                return "\(Int(rounded))\(suffix)"
             }
             return String(format: "%.1f%@", value, suffix)
         }
         let v = Double(n)
-        if n >= 1_000_000_000 { return format(v / 1_000_000_000, "B") }
-        if n >= 1_000_000 { return format(v / 1_000_000, "M") }
-        if n >= 1_000 { return format(v / 1_000, "K") }
+
+        if n >= 1_000_000_000 {
+            return format(v / 1_000_000_000, "B")
+        }
+
+        if n >= 1_000_000 {
+            let valueInThisTier = v / 1_000_000
+            // If value would be >= 999.5 (approaches 1000), promote to B to avoid "1000.0M"
+            if valueInThisTier >= 999.5 {
+                return format(v / 1_000_000_000, "B")
+            }
+            return format(valueInThisTier, "M")
+        }
+
+        if n >= 1_000 {
+            let valueInThisTier = v / 1_000
+            // If value would be >= 999.5 (approaches 1000), promote to M to avoid "1000.0K"
+            if valueInThisTier >= 999.5 {
+                return format(v / 1_000_000, "M")
+            }
+            return format(valueInThisTier, "K")
+        }
+
         return "\(n)"
     }
 }

--- a/Claude Usage/Views/Settings/Components/MetricIconCard.swift
+++ b/Claude Usage/Views/Settings/Components/MetricIconCard.swift
@@ -46,7 +46,7 @@ struct MetricIconCard: View {
 
             if config.isEnabled {
                 // Icon style selector (only for Session and Week, not API)
-                if metricType != .api {
+                if metricType != .api && !metricType.isTokenMetric {
                     Divider()
                         .padding(.vertical, Spacing.xs)
 

--- a/Claude Usage/Views/Settings/Profile/AppearanceSettingsView.swift
+++ b/Claude Usage/Views/Settings/Profile/AppearanceSettingsView.swift
@@ -190,6 +190,42 @@ struct AppearanceSettingsView: View {
                                 onConfigChanged: { saveConfiguration() }
                             )
                         }
+
+                        // Total Tokens - All Time
+                        if let idx = configuration.metrics.firstIndex(where: { $0.metricType == .tokensAllTime }) {
+                            MetricIconCard(
+                                metricType: .tokensAllTime,
+                                config: Binding(
+                                    get: { configuration.metrics[idx] },
+                                    set: { newValue in configuration.metrics[idx] = newValue }
+                                ),
+                                onConfigChanged: { saveConfiguration() }
+                            )
+                        }
+
+                        // Total Tokens - 7 Days
+                        if let idx = configuration.metrics.firstIndex(where: { $0.metricType == .tokens7Days }) {
+                            MetricIconCard(
+                                metricType: .tokens7Days,
+                                config: Binding(
+                                    get: { configuration.metrics[idx] },
+                                    set: { newValue in configuration.metrics[idx] = newValue }
+                                ),
+                                onConfigChanged: { saveConfiguration() }
+                            )
+                        }
+
+                        // Total Tokens - 30 Days
+                        if let idx = configuration.metrics.firstIndex(where: { $0.metricType == .tokens30Days }) {
+                            MetricIconCard(
+                                metricType: .tokens30Days,
+                                config: Binding(
+                                    get: { configuration.metrics[idx] },
+                                    set: { newValue in configuration.metrics[idx] = newValue }
+                                ),
+                                onConfigChanged: { saveConfiguration() }
+                            )
+                        }
                     }
                 }
                 .disabled(isMultiProfileMode)

--- a/Claude UsageTests/FormatterHelperTests.swift
+++ b/Claude UsageTests/FormatterHelperTests.swift
@@ -10,5 +10,8 @@ final class FormatterHelperTests: XCTestCase {
         XCTAssertEqual(FormatterHelper.abbreviatedCount(21_062_418), "21.1M")
         XCTAssertEqual(FormatterHelper.abbreviatedCount(10_000_000), "10M")
         XCTAssertEqual(FormatterHelper.abbreviatedCount(1_200_000_000), "1.2B")
+        XCTAssertEqual(FormatterHelper.abbreviatedCount(999_500), "1M")
+        XCTAssertEqual(FormatterHelper.abbreviatedCount(999_999), "1M")
+        XCTAssertEqual(FormatterHelper.abbreviatedCount(999_950_000), "1B")
     }
 }

--- a/Claude UsageTests/FormatterHelperTests.swift
+++ b/Claude UsageTests/FormatterHelperTests.swift
@@ -1,0 +1,14 @@
+import XCTest
+@testable import Claude_Usage
+
+final class FormatterHelperTests: XCTestCase {
+    func testAbbreviatedCount() {
+        XCTAssertEqual(FormatterHelper.abbreviatedCount(0), "0")
+        XCTAssertEqual(FormatterHelper.abbreviatedCount(999), "999")
+        XCTAssertEqual(FormatterHelper.abbreviatedCount(1_000), "1K")
+        XCTAssertEqual(FormatterHelper.abbreviatedCount(1_500), "1.5K")
+        XCTAssertEqual(FormatterHelper.abbreviatedCount(21_062_418), "21.1M")
+        XCTAssertEqual(FormatterHelper.abbreviatedCount(10_000_000), "10M")
+        XCTAssertEqual(FormatterHelper.abbreviatedCount(1_200_000_000), "1.2B")
+    }
+}

--- a/Claude UsageTests/MenuBarTokenMetricTests.swift
+++ b/Claude UsageTests/MenuBarTokenMetricTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+@testable import Claude_Usage
+
+final class MenuBarTokenMetricTests: XCTestCase {
+
+    func testTokenMetricCasesExist() {
+        XCTAssertEqual(MenuBarMetricType(rawValue: "tokensAllTime"), .tokensAllTime)
+        XCTAssertEqual(MenuBarMetricType(rawValue: "tokens7Days"), .tokens7Days)
+        XCTAssertEqual(MenuBarMetricType(rawValue: "tokens30Days"), .tokens30Days)
+    }
+
+    func testTokenMetricProperties() {
+        XCTAssertEqual(MenuBarMetricType.tokensAllTime.prefixText, "∑")
+        XCTAssertEqual(MenuBarMetricType.tokens7Days.prefixText, "7d")
+        XCTAssertEqual(MenuBarMetricType.tokens30Days.prefixText, "30d")
+        XCTAssertTrue(MenuBarMetricType.tokensAllTime.isTokenMetric)
+        XCTAssertFalse(MenuBarMetricType.session.isTokenMetric)
+    }
+
+    func testTokenStatsValueSelection() {
+        let s = TokenStats(allTime: 100, last7Days: 20, last30Days: 30, isAvailable: true)
+        XCTAssertEqual(s.value(for: .tokensAllTime), 100)
+        XCTAssertEqual(s.value(for: .tokens7Days), 20)
+        XCTAssertEqual(s.value(for: .tokens30Days), 30)
+        XCTAssertNil(s.value(for: .session))
+    }
+
+    func testDefaultConfigurationContainsTokenMetricsDisabled() {
+        let config = MenuBarIconConfiguration.default
+        for t in [MenuBarMetricType.tokensAllTime, .tokens7Days, .tokens30Days] {
+            let mc = config.config(for: t)
+            XCTAssertNotNil(mc, "default metrics missing \(t.rawValue)")
+            XCTAssertEqual(mc?.isEnabled, false)
+        }
+    }
+
+    func testDecodingLegacyConfigBackfillsTokenMetrics() throws {
+        // Legacy config JSON with only session/week/api metrics
+        let legacy = """
+        {
+          "colorMode": "multiColor",
+          "singleColorHex": "#00BFFF",
+          "showIconNames": true,
+          "metrics": [
+            { "metricType": "session", "isEnabled": true, "iconStyle": "battery", "order": 0,
+              "weekDisplayMode": "percentage", "apiDisplayMode": "remaining", "showNextSessionTime": false }
+          ]
+        }
+        """
+        let config = try JSONDecoder().decode(MenuBarIconConfiguration.self, from: Data(legacy.utf8))
+        XCTAssertNotNil(config.config(for: .tokensAllTime))
+        XCTAssertNotNil(config.config(for: .tokens7Days))
+        XCTAssertNotNil(config.config(for: .tokens30Days))
+    }
+}

--- a/Claude UsageTests/MenuBarTokenMetricTests.swift
+++ b/Claude UsageTests/MenuBarTokenMetricTests.swift
@@ -17,6 +17,12 @@ final class MenuBarTokenMetricTests: XCTestCase {
         XCTAssertFalse(MenuBarMetricType.session.isTokenMetric)
     }
 
+    func testTokenTopLabel() {
+        XCTAssertEqual(MenuBarMetricType.tokensAllTime.tokenTopLabel, "ALL")
+        XCTAssertEqual(MenuBarMetricType.tokens7Days.tokenTopLabel, "7D")
+        XCTAssertEqual(MenuBarMetricType.tokens30Days.tokenTopLabel, "30D")
+    }
+
     func testTokenStatsValueSelection() {
         let s = TokenStats(allTime: 100, last7Days: 20, last30Days: 30, isAvailable: true)
         XCTAssertEqual(s.value(for: .tokensAllTime), 100)

--- a/Claude UsageTests/TokenStatsServiceTests.swift
+++ b/Claude UsageTests/TokenStatsServiceTests.swift
@@ -212,6 +212,37 @@ final class TokenStatsServiceTests: XCTestCase {
         XCTAssertEqual(stats.allTime, 175)
     }
 
+    func testDecodedCacheWithoutLastComputedDateFallsBackToFullJSONLSum() {
+        // Cache decodes fine and has real aggregates (modelUsage summing to 1000, plus a
+        // dailyModelTokens entry), but lastComputedDate is absent. Without a valid cutoff we
+        // cannot safely combine the cache's totals with a JSONL delta (that would either double-
+        // count the cache's lifetime total on top of the full JSONL history, or silently ignore
+        // the cache's daily entries in window sums). The fix must fall back to pure JSONL: only
+        // the JSONL line's 150 tokens should count, not 1000, and not 1150.
+        let json = """
+        {
+          "modelUsage": {
+            "claude-sonnet-4-5": { "inputTokens": 700, "outputTokens": 300 }
+          },
+          "dailyModelTokens": [
+            { "date": "\(day(offsetFromToday: -5))", "tokensByModel": { "a": 40 } }
+          ]
+        }
+        """
+        let statsURL = writeStatsCache(json)
+        let projectsDir = writeJSONL([(day: day(offsetFromToday: -1), input: 100, output: 50)])
+
+        let stats = TokenStatsService().load(
+            enabledFrames: [.tokensAllTime],
+            statsURL: statsURL,
+            projectsDir: projectsDir,
+            referenceDate: referenceDate
+        )
+
+        XCTAssertTrue(stats.isAvailable)
+        XCTAssertEqual(stats.allTime, 150, "no valid cutoff -> pure JSONL, not 1150 (double-count) or 1000 (cache-only)")
+    }
+
     func testNothingAvailableReturnsUnavailable() {
         let stats = TokenStatsService().load(
             enabledFrames: [.tokensAllTime],

--- a/Claude UsageTests/TokenStatsServiceTests.swift
+++ b/Claude UsageTests/TokenStatsServiceTests.swift
@@ -56,16 +56,20 @@ final class TokenStatsServiceTests: XCTestCase {
         return url
     }
 
-    /// Writes a single JSONL session file containing one assistant line per (day, input, output)
-    /// tuple. `projectsDir` layout mirrors `~/.claude/projects/<slug>/<session>.jsonl`.
-    private func writeJSONL(_ lines: [(day: String, input: Int, output: Int)]) -> URL {
+    /// Writes a single JSONL session file containing one assistant line per token tuple.
+    /// `projectsDir` layout mirrors `~/.claude/projects/<slug>/<session>.jsonl`.
+    ///
+    /// All four token kinds are spelled out per line because the delta sum must include cache
+    /// tokens (see `testCacheTokensCountTowardEveryFrame`), so a fixture that left them implicit
+    /// would hide exactly the arithmetic these tests exist to pin down.
+    private func writeJSONL(_ lines: [(day: String, input: Int, output: Int, cacheRead: Int, cacheCreate: Int)]) -> URL {
         let projectsDir = tempDir.appendingPathComponent("projects/my-project")
         try! FileManager.default.createDirectory(at: projectsDir, withIntermediateDirectories: true)
         let sessionFile = projectsDir.appendingPathComponent("session.jsonl")
 
         let body = lines.map { line in
             """
-            {"type":"assistant","timestamp":"\(line.day)T12:00:00.000Z","message":{"usage":{"input_tokens":\(line.input),"output_tokens":\(line.output),"cache_read_input_tokens":999999}}}
+            {"type":"assistant","timestamp":"\(line.day)T12:00:00.000Z","message":{"usage":{"input_tokens":\(line.input),"output_tokens":\(line.output),"cache_read_input_tokens":\(line.cacheRead),"cache_creation_input_tokens":\(line.cacheCreate)}}}
             """
         }.joined(separator: "\n")
 
@@ -86,20 +90,25 @@ final class TokenStatsServiceTests: XCTestCase {
     // MARK: - Tests
 
     func testHybridAllTimeAddsCacheAndPostCutoffJSONL() {
-        // Cache lifetime total = 1000, authoritative through "today - 3".
-        // A JSONL line 2 days after the cutoff (input 100 + output 50) should be added on top.
+        // Cache lifetime total = 700 + 300 + 4000 + 200 = 5200, authoritative through "today - 3".
+        // A JSONL line 2 days after the cutoff (100 + 50 + 800 + 40 = 990) is added on top.
         let cutoff = day(offsetFromToday: -3)
         let json = """
         {
           "modelUsage": {
-            "claude-sonnet-4-5": { "inputTokens": 700, "outputTokens": 300 }
+            "claude-sonnet-4-5": {
+              "inputTokens": 700, "outputTokens": 300,
+              "cacheReadInputTokens": 4000, "cacheCreationInputTokens": 200
+            }
           },
           "dailyModelTokens": [],
           "lastComputedDate": "\(cutoff)"
         }
         """
         let statsURL = writeStatsCache(json)
-        let projectsDir = writeJSONL([(day: day(offsetFromToday: -1), input: 100, output: 50)])
+        let projectsDir = writeJSONL([
+            (day: day(offsetFromToday: -1), input: 100, output: 50, cacheRead: 800, cacheCreate: 40)
+        ])
 
         let stats = TokenStatsService().load(
             enabledFrames: [.tokensAllTime],
@@ -109,9 +118,50 @@ final class TokenStatsServiceTests: XCTestCase {
         )
 
         XCTAssertTrue(stats.isAvailable)
-        XCTAssertEqual(stats.allTime, 1150)
+        XCTAssertEqual(stats.allTime, 6190)
         XCTAssertEqual(stats.last7Days, 0, "disabled frame should not be computed")
         XCTAssertEqual(stats.last30Days, 0, "disabled frame should not be computed")
+    }
+
+    /// Regression guard for the CLI 2.1.221 accounting change: `dailyModelTokens` (which feeds the
+    /// 7D/30D windows) counts input + output + cache_read + cache_creation. If the all-time
+    /// aggregate or the post-cutoff JSONL delta counted only input + output, the frames would
+    /// report mutually inconsistent quantities - a 7D window larger than all-time.
+    func testCacheTokensCountTowardEveryFrame() {
+        // A pure cache-read line: zero input, zero output. Under the old accounting it contributed
+        // nothing at all; it must now contribute its full 1000 to both all-time and the 7D window.
+        let cutoff = day(offsetFromToday: -2)
+        let json = """
+        {
+          "modelUsage": {
+            "m": {
+              "inputTokens": 0, "outputTokens": 0,
+              "cacheReadInputTokens": 60, "cacheCreationInputTokens": 15
+            }
+          },
+          "dailyModelTokens": [ { "date": "\(cutoff)", "tokensByModel": { "m": 75 } } ],
+          "lastComputedDate": "\(cutoff)"
+        }
+        """
+        let statsURL = writeStatsCache(json)
+        let projectsDir = writeJSONL([
+            (day: day(offsetFromToday: -1), input: 0, output: 0, cacheRead: 1000, cacheCreate: 0)
+        ])
+
+        let stats = TokenStatsService().load(
+            enabledFrames: [.tokensAllTime, .tokens7Days, .tokens30Days],
+            statsURL: statsURL,
+            projectsDir: projectsDir,
+            referenceDate: referenceDate
+        )
+
+        XCTAssertTrue(stats.isAvailable)
+        XCTAssertEqual(stats.allTime, 1075, "cache-only lines must count: 60 + 15 cached + 1000 from JSONL")
+        XCTAssertEqual(stats.last7Days, 1075, "75 from the cached day + 1000 from the post-cutoff day")
+        XCTAssertGreaterThanOrEqual(
+            stats.allTime, stats.last7Days,
+            "all-time and the windows must measure the same quantity, so all-time can never be smaller"
+        )
     }
 
     func testWindowMergesCacheDayAndJSONLDayWithinRange() {
@@ -129,7 +179,9 @@ final class TokenStatsServiceTests: XCTestCase {
         }
         """
         let statsURL = writeStatsCache(json)
-        let projectsDir = writeJSONL([(day: day(offsetFromToday: -2), input: 20, output: 10)])
+        let projectsDir = writeJSONL([
+            (day: day(offsetFromToday: -2), input: 20, output: 10, cacheRead: 500, cacheCreate: 5)
+        ])
 
         let stats = TokenStatsService().load(
             enabledFrames: [.tokens7Days],
@@ -139,7 +191,7 @@ final class TokenStatsServiceTests: XCTestCase {
         )
 
         XCTAssertTrue(stats.isAvailable)
-        XCTAssertEqual(stats.last7Days, 80)
+        XCTAssertEqual(stats.last7Days, 585, "50 cached + (20 + 10 + 500 + 5) from JSONL")
         XCTAssertEqual(stats.allTime, 0, "disabled frame should not be computed")
     }
 
@@ -150,14 +202,19 @@ final class TokenStatsServiceTests: XCTestCase {
         let json = """
         {
           "modelUsage": {
-            "m": { "inputTokens": 500, "outputTokens": 0 }
+            "m": {
+              "inputTokens": 500, "outputTokens": 0,
+              "cacheReadInputTokens": 1500, "cacheCreationInputTokens": 0
+            }
           },
           "dailyModelTokens": [],
           "lastComputedDate": "\(cutoff)"
         }
         """
         let statsURL = writeStatsCache(json)
-        let projectsDir = writeJSONL([(day: cutoff, input: 9999, output: 9999)])
+        let projectsDir = writeJSONL([
+            (day: cutoff, input: 9999, output: 9999, cacheRead: 9999, cacheCreate: 9999)
+        ])
 
         let stats = TokenStatsService().load(
             enabledFrames: [.tokensAllTime],
@@ -167,7 +224,7 @@ final class TokenStatsServiceTests: XCTestCase {
         )
 
         XCTAssertTrue(stats.isAvailable)
-        XCTAssertEqual(stats.allTime, 500, "on-cutoff JSONL line already counted in cache; must be ignored")
+        XCTAssertEqual(stats.allTime, 2000, "on-cutoff JSONL line already counted in cache; must be ignored")
     }
 
     func testDisabledFrameIsNotComputed() {
@@ -180,7 +237,9 @@ final class TokenStatsServiceTests: XCTestCase {
         }
         """
         let statsURL = writeStatsCache(json)
-        let projectsDir = writeJSONL([(day: day(offsetFromToday: -1), input: 10, output: 5)])
+        let projectsDir = writeJSONL([
+            (day: day(offsetFromToday: -1), input: 10, output: 5, cacheRead: 100, cacheCreate: 0)
+        ])
 
         let stats = TokenStatsService().load(
             enabledFrames: [.tokens7Days],
@@ -192,13 +251,13 @@ final class TokenStatsServiceTests: XCTestCase {
         XCTAssertTrue(stats.isAvailable)
         XCTAssertEqual(stats.allTime, 0, "only enabled frames are computed")
         XCTAssertEqual(stats.last30Days, 0, "only enabled frames are computed")
-        XCTAssertEqual(stats.last7Days, 55)
+        XCTAssertEqual(stats.last7Days, 155, "40 cached + (10 + 5 + 100) from JSONL")
     }
 
     func testMissingCacheFallsBackToFullJSONLSum() {
         let projectsDir = writeJSONL([
-            (day: day(offsetFromToday: -10), input: 100, output: 50),
-            (day: day(offsetFromToday: -1), input: 20, output: 5)
+            (day: day(offsetFromToday: -10), input: 100, output: 50, cacheRead: 200, cacheCreate: 10),
+            (day: day(offsetFromToday: -1), input: 20, output: 5, cacheRead: 30, cacheCreate: 1)
         ])
 
         let stats = TokenStatsService().load(
@@ -209,7 +268,7 @@ final class TokenStatsServiceTests: XCTestCase {
         )
 
         XCTAssertTrue(stats.isAvailable)
-        XCTAssertEqual(stats.allTime, 175)
+        XCTAssertEqual(stats.allTime, 416, "360 + 56")
     }
 
     func testDecodedCacheWithoutLastComputedDateFallsBackToFullJSONLSum() {
@@ -218,7 +277,7 @@ final class TokenStatsServiceTests: XCTestCase {
         // cannot safely combine the cache's totals with a JSONL delta (that would either double-
         // count the cache's lifetime total on top of the full JSONL history, or silently ignore
         // the cache's daily entries in window sums). The fix must fall back to pure JSONL: only
-        // the JSONL line's 150 tokens should count, not 1000, and not 1150.
+        // the JSONL line's 470 tokens should count, not 1000, and not 1470.
         let json = """
         {
           "modelUsage": {
@@ -230,7 +289,9 @@ final class TokenStatsServiceTests: XCTestCase {
         }
         """
         let statsURL = writeStatsCache(json)
-        let projectsDir = writeJSONL([(day: day(offsetFromToday: -1), input: 100, output: 50)])
+        let projectsDir = writeJSONL([
+            (day: day(offsetFromToday: -1), input: 100, output: 50, cacheRead: 300, cacheCreate: 20)
+        ])
 
         let stats = TokenStatsService().load(
             enabledFrames: [.tokensAllTime],
@@ -240,7 +301,7 @@ final class TokenStatsServiceTests: XCTestCase {
         )
 
         XCTAssertTrue(stats.isAvailable)
-        XCTAssertEqual(stats.allTime, 150, "no valid cutoff -> pure JSONL, not 1150 (double-count) or 1000 (cache-only)")
+        XCTAssertEqual(stats.allTime, 470, "no valid cutoff -> pure JSONL, not 1470 (double-count) or 1000 (cache-only)")
     }
 
     func testNothingAvailableReturnsUnavailable() {
@@ -280,7 +341,7 @@ final class TokenStatsServiceTests: XCTestCase {
         let goodDay = day(offsetFromToday: -1)
         let content = """
         { this is not valid json at all "usage"
-        {"type":"assistant","timestamp":"\(goodDay)T09:00:00.000Z","message":{"usage":{"input_tokens":10,"output_tokens":5}}}
+        {"type":"assistant","timestamp":"\(goodDay)T09:00:00.000Z","message":{"usage":{"input_tokens":10,"output_tokens":5,"cache_read_input_tokens":100}}}
         {"type":"assistant","timestamp":"not-a-real-timestamp","message":{"usage":{"input_tokens":1,"output_tokens":1}}}
         {"type":"user","timestamp":"\(goodDay)T09:01:00.000Z"}
         """
@@ -294,6 +355,10 @@ final class TokenStatsServiceTests: XCTestCase {
         )
 
         XCTAssertTrue(stats.isAvailable)
-        XCTAssertEqual(stats.allTime, 15, "malformed/unusable lines are skipped; the one good line still counts")
+        XCTAssertEqual(
+            stats.allTime, 115,
+            "malformed/unusable lines are skipped; the one good line still counts, cache included. "
+            + "A line omitting cache_creation_input_tokens entirely must decode as 0, not fail."
+        )
     }
 }

--- a/Claude UsageTests/TokenStatsServiceTests.swift
+++ b/Claude UsageTests/TokenStatsServiceTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+@testable import Claude_Usage
+
+final class TokenStatsServiceTests: XCTestCase {
+
+    private func writeFixture(_ json: String) -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("stats-\(UUID().uuidString).json")
+        try! json.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    // referenceDate 2026-07-23; windows anchored to that day
+    private let ref: Date = {
+        var c = DateComponents(); c.year = 2026; c.month = 7; c.day = 23
+        return Calendar.current.date(from: c)!
+    }()
+
+    func testMissingFileIsUnavailable() {
+        let missing = URL(fileURLWithPath: "/nonexistent/stats-cache.json")
+        let stats = TokenStatsService().load(from: missing, referenceDate: ref)
+        XCTAssertFalse(stats.isAvailable)
+        XCTAssertEqual(stats, .unavailable)
+    }
+
+    func testAllTimeSumsInputPlusOutputExcludingCache() {
+        let json = """
+        {
+          "modelUsage": {
+            "claude-sonnet-4-5": { "inputTokens": 1000, "outputTokens": 500,
+              "cacheReadInputTokens": 9000000, "cacheCreationInputTokens": 8000000 },
+            "claude-opus-4-8": { "inputTokens": 200, "outputTokens": 300 }
+          },
+          "dailyModelTokens": []
+        }
+        """
+        let stats = TokenStatsService().load(from: writeFixture(json), referenceDate: ref)
+        XCTAssertTrue(stats.isAvailable)
+        XCTAssertEqual(stats.allTime, 2000) // 1000+500+200+300, cache ignored
+    }
+
+    func testWindowsSumDailyTokensWithinRange() {
+        // ref day = 2026-07-23. 7d window includes 07-17..07-23; 30d includes 06-24..07-23.
+        let json = """
+        {
+          "modelUsage": {},
+          "dailyModelTokens": [
+            { "date": "2026-07-23", "tokensByModel": { "a": 100, "b": 50 } },
+            { "date": "2026-07-17", "tokensByModel": { "a": 10 } },
+            { "date": "2026-07-16", "tokensByModel": { "a": 7 } },
+            { "date": "2026-06-24", "tokensByModel": { "a": 3 } },
+            { "date": "2026-06-23", "tokensByModel": { "a": 999 } }
+          ]
+        }
+        """
+        let stats = TokenStatsService().load(from: writeFixture(json), referenceDate: ref)
+        XCTAssertEqual(stats.last7Days, 160)   // 150 + 10 (07-16 excluded)
+        XCTAssertEqual(stats.last30Days, 170)  // 150 + 10 + 7 + 3 (06-23 excluded)
+    }
+
+    func testMalformedJsonIsUnavailable() {
+        let stats = TokenStatsService().load(from: writeFixture("{ not json "), referenceDate: ref)
+        XCTAssertFalse(stats.isAvailable)
+    }
+}

--- a/Claude UsageTests/TokenStatsServiceTests.swift
+++ b/Claude UsageTests/TokenStatsServiceTests.swift
@@ -3,63 +3,266 @@ import XCTest
 
 final class TokenStatsServiceTests: XCTestCase {
 
-    private func writeFixture(_ json: String) -> URL {
-        let url = FileManager.default.temporaryDirectory
-            .appendingPathComponent("stats-\(UUID().uuidString).json")
+    // MARK: - Fixture helpers
+
+    private var tempDir: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TokenStatsServiceTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: tempDir)
+        tempDir = nil
+        try super.tearDownWithError()
+    }
+
+    /// referenceDate is pinned to "now" (not a hardcoded historic date). This matters for the
+    /// JSONL scan's mtime-based skip optimization: fixture files are written with mtime = real
+    /// "now", so as long as `referenceDate` is also real "now", `scanFrom` (always <= today)
+    /// can never be later than the fixture's mtime, and the optimization never spuriously skips
+    /// a fixture file. All fixture calendar dates below are computed as offsets from this
+    /// reference (via `day(offsetFromToday:)`) rather than hardcoded literals, so window math
+    /// stays deterministic regardless of which real-world day the suite runs on.
+    private let referenceDate = Date()
+
+    private lazy var calendar: Calendar = {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = .current
+        return cal
+    }()
+
+    private lazy var dayFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.calendar = calendar
+        f.timeZone = .current
+        f.dateFormat = "yyyy-MM-dd"
+        return f
+    }()
+
+    /// "yyyy-MM-dd" string for `referenceDate + offset` days (offset may be negative).
+    private func day(offsetFromToday offset: Int) -> String {
+        let today = calendar.startOfDay(for: referenceDate)
+        let d = calendar.date(byAdding: .day, value: offset, to: today)!
+        return dayFormatter.string(from: d)
+    }
+
+    private func writeStatsCache(_ json: String) -> URL {
+        let url = tempDir.appendingPathComponent("stats-cache.json")
         try! json.write(to: url, atomically: true, encoding: .utf8)
         return url
     }
 
-    // referenceDate 2026-07-23; windows anchored to that day
-    private let ref: Date = {
-        var c = DateComponents(); c.year = 2026; c.month = 7; c.day = 23
-        return Calendar.current.date(from: c)!
-    }()
+    /// Writes a single JSONL session file containing one assistant line per (day, input, output)
+    /// tuple. `projectsDir` layout mirrors `~/.claude/projects/<slug>/<session>.jsonl`.
+    private func writeJSONL(_ lines: [(day: String, input: Int, output: Int)]) -> URL {
+        let projectsDir = tempDir.appendingPathComponent("projects/my-project")
+        try! FileManager.default.createDirectory(at: projectsDir, withIntermediateDirectories: true)
+        let sessionFile = projectsDir.appendingPathComponent("session.jsonl")
 
-    func testMissingFileIsUnavailable() {
-        let missing = URL(fileURLWithPath: "/nonexistent/stats-cache.json")
-        let stats = TokenStatsService().load(from: missing, referenceDate: ref)
-        XCTAssertFalse(stats.isAvailable)
-        XCTAssertEqual(stats, .unavailable)
+        let body = lines.map { line in
+            """
+            {"type":"assistant","timestamp":"\(line.day)T12:00:00.000Z","message":{"usage":{"input_tokens":\(line.input),"output_tokens":\(line.output),"cache_read_input_tokens":999999}}}
+            """
+        }.joined(separator: "\n")
+
+        try! body.write(to: sessionFile, atomically: true, encoding: .utf8)
+        return projectsDir.deletingLastPathComponent() // return the `projects` dir itself
     }
 
-    func testAllTimeSumsInputPlusOutputExcludingCache() {
+    private func emptyProjectsDir() -> URL {
+        let dir = tempDir.appendingPathComponent("projects-empty")
+        try! FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private func missingStatsURL() -> URL {
+        tempDir.appendingPathComponent("no-such-stats-cache.json")
+    }
+
+    // MARK: - Tests
+
+    func testHybridAllTimeAddsCacheAndPostCutoffJSONL() {
+        // Cache lifetime total = 1000, authoritative through "today - 3".
+        // A JSONL line 2 days after the cutoff (input 100 + output 50) should be added on top.
+        let cutoff = day(offsetFromToday: -3)
         let json = """
         {
           "modelUsage": {
-            "claude-sonnet-4-5": { "inputTokens": 1000, "outputTokens": 500,
-              "cacheReadInputTokens": 9000000, "cacheCreationInputTokens": 8000000 },
-            "claude-opus-4-8": { "inputTokens": 200, "outputTokens": 300 }
+            "claude-sonnet-4-5": { "inputTokens": 700, "outputTokens": 300 }
           },
-          "dailyModelTokens": []
+          "dailyModelTokens": [],
+          "lastComputedDate": "\(cutoff)"
         }
         """
-        let stats = TokenStatsService().load(from: writeFixture(json), referenceDate: ref)
+        let statsURL = writeStatsCache(json)
+        let projectsDir = writeJSONL([(day: day(offsetFromToday: -1), input: 100, output: 50)])
+
+        let stats = TokenStatsService().load(
+            enabledFrames: [.tokensAllTime],
+            statsURL: statsURL,
+            projectsDir: projectsDir,
+            referenceDate: referenceDate
+        )
+
         XCTAssertTrue(stats.isAvailable)
-        XCTAssertEqual(stats.allTime, 2000) // 1000+500+200+300, cache ignored
+        XCTAssertEqual(stats.allTime, 1150)
+        XCTAssertEqual(stats.last7Days, 0, "disabled frame should not be computed")
+        XCTAssertEqual(stats.last30Days, 0, "disabled frame should not be computed")
     }
 
-    func testWindowsSumDailyTokensWithinRange() {
-        // ref day = 2026-07-23. 7d window includes 07-17..07-23; 30d includes 06-24..07-23.
+    func testWindowMergesCacheDayAndJSONLDayWithinRange() {
+        // Cache authoritative through "today - 3"; a dailyModelTokens entry that day (50 tokens)
+        // plus a JSONL line 1 day after the cutoff (30 tokens), both within the 7-day window,
+        // must sum together.
+        let cutoff = day(offsetFromToday: -3)
         let json = """
         {
           "modelUsage": {},
           "dailyModelTokens": [
-            { "date": "2026-07-23", "tokensByModel": { "a": 100, "b": 50 } },
-            { "date": "2026-07-17", "tokensByModel": { "a": 10 } },
-            { "date": "2026-07-16", "tokensByModel": { "a": 7 } },
-            { "date": "2026-06-24", "tokensByModel": { "a": 3 } },
-            { "date": "2026-06-23", "tokensByModel": { "a": 999 } }
-          ]
+            { "date": "\(cutoff)", "tokensByModel": { "a": 50 } }
+          ],
+          "lastComputedDate": "\(cutoff)"
         }
         """
-        let stats = TokenStatsService().load(from: writeFixture(json), referenceDate: ref)
-        XCTAssertEqual(stats.last7Days, 160)   // 150 + 10 (07-16 excluded)
-        XCTAssertEqual(stats.last30Days, 170)  // 150 + 10 + 7 + 3 (06-23 excluded)
+        let statsURL = writeStatsCache(json)
+        let projectsDir = writeJSONL([(day: day(offsetFromToday: -2), input: 20, output: 10)])
+
+        let stats = TokenStatsService().load(
+            enabledFrames: [.tokens7Days],
+            statsURL: statsURL,
+            projectsDir: projectsDir,
+            referenceDate: referenceDate
+        )
+
+        XCTAssertTrue(stats.isAvailable)
+        XCTAssertEqual(stats.last7Days, 80)
+        XCTAssertEqual(stats.allTime, 0, "disabled frame should not be computed")
     }
 
-    func testMalformedJsonIsUnavailable() {
-        let stats = TokenStatsService().load(from: writeFixture("{ not json "), referenceDate: ref)
+    func testJSONLLinesOnOrBeforeCutoffAreIgnored() {
+        // A JSONL line dated exactly on lastComputedDate duplicates data already folded into the
+        // cache and must NOT be double-counted.
+        let cutoff = day(offsetFromToday: -1)
+        let json = """
+        {
+          "modelUsage": {
+            "m": { "inputTokens": 500, "outputTokens": 0 }
+          },
+          "dailyModelTokens": [],
+          "lastComputedDate": "\(cutoff)"
+        }
+        """
+        let statsURL = writeStatsCache(json)
+        let projectsDir = writeJSONL([(day: cutoff, input: 9999, output: 9999)])
+
+        let stats = TokenStatsService().load(
+            enabledFrames: [.tokensAllTime],
+            statsURL: statsURL,
+            projectsDir: projectsDir,
+            referenceDate: referenceDate
+        )
+
+        XCTAssertTrue(stats.isAvailable)
+        XCTAssertEqual(stats.allTime, 500, "on-cutoff JSONL line already counted in cache; must be ignored")
+    }
+
+    func testDisabledFrameIsNotComputed() {
+        let cutoff = day(offsetFromToday: -2)
+        let json = """
+        {
+          "modelUsage": { "m": { "inputTokens": 1000, "outputTokens": 0 } },
+          "dailyModelTokens": [ { "date": "\(cutoff)", "tokensByModel": { "a": 40 } } ],
+          "lastComputedDate": "\(cutoff)"
+        }
+        """
+        let statsURL = writeStatsCache(json)
+        let projectsDir = writeJSONL([(day: day(offsetFromToday: -1), input: 10, output: 5)])
+
+        let stats = TokenStatsService().load(
+            enabledFrames: [.tokens7Days],
+            statsURL: statsURL,
+            projectsDir: projectsDir,
+            referenceDate: referenceDate
+        )
+
+        XCTAssertTrue(stats.isAvailable)
+        XCTAssertEqual(stats.allTime, 0, "only enabled frames are computed")
+        XCTAssertEqual(stats.last30Days, 0, "only enabled frames are computed")
+        XCTAssertEqual(stats.last7Days, 55)
+    }
+
+    func testMissingCacheFallsBackToFullJSONLSum() {
+        let projectsDir = writeJSONL([
+            (day: day(offsetFromToday: -10), input: 100, output: 50),
+            (day: day(offsetFromToday: -1), input: 20, output: 5)
+        ])
+
+        let stats = TokenStatsService().load(
+            enabledFrames: [.tokensAllTime],
+            statsURL: missingStatsURL(),
+            projectsDir: projectsDir,
+            referenceDate: referenceDate
+        )
+
+        XCTAssertTrue(stats.isAvailable)
+        XCTAssertEqual(stats.allTime, 175)
+    }
+
+    func testNothingAvailableReturnsUnavailable() {
+        let stats = TokenStatsService().load(
+            enabledFrames: [.tokensAllTime],
+            statsURL: missingStatsURL(),
+            projectsDir: emptyProjectsDir(),
+            referenceDate: referenceDate
+        )
+
+        XCTAssertEqual(stats, .unavailable)
         XCTAssertFalse(stats.isAvailable)
+    }
+
+    func testNoTokenFramesEnabledReturnsUnavailable() {
+        // Only non-token metrics enabled -> nothing to compute, even with valid data present.
+        let json = """
+        { "modelUsage": { "m": { "inputTokens": 10, "outputTokens": 10 } }, "dailyModelTokens": [] }
+        """
+        let statsURL = writeStatsCache(json)
+
+        let stats = TokenStatsService().load(
+            enabledFrames: [.session, .week, .api],
+            statsURL: statsURL,
+            projectsDir: emptyProjectsDir(),
+            referenceDate: referenceDate
+        )
+
+        XCTAssertEqual(stats, .unavailable)
+    }
+
+    func testMalformedJSONLLineIsSkippedButGoodLinesStillCount() {
+        let projectsDir = tempDir.appendingPathComponent("projects/bad-project")
+        try! FileManager.default.createDirectory(at: projectsDir, withIntermediateDirectories: true)
+        let sessionFile = projectsDir.appendingPathComponent("session.jsonl")
+
+        let goodDay = day(offsetFromToday: -1)
+        let content = """
+        { this is not valid json at all "usage"
+        {"type":"assistant","timestamp":"\(goodDay)T09:00:00.000Z","message":{"usage":{"input_tokens":10,"output_tokens":5}}}
+        {"type":"assistant","timestamp":"not-a-real-timestamp","message":{"usage":{"input_tokens":1,"output_tokens":1}}}
+        {"type":"user","timestamp":"\(goodDay)T09:01:00.000Z"}
+        """
+        try! content.write(to: sessionFile, atomically: true, encoding: .utf8)
+
+        let stats = TokenStatsService().load(
+            enabledFrames: [.tokensAllTime],
+            statsURL: missingStatsURL(),
+            projectsDir: projectsDir.deletingLastPathComponent(),
+            referenceDate: referenceDate
+        )
+
+        XCTAssertTrue(stats.isAvailable)
+        XCTAssertEqual(stats.allTime, 15, "malformed/unusable lines are skipped; the one good line still counts")
     }
 }


### PR DESCRIPTION
## Summary

Adds three independently-toggleable menu-bar metrics showing **Claude Code CLI "Total Tokens"** (All time / Last 7 days / Last 30 days) as a compact number.

Unlike the existing Session/Week/API metrics (which come from the claude.ai / Console APIs), this reads the Claude Code CLI's local pre-aggregated cache at `~/.claude/stats-cache.json`, so it reflects your local CLI usage. If that file is absent (Claude Code not used) the metric shows `—`.

## What it does

- Three new `MenuBarMetricType` cases: `tokensAllTime`, `tokens7Days`, `tokens30Days`, each toggled independently in **Settings → Appearance → Menu Bar Metric**.
- Rendered as a compact **stacked** icon — a small uppercase label above the number (`ALL` / `7D` / `30D`), CPU/RAM-widget style — to save horizontal space.
- Numbers are abbreviated (`21.1M`, `9.2M`, …) via a new `FormatterHelper.abbreviatedCount`.
- Token definition matches the CLI's Total Tokens: **input + output tokens, excluding cache** (verified against real `stats-cache.json`: all-time = Σ `modelUsage` input+output; 7d/30d = Σ windowed `dailyModelTokens`).
- Existing users' saved menu-bar config is migrated (the three metrics are backfilled, disabled by default) so nothing changes unless enabled.

## Implementation notes

- New `TokenStatsService` + `TokenStats` model; graceful `.unavailable` → `—` on missing/malformed cache.
- `tokenStats` loaded on the existing refresh cycle in `MenuBarManager.refreshUsage()` (off the main actor) and threaded through `StatusBarUIManager` → `MenuBarIconRenderer`.
- Token metrics are text-only (no bar/pace styles); the icon-style picker is hidden for them in settings.
- Metric display names follow the existing (non-localized) `MenuBarMetricType` pattern, so no new localization keys are introduced.

## Testing

- New unit tests: `TokenStatsServiceTests` (token math, window boundaries, missing/malformed → unavailable), `FormatterHelperTests` (K/M/B incl. rounding boundaries), `MenuBarTokenMetricTests` (cases, properties, `value(for:)`, default config, legacy-config backfill migration).
- Full suite passes; clean build on Xcode 26.0.1 with no new warnings.

## Note

I'll add a menu-bar screenshot of the stacked display to this PR.
