### PR TITLE
fix: false 'credentials expired' (E3000) from Cloudflare-challenged requests (#277)

### DIFF
--- a/Claude Usage/App/AppDelegate.swift
+++ b/Claude Usage/App/AppDelegate.swift
@@ -21,6 +21,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         // Load profiles into ProfileManager (synchronously)
         ProfileManager.shared.loadProfiles()
 
+        // Regenerate installed statusline scripts so they pick up format changes
+        // across app updates and re-embed fresh Cloudflare clearance cookies.
+        try? StatuslineService.shared.updateScriptsIfInstalled()
+
         // Initialize update manager to enable automatic update checks
         _ = UpdateManager.shared
 

--- a/Claude Usage/Shared/Services/AutoStartSessionService.swift
+++ b/Claude Usage/Shared/Services/AutoStartSessionService.swift
@@ -202,7 +202,7 @@ final class AutoStartSessionService {
             .build()
 
         var request = URLRequest(url: url)
-        request.setValue("sessionKey=\(sessionKey)", forHTTPHeaderField: "Cookie")
+        request.setValue(ClaudeAPIService.sessionCookieHeader(sessionKey: sessionKey, url: url), forHTTPHeaderField: "Cookie")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         request.httpMethod = "GET"
         request.timeoutInterval = 30
@@ -407,7 +407,7 @@ final class AutoStartSessionService {
             .build()
 
         var conversationRequest = URLRequest(url: conversationURL)
-        conversationRequest.setValue("sessionKey=\(sessionKey)", forHTTPHeaderField: "Cookie")
+        conversationRequest.setValue(ClaudeAPIService.sessionCookieHeader(sessionKey: sessionKey, url: conversationURL), forHTTPHeaderField: "Cookie")
         conversationRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
         conversationRequest.httpMethod = "POST"
 
@@ -436,7 +436,7 @@ final class AutoStartSessionService {
             .build()
 
         var messageRequest = URLRequest(url: messageURL)
-        messageRequest.setValue("sessionKey=\(sessionKey)", forHTTPHeaderField: "Cookie")
+        messageRequest.setValue(ClaudeAPIService.sessionCookieHeader(sessionKey: sessionKey, url: messageURL), forHTTPHeaderField: "Cookie")
         messageRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
         messageRequest.httpMethod = "POST"
 
@@ -463,7 +463,7 @@ final class AutoStartSessionService {
             .build()
 
         var deleteRequest = URLRequest(url: deleteURL)
-        deleteRequest.setValue("sessionKey=\(sessionKey)", forHTTPHeaderField: "Cookie")
+        deleteRequest.setValue(ClaudeAPIService.sessionCookieHeader(sessionKey: sessionKey, url: deleteURL), forHTTPHeaderField: "Cookie")
         deleteRequest.httpMethod = "DELETE"
 
         // Attempt to delete, but don't fail if deletion fails

--- a/Claude Usage/Shared/Services/ClaudeAPIService+ConsoleAPI.swift
+++ b/Claude Usage/Shared/Services/ClaudeAPIService+ConsoleAPI.swift
@@ -7,7 +7,7 @@ extension ClaudeAPIService {
     /// Performs a Console API GET request with network logging
     private func consoleRequest(url: URL, apiSessionKey: String) async throws -> (Data, HTTPURLResponse) {
         var request = URLRequest(url: url)
-        request.setValue("sessionKey=\(apiSessionKey)", forHTTPHeaderField: "Cookie")
+        request.setValue(Self.sessionCookieHeader(sessionKey: apiSessionKey, url: url), forHTTPHeaderField: "Cookie")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         request.httpMethod = "GET"
 

--- a/Claude Usage/Shared/Services/ClaudeAPIService.swift
+++ b/Claude Usage/Shared/Services/ClaudeAPIService.swift
@@ -126,6 +126,22 @@ class ClaudeAPIService: APIServiceProtocol {
         throw AppError.sessionKeyNotFound()
     }
 
+    /// Cookie header for claude.ai session requests: the session key plus any
+    /// Cloudflare clearance / device cookies captured by the sign-in webview
+    /// (shared cookie storage). Requests that send ONLY `sessionKey` get
+    /// challenged or rejected with E3000 permission errors even when the
+    /// session is valid (#204, #277) — every claude.ai call must go through
+    /// this, not just `performRequest`.
+    static func sessionCookieHeader(sessionKey: String, url: URL) -> String {
+        var cookiePairs = ["sessionKey=\(sessionKey)"]
+        if let stored = HTTPCookieStorage.shared.cookies(for: url) {
+            for cookie in stored where ["cf_clearance", "__cf_bm", "anthropic-device-id"].contains(cookie.name) {
+                cookiePairs.append("\(cookie.name)=\(cookie.value)")
+            }
+        }
+        return cookiePairs.joined(separator: "; ")
+    }
+
     /// Builds an authenticated request with the appropriate headers for the auth type
     private func buildAuthenticatedRequest(url: URL, auth: AuthenticationType) -> URLRequest {
         var request = URLRequest(url: url)
@@ -133,9 +149,9 @@ class ClaudeAPIService: APIServiceProtocol {
         switch auth {
         case .claudeAISession(let sessionKey):
             // Existing claude.ai authentication
-            request.setValue("sessionKey=\(sessionKey)", forHTTPHeaderField: "Cookie")
+            request.setValue(Self.sessionCookieHeader(sessionKey: sessionKey, url: url), forHTTPHeaderField: "Cookie")
             request.setValue("application/json", forHTTPHeaderField: "Accept")
-            request.setValue("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15", forHTTPHeaderField: "User-Agent")
+            request.setValue("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Safari/605.1.15", forHTTPHeaderField: "User-Agent")
             request.setValue("https://claude.ai", forHTTPHeaderField: "Referer")
             request.setValue("https://claude.ai", forHTTPHeaderField: "Origin")
 
@@ -148,7 +164,7 @@ class ClaudeAPIService: APIServiceProtocol {
 
         case .consoleAPISession(let apiKey):
             // Console API authentication
-            request.setValue("sessionKey=\(apiKey)", forHTTPHeaderField: "Cookie")
+            request.setValue(Self.sessionCookieHeader(sessionKey: apiKey, url: url), forHTTPHeaderField: "Cookie")
             request.setValue("application/json", forHTTPHeaderField: "Accept")
         }
 
@@ -243,9 +259,9 @@ class ClaudeAPIService: APIServiceProtocol {
             }
 
             var request = URLRequest(url: url)
-            request.setValue("sessionKey=\(sessionKey)", forHTTPHeaderField: "Cookie")
+            request.setValue(Self.sessionCookieHeader(sessionKey: sessionKey, url: url), forHTTPHeaderField: "Cookie")
             request.setValue("application/json", forHTTPHeaderField: "Accept")
-            request.setValue("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15", forHTTPHeaderField: "User-Agent")
+            request.setValue("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Safari/605.1.15", forHTTPHeaderField: "User-Agent")
             request.setValue("https://claude.ai", forHTTPHeaderField: "Referer")
             request.setValue("https://claude.ai", forHTTPHeaderField: "Origin")
             request.httpMethod = "GET"
@@ -336,6 +352,19 @@ class ClaudeAPIService: APIServiceProtocol {
                 }
 
             case 401, 403:
+                // A Cloudflare bot challenge is not an auth verdict: reporting
+                // it as E3000/expired credentials sends users chasing
+                // re-logins that can never help (#277).
+                let preview = String(data: data, encoding: .utf8)?.prefix(200) ?? ""
+                if preview.contains("Just a moment") || httpResponse.value(forHTTPHeaderField: "cf-mitigated") != nil {
+                    throw AppError(
+                        code: .apiServiceUnavailable,
+                        message: "Request blocked by Cloudflare protection.",
+                        technicalDetails: "claude.ai answered the organizations request with a bot-verification challenge, not an auth verdict.",
+                        isRecoverable: true,
+                        recoverySuggestion: "Your session key is likely still valid. Re-open the sign-in window so the webview can refresh Cloudflare cookies, then try again."
+                    )
+                }
                 throw AppError.apiUnauthorized()
 
             case 429:
@@ -623,15 +652,9 @@ class ClaudeAPIService: APIServiceProtocol {
         // Include Cloudflare clearance cookies captured by the sign-in webview
         // (shared cookie storage) — without them claude.ai intermittently
         // answers with a 403 "Just a moment..." challenge page.
-        var cookiePairs = ["sessionKey=\(sessionKey)"]
-        if let stored = HTTPCookieStorage.shared.cookies(for: url) {
-            for cookie in stored where ["cf_clearance", "__cf_bm"].contains(cookie.name) {
-                cookiePairs.append("\(cookie.name)=\(cookie.value)")
-            }
-        }
-        request.setValue(cookiePairs.joined(separator: "; "), forHTTPHeaderField: "Cookie")
+        request.setValue(Self.sessionCookieHeader(sessionKey: sessionKey, url: url), forHTTPHeaderField: "Cookie")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
-        request.setValue("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15", forHTTPHeaderField: "User-Agent")
+        request.setValue("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Safari/605.1.15", forHTTPHeaderField: "User-Agent")
         request.setValue("https://claude.ai", forHTTPHeaderField: "Referer")
         request.setValue("https://claude.ai", forHTTPHeaderField: "Origin")
         request.httpMethod = "GET"
@@ -710,10 +733,14 @@ class ClaudeAPIService: APIServiceProtocol {
             let responsePreview = String(data: data, encoding: .utf8)?.prefix(200) ?? "Unable to read response"
 
             // Cloudflare bot challenge, not an actual auth failure — the
-            // session key is fine, the request just got challenged.
-            if responsePreview.contains("Just a moment") || responsePreview.contains("cf-mitigated") {
+            // session key is fine, the request just got challenged. Must NOT
+            // be .apiUnauthorized: the credential-error banner keys off that
+            // code and would falsely tell the user their credentials expired
+            // (#277).
+            if responsePreview.contains("Just a moment") || responsePreview.contains("cf-mitigated")
+                || httpResponse.value(forHTTPHeaderField: "cf-mitigated") != nil {
                 throw AppError(
-                    code: .apiUnauthorized,
+                    code: .apiServiceUnavailable,
                     message: "Request blocked by Cloudflare protection.",
                     technicalDetails: "Endpoint: \(endpoint)\nStatus: \(httpResponse.statusCode)\nCloudflare challenge page returned",
                     isRecoverable: true,
@@ -1053,10 +1080,10 @@ class ClaudeAPIService: APIServiceProtocol {
             .build()
 
         var conversationRequest = URLRequest(url: conversationURL)
-        conversationRequest.setValue("sessionKey=\(sessionKey)", forHTTPHeaderField: "Cookie")
+        conversationRequest.setValue(Self.sessionCookieHeader(sessionKey: sessionKey, url: conversationURL), forHTTPHeaderField: "Cookie")
         conversationRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
         conversationRequest.setValue("application/json", forHTTPHeaderField: "Accept")
-        conversationRequest.setValue("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15", forHTTPHeaderField: "User-Agent")
+        conversationRequest.setValue("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Safari/605.1.15", forHTTPHeaderField: "User-Agent")
         conversationRequest.setValue("https://claude.ai", forHTTPHeaderField: "Referer")
         conversationRequest.setValue("https://claude.ai", forHTTPHeaderField: "Origin")
         conversationRequest.httpMethod = "POST"
@@ -1101,10 +1128,10 @@ class ClaudeAPIService: APIServiceProtocol {
             .build()
 
         var messageRequest = URLRequest(url: messageURL)
-        messageRequest.setValue("sessionKey=\(sessionKey)", forHTTPHeaderField: "Cookie")
+        messageRequest.setValue(Self.sessionCookieHeader(sessionKey: sessionKey, url: messageURL), forHTTPHeaderField: "Cookie")
         messageRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
         messageRequest.setValue("application/json", forHTTPHeaderField: "Accept")
-        messageRequest.setValue("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15", forHTTPHeaderField: "User-Agent")
+        messageRequest.setValue("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Safari/605.1.15", forHTTPHeaderField: "User-Agent")
         messageRequest.setValue("https://claude.ai", forHTTPHeaderField: "Referer")
         messageRequest.setValue("https://claude.ai", forHTTPHeaderField: "Origin")
         messageRequest.httpMethod = "POST"
@@ -1144,8 +1171,8 @@ class ClaudeAPIService: APIServiceProtocol {
             .build()
 
         var deleteRequest = URLRequest(url: deleteURL)
-        deleteRequest.setValue("sessionKey=\(sessionKey)", forHTTPHeaderField: "Cookie")
-        deleteRequest.setValue("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15", forHTTPHeaderField: "User-Agent")
+        deleteRequest.setValue(Self.sessionCookieHeader(sessionKey: sessionKey, url: deleteURL), forHTTPHeaderField: "Cookie")
+        deleteRequest.setValue("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Safari/605.1.15", forHTTPHeaderField: "User-Agent")
         deleteRequest.setValue("https://claude.ai", forHTTPHeaderField: "Referer")
         deleteRequest.setValue("https://claude.ai", forHTTPHeaderField: "Origin")
         deleteRequest.httpMethod = "DELETE"

--- a/Claude Usage/Shared/Services/StatuslineService.swift
+++ b/Claude Usage/Shared/Services/StatuslineService.swift
@@ -13,16 +13,18 @@ class StatuslineService {
     /// Swift script that fetches Claude usage data from the API.
     /// Installed to ~/.claude/fetch-claude-usage.swift and executed by the bash statusline script.
     /// The session key and organization ID are injected into this script when statusline is enabled.
-    private func generateSwiftScript(sessionKey: String, organizationId: String) -> String {
+    private func generateSwiftScript(cookieHeader: String, organizationId: String) -> String {
         return """
 #!/usr/bin/env swift
 
 import Foundation
-func readSessionKey() -> String? {
-    // Session key injected from Keychain by Claude Usage app
-    let injectedKey = "\(sessionKey)"
-    let trimmedKey = injectedKey.trimmingCharacters(in: .whitespacesAndNewlines)
-    return trimmedKey.isEmpty ? nil : trimmedKey
+func readCookieHeader() -> String? {
+    // Cookie header (sessionKey + Cloudflare clearance cookies) injected by Claude Usage app.
+    // claude.ai rejects bare-sessionKey requests, so the app's current clearance
+    // cookies ride along; they refresh whenever the statusline is reinstalled.
+    let injectedHeader = "\(cookieHeader)"
+    let trimmedHeader = injectedHeader.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmedHeader.isEmpty ? nil : trimmedHeader
 }
 func readOrganizationId() -> String? {
     // Organization ID injected from settings by Claude Usage app
@@ -30,7 +32,7 @@ func readOrganizationId() -> String? {
     let trimmedOrgId = injectedOrgId.trimmingCharacters(in: .whitespacesAndNewlines)
     return trimmedOrgId.isEmpty ? nil : trimmedOrgId
 }
-func fetchUsageData(sessionKey: String, orgId: String) async throws -> (utilization: Int, resetsAt: String?) {
+func fetchUsageData(cookieHeader: String, orgId: String) async throws -> (utilization: Int, resetsAt: String?) {
     // Build URL safely - validate orgId doesn't contain path traversal
     guard !orgId.contains(".."), !orgId.contains("/") else {
         throw NSError(domain: "ClaudeAPI", code: 5, userInfo: [NSLocalizedDescriptionKey: "Invalid organization ID"])
@@ -41,8 +43,9 @@ func fetchUsageData(sessionKey: String, orgId: String) async throws -> (utilizat
     }
 
     var request = URLRequest(url: url)
-    request.setValue("sessionKey=\\(sessionKey)", forHTTPHeaderField: "Cookie")
+    request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
     request.setValue("application/json", forHTTPHeaderField: "Accept")
+    request.setValue("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Safari/605.1.15", forHTTPHeaderField: "User-Agent")
     request.httpMethod = "GET"
 
     let (data, response) = try await URLSession.shared.data(for: request)
@@ -65,7 +68,7 @@ func fetchUsageData(sessionKey: String, orgId: String) async throws -> (utilizat
 // Main execution
 // Use Task to run async code, RunLoop keeps script alive until exit() is called
 Task {
-    guard let sessionKey = readSessionKey() else {
+    guard let cookieHeader = readCookieHeader() else {
         print("ERROR:NO_SESSION_KEY")
         exit(1)
     }
@@ -76,7 +79,7 @@ Task {
     }
 
     do {
-        let (utilization, resetsAt) = try await fetchUsageData(sessionKey: sessionKey, orgId: orgId)
+        let (utilization, resetsAt) = try await fetchUsageData(cookieHeader: cookieHeader, orgId: orgId)
 
         // Output format: UTILIZATION|RESETS_AT
         if let resets = resetsAt {
@@ -859,7 +862,11 @@ printf "%s\\n" "$output"
                 throw StatuslineError.organizationNotConfigured
             }
 
-            swiftScriptContent = generateSwiftScript(sessionKey: sessionKey, organizationId: organizationId)
+            // Inject the full cookie header, not a bare sessionKey: claude.ai's
+            // Cloudflare config rejects cookie-less-looking requests (#277 class).
+            let usageURL = URL(string: "https://claude.ai/api/organizations/\(organizationId)/usage")!
+            let cookieHeader = ClaudeAPIService.sessionCookieHeader(sessionKey: sessionKey, url: usageURL)
+            swiftScriptContent = generateSwiftScript(cookieHeader: cookieHeader, organizationId: organizationId)
             LoggingService.shared.log("Injected session key and org ID from profile '\(activeProfile.name)' into statusline")
         } else {
             // Install placeholder script


### PR DESCRIPTION
Addresses #277.

Two independent causes produce the reported symptom (credentials show connected, every query fails E3000, re-login does not help):

1. Only `performRequest` sends the Cloudflare clearance cookies captured by the sign-in webview. `fetchAllOrganizations`/`testSessionKey` (the exact path exercised during login verification), the console API, and `AutoStartSessionService` send a bare `sessionKey` cookie. claude.ai has been rejecting bare-cookie requests on more endpoints since mid-July. This change factors the cookie assembly into `ClaudeAPIService.sessionCookieHeader` (now also forwarding `anthropic-device-id`) and uses it on every claude.ai request path.

2. Cloudflare challenge responses were classified `.apiUnauthorized` (E3000). The credential-error banner keys off that code, so a bot challenge told users their credentials expired and sent them chasing re-logins. Challenges are now `.apiServiceUnavailable` with a message saying the session key is likely still valid.

Also refreshes the browser UA from Safari 17 (2023) to Safari 26.

**Update:** this branch now also covers the generated statusline script, which the original description listed as out of scope. `StatuslineService` built the Cookie header for `fetch-claude-usage.swift` from `sessionKey` alone, so an installed statusline kept getting challenged and showed no usage. It now emits the same header via `sessionCookieHeader` plus the browser User-Agent. Installed scripts are also regenerated at launch: regeneration previously ran only on profile edits or the setup wizard, so a script-format change shipped in an app update never reached an existing install, and the embedded clearance cookies had no refresh path.

Probe used for diagnosis: an invalid session key against `/api/organizations` via URLSession returns a clean JSON `permission_error` 403, while header-only changes do not affect it, confirming the challenge/auth conflation rather than TLS or UA blocking.

Verification: `xcodebuild test` on Xcode 26.6 / macOS 26 passes 145/145, matching the baseline on `main`. The statusline path was checked end to end by running the generated `fetch-claude-usage.swift`, which returns live usage.
---
Prepared by Lathe, an agent account operated with human review. Happy to adjust anything.