### PR TITLE
feat: macOS desktop widgets via WidgetKit extension (no App Groups)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,16 @@ jobs:
           # DO NOT use --deep flag as it breaks XPC service signatures
           # Reference: https://sparkle-project.org/documentation/sandboxing/
 
+          # 0. Sign the embedded widget extension first — nested code must
+          #    carry its own signature before the outer app is signed, and
+          #    the outer codesign call deliberately omits --deep.
+          echo "Signing Claude UsageWidget.appex..."
+          codesign --force --sign "$SIGNING_IDENTITY" \
+            --timestamp \
+            --options runtime \
+            --entitlements "ClaudeUsageWidget/ClaudeUsageWidget.entitlements" \
+            "$APP_PATH/Contents/PlugIns/Claude UsageWidget.appex"
+
           # 1. Sign XPC Services first
           echo "Signing Installer.xpc..."
           codesign --force --sign "$SIGNING_IDENTITY" \

--- a/Claude Usage.xcodeproj/project.pbxproj
+++ b/Claude Usage.xcodeproj/project.pbxproj
@@ -8,7 +8,14 @@
 
 /* Begin PBXBuildFile section */
 		056C52802F017E50007E2A48 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = SPARKLE_PRODUCT_DEP /* Sparkle */; };
+		APP_SRC_WIDGET_SNAPSHOT /* WidgetSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = WIDGETSHARED_FILE_SNAPSHOT /* WidgetSnapshot.swift */; };
+		APP_EMBED_WIDGET /* Claude UsageWidget.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = WIDGET_APPEX_REF /* Claude UsageWidget.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		DYNAMICNOTCH_BUILD_FILE /* DynamicNotchKit in Frameworks */ = {isa = PBXBuildFile; productRef = DYNAMICNOTCH_PRODUCT_DEP /* DynamicNotchKit */; };
+		WIDGET_SRC_BUNDLE /* ClaudeUsageWidgetBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = WIDGET_FILE_BUNDLE /* ClaudeUsageWidgetBundle.swift */; };
+		WIDGET_SRC_PROVIDER /* UsageTimelineProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = WIDGET_FILE_PROVIDER /* UsageTimelineProvider.swift */; };
+		WIDGET_SRC_VIEWS /* UsageWidgetViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = WIDGET_FILE_VIEWS /* UsageWidgetViews.swift */; };
+		WIDGET_SRC_SNAPSHOT /* WidgetSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = WIDGETSHARED_FILE_SNAPSHOT /* WidgetSnapshot.swift */; };
+		WIDGET_RES_LOC /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = WIDGET_LOC_VARIANT /* Localizable.strings */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -19,11 +26,52 @@
 			remoteGlobalIDString = 05CD2CB12EA985A100004C83;
 			remoteInfo = "Claude Usage";
 		};
+		WIDGET_CONTAINER_PROXY /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 05CD2CAA2EA985A100004C83 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = WIDGET_TARGET;
+			remoteInfo = "Claude UsageWidget";
+		};
 /* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		APP_EMBED_EXT_PHASE /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				APP_EMBED_WIDGET /* Claude UsageWidget.appex in Embed Foundation Extensions */,
+			);
+			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		05CD2CB22EA985A100004C83 /* Claude Usage.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Claude Usage.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		05CD2CC02EA985A100004C83 /* Claude UsageTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Claude UsageTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		WIDGET_APPEX_REF /* Claude UsageWidget.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "Claude UsageWidget.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
+		WIDGET_FILE_BUNDLE /* ClaudeUsageWidgetBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeUsageWidgetBundle.swift; sourceTree = "<group>"; };
+		WIDGET_FILE_PROVIDER /* UsageTimelineProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageTimelineProvider.swift; sourceTree = "<group>"; };
+		WIDGET_FILE_VIEWS /* UsageWidgetViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageWidgetViews.swift; sourceTree = "<group>"; };
+		WIDGET_FILE_INFO /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		WIDGET_FILE_ENTITLEMENTS /* ClaudeUsageWidget.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ClaudeUsageWidget.entitlements; sourceTree = "<group>"; };
+		WIDGETSHARED_FILE_SNAPSHOT /* WidgetSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetSnapshot.swift; sourceTree = "<group>"; };
+		WIDGET_LOC_DE /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
+		WIDGET_LOC_EN /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
+		WIDGET_LOC_ES /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
+		WIDGET_LOC_FR /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
+		WIDGET_LOC_IT /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Localizable.strings; sourceTree = "<group>"; };
+		WIDGET_LOC_JA /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
+		WIDGET_LOC_KO /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/Localizable.strings; sourceTree = "<group>"; };
+		WIDGET_LOC_PT /* pt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pt; path = pt.lproj/Localizable.strings; sourceTree = "<group>"; };
+		WIDGET_LOC_PTBR /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		WIDGET_LOC_TR /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/Localizable.strings; sourceTree = "<group>"; };
+		WIDGET_LOC_UK /* uk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/Localizable.strings; sourceTree = "<group>"; };
+		WIDGET_LOC_ZHHANS /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		WIDGET_LOC_ZHHANT /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/Localizable.strings"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -56,6 +104,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		WIDGET_FRAMEWORKS_PHASE /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -64,6 +119,8 @@
 			children = (
 				05CD2CB42EA985A100004C83 /* Claude Usage */,
 				05CD2CC12EA985A100004C83 /* Claude UsageTests */,
+				WIDGET_GROUP /* ClaudeUsageWidget */,
+				WIDGETSHARED_GROUP /* WidgetShared */,
 				05CD2CB32EA985A100004C83 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -73,8 +130,38 @@
 			children = (
 				05CD2CB22EA985A100004C83 /* Claude Usage.app */,
 				05CD2CC02EA985A100004C83 /* Claude UsageTests.xctest */,
+				WIDGET_APPEX_REF /* Claude UsageWidget.appex */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		WIDGET_GROUP /* ClaudeUsageWidget */ = {
+			isa = PBXGroup;
+			children = (
+				WIDGET_FILE_BUNDLE /* ClaudeUsageWidgetBundle.swift */,
+				WIDGET_FILE_PROVIDER /* UsageTimelineProvider.swift */,
+				WIDGET_FILE_VIEWS /* UsageWidgetViews.swift */,
+				WIDGET_FILE_INFO /* Info.plist */,
+				WIDGET_FILE_ENTITLEMENTS /* ClaudeUsageWidget.entitlements */,
+				WIDGET_RES_GROUP /* Resources */,
+			);
+			path = ClaudeUsageWidget;
+			sourceTree = "<group>";
+		};
+		WIDGET_RES_GROUP /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				WIDGET_LOC_VARIANT /* Localizable.strings */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
+		WIDGETSHARED_GROUP /* WidgetShared */ = {
+			isa = PBXGroup;
+			children = (
+				WIDGETSHARED_FILE_SNAPSHOT /* WidgetSnapshot.swift */,
+			);
+			path = WidgetShared;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -87,10 +174,12 @@
 				05CD2CAE2EA985A100004C83 /* Sources */,
 				05CD2CAF2EA985A100004C83 /* Frameworks */,
 				05CD2CB02EA985A100004C83 /* Resources */,
+				APP_EMBED_EXT_PHASE /* Embed Foundation Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				WIDGET_TARGET_DEP /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				05CD2CB42EA985A100004C83 /* Claude Usage */,
@@ -126,6 +215,25 @@
 			productName = "Claude UsageTests";
 			productReference = 05CD2CC02EA985A100004C83 /* Claude UsageTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		WIDGET_TARGET /* Claude UsageWidget */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = WIDGET_CONFIG_LIST /* Build configuration list for PBXNativeTarget "Claude UsageWidget" */;
+			buildPhases = (
+				WIDGET_SOURCES_PHASE /* Sources */,
+				WIDGET_FRAMEWORKS_PHASE /* Frameworks */,
+				WIDGET_RESOURCES_PHASE /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Claude UsageWidget";
+			packageProductDependencies = (
+			);
+			productName = "Claude UsageWidget";
+			productReference = WIDGET_APPEX_REF /* Claude UsageWidget.appex */;
+			productType = "com.apple.product-type.app-extension";
 		};
 /* End PBXNativeTarget section */
 
@@ -163,6 +271,7 @@
 				uk,
 				"zh-ch",
 				"zh-CH",
+				"zh-Hans",
 				"zh-Hant",
 				tr,
 			);
@@ -179,6 +288,7 @@
 			targets = (
 				05CD2CB12EA985A100004C83 /* Claude Usage */,
 				05CD2CC52EA985A100004C83 /* Claude UsageTests */,
+				WIDGET_TARGET /* Claude UsageWidget */,
 			);
 		};
 /* End PBXProject section */
@@ -198,6 +308,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		WIDGET_RESOURCES_PHASE /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				WIDGET_RES_LOC /* Localizable.strings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -205,6 +323,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				APP_SRC_WIDGET_SNAPSHOT /* WidgetSnapshot.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -212,6 +331,17 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		WIDGET_SOURCES_PHASE /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				WIDGET_SRC_BUNDLE /* ClaudeUsageWidgetBundle.swift in Sources */,
+				WIDGET_SRC_PROVIDER /* UsageTimelineProvider.swift in Sources */,
+				WIDGET_SRC_VIEWS /* UsageWidgetViews.swift in Sources */,
+				WIDGET_SRC_SNAPSHOT /* WidgetSnapshot.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -223,7 +353,35 @@
 			target = 05CD2CB12EA985A100004C83 /* Claude Usage */;
 			targetProxy = 05CD2CC72EA985A100004C83 /* PBXContainerItemProxy */;
 		};
+		WIDGET_TARGET_DEP /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = WIDGET_TARGET /* Claude UsageWidget */;
+			targetProxy = WIDGET_CONTAINER_PROXY /* PBXContainerItemProxy */;
+		};
 /* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		WIDGET_LOC_VARIANT /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				WIDGET_LOC_EN /* en */,
+				WIDGET_LOC_DE /* de */,
+				WIDGET_LOC_ES /* es */,
+				WIDGET_LOC_FR /* fr */,
+				WIDGET_LOC_IT /* it */,
+				WIDGET_LOC_JA /* ja */,
+				WIDGET_LOC_KO /* ko */,
+				WIDGET_LOC_PT /* pt */,
+				WIDGET_LOC_PTBR /* pt-BR */,
+				WIDGET_LOC_TR /* tr */,
+				WIDGET_LOC_UK /* uk */,
+				WIDGET_LOC_ZHHANS /* zh-Hans */,
+				WIDGET_LOC_ZHHANT /* zh-Hant */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
 		05CD2CBB2EA985A100004C83 /* Debug */ = {
@@ -494,6 +652,65 @@
 			};
 			name = Release;
 		};
+		WIDGET_DEBUG_CONFIG /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = "ClaudeUsageWidget/ClaudeUsageWidget.entitlements";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 17;
+				DEAD_CODE_STRIPPING = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "ClaudeUsageWidget/Info.plist";
+				INFOPLIST_KEY_CFBundleDisplayName = "Claude Usage Widgets";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@executable_path/../../../../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 3.2.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "HamedElfayome.Claude-Usage.widget";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = macosx;
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		WIDGET_RELEASE_CONFIG /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = "ClaudeUsageWidget/ClaudeUsageWidget.entitlements";
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 17;
+				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_TEAM = T77ZWDC739;
+				ENABLE_HARDENED_RUNTIME = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "ClaudeUsageWidget/Info.plist";
+				INFOPLIST_KEY_CFBundleDisplayName = "Claude Usage Widgets";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@executable_path/../../../../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 3.2.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "HamedElfayome.Claude-Usage.widget";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = macosx;
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -520,6 +737,15 @@
 			buildConfigurations = (
 				05CD2CC82EA985A100004C83 /* Debug */,
 				05CD2CC92EA985A100004C83 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		WIDGET_CONFIG_LIST /* Build configuration list for PBXNativeTarget "Claude UsageWidget" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				WIDGET_DEBUG_CONFIG /* Debug */,
+				WIDGET_RELEASE_CONFIG /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Claude Usage/MenuBar/MenuBarManager.swift
+++ b/Claude Usage/MenuBar/MenuBarManager.swift
@@ -841,6 +841,14 @@ class MenuBarManager: NSObject, ObservableObject {
                     // Reconfigure menu bar to show default logo
                     let config = self.profileManager.activeProfile?.iconConfig ?? .default
                     self.updateMenuBarDisplay(with: config)
+
+                    // No refresh will run, so publish directly: this clears
+                    // (or trims) the widget snapshot instead of letting stale
+                    // usage linger until the widget's stale threshold.
+                    WidgetSnapshotService.shared.publish(
+                        profiles: self.profileManager.profiles,
+                        activeProfileId: self.profileManager.activeProfile?.id
+                    )
                     return
                 }
 

--- a/Claude Usage/MenuBar/MenuBarManager.swift
+++ b/Claude Usage/MenuBar/MenuBarManager.swift
@@ -1163,6 +1163,11 @@ class MenuBarManager: NSObject, ObservableObject {
                 self.lastSuccessfulRefreshTime = Date()
                 self.isRefreshing = false
 
+                WidgetSnapshotService.shared.publish(
+                    profiles: self.profileManager.profiles,
+                    activeProfileId: self.profileManager.activeProfile?.id
+                )
+
                 // Check auto-switch for the active profile
                 if let activeProfile = self.profileManager.activeProfile,
                    let activeUsage = activeProfile.claudeUsage {
@@ -1360,6 +1365,11 @@ class MenuBarManager: NSObject, ObservableObject {
                     self.lastRefreshError = nil
                     self.hasCredentialError = false
                     self.lastSuccessfulRefreshTime = Date()
+
+                    WidgetSnapshotService.shared.publish(
+                        profiles: self.profileManager.profiles,
+                        activeProfileId: self.profileManager.activeProfile?.id
+                    )
                 }
 
             } catch {

--- a/Claude Usage/Shared/Services/WidgetSnapshotService.swift
+++ b/Claude Usage/Shared/Services/WidgetSnapshotService.swift
@@ -1,0 +1,76 @@
+import Foundation
+import WidgetKit
+
+/// Publishes the current usage of all display-selected profiles to the
+/// WidgetKit extension.
+///
+/// Mirrors `StatuslineService.writeUsageCache`: after each refresh cycle the
+/// app serializes a small JSON snapshot to Application Support and asks
+/// WidgetKit to reload timelines. Writes are skipped when nothing meaningful
+/// changed so the WidgetKit reload budget is not burned on identical data.
+final class WidgetSnapshotService {
+    static let shared = WidgetSnapshotService()
+
+    private var lastPublishedProfiles: [WidgetSnapshot.ProfileEntry]?
+    private var lastReloadTime: Date = .distantPast
+
+    /// Minimum spacing between WidgetKit reload requests, so frequent
+    /// refresh cycles don't exhaust the system's reload budget.
+    private static let reloadInterval: TimeInterval = 60
+
+    private init() {}
+
+    /// Builds a snapshot from the given profiles and publishes it if it
+    /// differs from the last published one.
+    func publish(profiles: [Profile], activeProfileId: UUID?) {
+        let entries: [WidgetSnapshot.ProfileEntry] = profiles
+            .filter { $0.isSelectedForDisplay }
+            .compactMap { profile in
+                guard let usage = profile.claudeUsage else { return nil }
+                return WidgetSnapshot.ProfileEntry(
+                    id: profile.id,
+                    name: profile.name,
+                    isActive: profile.id == activeProfileId,
+                    sessionPercentage: usage.effectiveSessionPercentage,
+                    sessionResetTime: usage.sessionResetTime,
+                    weeklyPercentage: usage.weeklyPercentage,
+                    weeklyResetTime: usage.weeklyResetTime,
+                    lastUpdated: usage.lastUpdated
+                )
+            }
+
+        guard !entries.isEmpty else { return }
+        guard hasMeaningfulChange(entries) else { return }
+
+        let snapshot = WidgetSnapshot(generatedAt: Date(), profiles: entries)
+        do {
+            try snapshot.write()
+            lastPublishedProfiles = entries
+            if Date().timeIntervalSince(lastReloadTime) >= Self.reloadInterval {
+                lastReloadTime = Date()
+                WidgetCenter.shared.reloadAllTimelines()
+            }
+        } catch {
+            LoggingService.shared.log("WidgetSnapshotService: Failed to write snapshot - \(error.localizedDescription)")
+        }
+    }
+
+    /// Whole-percent or reset-time changes are worth a widget reload;
+    /// sub-percent jitter is not.
+    private func hasMeaningfulChange(_ entries: [WidgetSnapshot.ProfileEntry]) -> Bool {
+        guard let previous = lastPublishedProfiles, previous.count == entries.count else {
+            return true
+        }
+        for (old, new) in zip(previous, entries) {
+            let identityChanged = old.id != new.id || old.name != new.name || old.isActive != new.isActive
+            let sessionChanged = Int(old.sessionPercentage) != Int(new.sessionPercentage)
+                || Int(old.sessionResetTime.timeIntervalSince1970) != Int(new.sessionResetTime.timeIntervalSince1970)
+            let weeklyChanged = Int(old.weeklyPercentage) != Int(new.weeklyPercentage)
+                || Int(old.weeklyResetTime.timeIntervalSince1970) != Int(new.weeklyResetTime.timeIntervalSince1970)
+            if identityChanged || sessionChanged || weeklyChanged {
+                return true
+            }
+        }
+        return false
+    }
+}

--- a/Claude Usage/Shared/Services/WidgetSnapshotService.swift
+++ b/Claude Usage/Shared/Services/WidgetSnapshotService.swift
@@ -1,18 +1,25 @@
 import Foundation
 import WidgetKit
 
-/// Publishes the current usage of all display-selected profiles to the
-/// WidgetKit extension.
+/// Publishes the current usage of the display-selected profiles (plus the
+/// active profile) to the WidgetKit extension.
 ///
 /// Mirrors `StatuslineService.writeUsageCache`: after each refresh cycle the
 /// app serializes a small JSON snapshot to Application Support and asks
-/// WidgetKit to reload timelines. Writes are skipped when nothing meaningful
-/// changed so the WidgetKit reload budget is not burned on identical data.
+/// WidgetKit to reload timelines. Timeline reloads only happen on meaningful
+/// changes, but the snapshot itself is rewritten at least every
+/// `heartbeatInterval` — the widget uses `generatedAt` as an app-alive
+/// signal, so a healthy app with flat usage must still refresh it.
 final class WidgetSnapshotService {
     static let shared = WidgetSnapshotService()
 
     private var lastPublishedProfiles: [WidgetSnapshot.ProfileEntry]?
+    private var lastWriteTime: Date = .distantPast
     private var lastReloadTime: Date = .distantPast
+
+    /// Maximum age of the on-disk snapshot while the app is running. Must be
+    /// comfortably below the widget's stale threshold (15 min).
+    private static let heartbeatInterval: TimeInterval = 5 * 60
 
     /// Minimum spacing between WidgetKit reload requests, so frequent
     /// refresh cycles don't exhaust the system's reload budget.
@@ -21,32 +28,39 @@ final class WidgetSnapshotService {
     private init() {}
 
     /// Builds a snapshot from the given profiles and publishes it if it
-    /// differs from the last published one.
+    /// differs from the last published one or the heartbeat is due.
     func publish(profiles: [Profile], activeProfileId: UUID?) {
-        let entries: [WidgetSnapshot.ProfileEntry] = profiles
-            .filter { $0.isSelectedForDisplay }
-            .compactMap { profile in
-                guard let usage = profile.claudeUsage else { return nil }
-                return WidgetSnapshot.ProfileEntry(
-                    id: profile.id,
-                    name: profile.name,
-                    isActive: profile.id == activeProfileId,
-                    sessionPercentage: usage.effectiveSessionPercentage,
-                    sessionResetTime: usage.sessionResetTime,
-                    weeklyPercentage: usage.weeklyPercentage,
-                    weeklyResetTime: usage.weeklyResetTime,
-                    lastUpdated: usage.lastUpdated
-                )
-            }
+        let entries: [WidgetSnapshot.ProfileEntry] = profiles.compactMap { profile in
+            let isActive = profile.id == activeProfileId
+            // The active profile is always included so the small widget can
+            // show it even when it is deselected from menu bar display.
+            guard profile.isSelectedForDisplay || isActive else { return nil }
+            guard let usage = profile.claudeUsage else { return nil }
+            return WidgetSnapshot.ProfileEntry(
+                id: profile.id,
+                name: profile.name,
+                isActive: isActive,
+                isDisplayed: profile.isSelectedForDisplay,
+                sessionPercentage: usage.effectiveSessionPercentage,
+                sessionResetTime: usage.sessionResetTime,
+                weeklyPercentage: usage.weeklyPercentage,
+                weeklyResetTime: usage.weeklyResetTime,
+                lastUpdated: usage.lastUpdated
+            )
+        }
 
         guard !entries.isEmpty else { return }
-        guard hasMeaningfulChange(entries) else { return }
+
+        let changed = hasMeaningfulChange(entries)
+        let heartbeatDue = Date().timeIntervalSince(lastWriteTime) >= Self.heartbeatInterval
+        guard changed || heartbeatDue else { return }
 
         let snapshot = WidgetSnapshot(generatedAt: Date(), profiles: entries)
         do {
             try snapshot.write()
+            lastWriteTime = Date()
             lastPublishedProfiles = entries
-            if Date().timeIntervalSince(lastReloadTime) >= Self.reloadInterval {
+            if changed, Date().timeIntervalSince(lastReloadTime) >= Self.reloadInterval {
                 lastReloadTime = Date()
                 WidgetCenter.shared.reloadAllTimelines()
             }
@@ -62,7 +76,8 @@ final class WidgetSnapshotService {
             return true
         }
         for (old, new) in zip(previous, entries) {
-            let identityChanged = old.id != new.id || old.name != new.name || old.isActive != new.isActive
+            let identityChanged = old.id != new.id || old.name != new.name
+                || old.isActive != new.isActive || old.isDisplayed != new.isDisplayed
             let sessionChanged = Int(old.sessionPercentage) != Int(new.sessionPercentage)
                 || Int(old.sessionResetTime.timeIntervalSince1970) != Int(new.sessionResetTime.timeIntervalSince1970)
             let weeklyChanged = Int(old.weeklyPercentage) != Int(new.weeklyPercentage)

--- a/Claude Usage/Shared/Services/WidgetSnapshotService.swift
+++ b/Claude Usage/Shared/Services/WidgetSnapshotService.swift
@@ -48,6 +48,25 @@ final class WidgetSnapshotService {
         self.reloadInterval = reloadInterval
     }
 
+    /// The snapshot file is readable outside the sandbox (the widget reaches
+    /// it through a read-only path exception, not an App Group), so profile
+    /// names are reduced before persisting: an email-shaped name — the usual
+    /// case for credential-derived profiles — keeps only its local part, and
+    /// the result is stripped of control characters and length-capped.
+    static let maxProfileNameLength = 64
+
+    static func sanitizedProfileName(_ raw: String) -> String {
+        var name = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let at = name.firstIndex(of: "@"),
+           at != name.startIndex,
+           name[name.index(after: at)...].contains(".") {
+            name = String(name[..<at])
+        }
+        let scalars = name.unicodeScalars.filter { !CharacterSet.controlCharacters.contains($0) }
+        name = String(String.UnicodeScalarView(scalars))
+        return String(name.prefix(maxProfileNameLength))
+    }
+
     /// Builds a snapshot from the given profiles and publishes it if it
     /// differs from the last published one or the heartbeat is due.
     func publish(profiles: [Profile], activeProfileId: UUID?) {
@@ -59,7 +78,7 @@ final class WidgetSnapshotService {
             guard let usage = profile.claudeUsage else { return nil }
             return WidgetSnapshot.ProfileEntry(
                 id: profile.id,
-                name: profile.name,
+                name: Self.sanitizedProfileName(profile.name),
                 isActive: isActive,
                 isDisplayed: profile.isSelectedForDisplay,
                 sessionPercentage: usage.effectiveSessionPercentage,

--- a/Claude Usage/Shared/Services/WidgetSnapshotService.swift
+++ b/Claude Usage/Shared/Services/WidgetSnapshotService.swift
@@ -49,8 +49,9 @@ final class WidgetSnapshotService {
             )
         }
 
-        guard !entries.isEmpty else { return }
-
+        // An empty entries list is still published: it clears the widget to
+        // its no-data state (e.g. after the last credentials were removed).
+        // Old data must not linger on disk until the stale threshold.
         let changed = hasMeaningfulChange(entries)
         let heartbeatDue = Date().timeIntervalSince(lastWriteTime) >= Self.heartbeatInterval
         guard changed || heartbeatDue else { return }

--- a/Claude Usage/Shared/Services/WidgetSnapshotService.swift
+++ b/Claude Usage/Shared/Services/WidgetSnapshotService.swift
@@ -13,19 +13,40 @@ import WidgetKit
 final class WidgetSnapshotService {
     static let shared = WidgetSnapshotService()
 
+    /// Serializes all publish state; `publish` may be called from any thread.
+    private let lock = NSLock()
     private var lastPublishedProfiles: [WidgetSnapshot.ProfileEntry]?
     private var lastWriteTime: Date = .distantPast
     private var lastReloadTime: Date = .distantPast
+    private var pendingReload: DispatchWorkItem?
 
     /// Maximum age of the on-disk snapshot while the app is running. Must be
     /// comfortably below the widget's stale threshold (15 min).
-    private static let heartbeatInterval: TimeInterval = 5 * 60
+    private let heartbeatInterval: TimeInterval
 
     /// Minimum spacing between WidgetKit reload requests, so frequent
     /// refresh cycles don't exhaust the system's reload budget.
-    private static let reloadInterval: TimeInterval = 60
+    private let reloadInterval: TimeInterval
 
-    private init() {}
+    private let now: () -> Date
+    private let writeSnapshot: (WidgetSnapshot) throws -> Void
+    private let requestReload: () -> Void
+
+    /// Dependency-injecting initializer; production code uses `shared`,
+    /// tests substitute the clock, writer, and reload hook.
+    init(
+        now: @escaping () -> Date = Date.init,
+        writeSnapshot: @escaping (WidgetSnapshot) throws -> Void = { try $0.write() },
+        requestReload: @escaping () -> Void = { WidgetCenter.shared.reloadAllTimelines() },
+        heartbeatInterval: TimeInterval = 5 * 60,
+        reloadInterval: TimeInterval = 60
+    ) {
+        self.now = now
+        self.writeSnapshot = writeSnapshot
+        self.requestReload = requestReload
+        self.heartbeatInterval = heartbeatInterval
+        self.reloadInterval = reloadInterval
+    }
 
     /// Builds a snapshot from the given profiles and publishes it if it
     /// differs from the last published one or the heartbeat is due.
@@ -48,25 +69,56 @@ final class WidgetSnapshotService {
                 lastUpdated: usage.lastUpdated
             )
         }
+        publish(entries: entries)
+    }
 
-        // An empty entries list is still published: it clears the widget to
-        // its no-data state (e.g. after the last credentials were removed).
-        // Old data must not linger on disk until the stale threshold.
+    /// An empty entries list is still published: it clears the widget to
+    /// its no-data state (e.g. after the last credentials were removed).
+    /// Old data must not linger on disk until the stale threshold.
+    func publish(entries: [WidgetSnapshot.ProfileEntry]) {
+        lock.lock()
+        defer { lock.unlock() }
+
         let changed = hasMeaningfulChange(entries)
-        let heartbeatDue = Date().timeIntervalSince(lastWriteTime) >= Self.heartbeatInterval
+        let heartbeatDue = now().timeIntervalSince(lastWriteTime) >= heartbeatInterval
         guard changed || heartbeatDue else { return }
 
-        let snapshot = WidgetSnapshot(generatedAt: Date(), profiles: entries)
+        let snapshot = WidgetSnapshot(generatedAt: now(), profiles: entries)
         do {
-            try snapshot.write()
-            lastWriteTime = Date()
+            try writeSnapshot(snapshot)
+            lastWriteTime = now()
             lastPublishedProfiles = entries
-            if changed, Date().timeIntervalSince(lastReloadTime) >= Self.reloadInterval {
-                lastReloadTime = Date()
-                WidgetCenter.shared.reloadAllTimelines()
+            if changed {
+                requestOrDeferReloadLocked()
             }
         } catch {
             LoggingService.shared.log("WidgetSnapshotService: Failed to write snapshot - \(error.localizedDescription)")
+        }
+    }
+
+    /// Reloads immediately when outside the throttle window; otherwise
+    /// schedules a single deferred reload for when the window reopens, so a
+    /// throttled change is never silently dropped until the next one.
+    /// Must be called with `lock` held.
+    private func requestOrDeferReloadLocked() {
+        let remaining = reloadInterval - now().timeIntervalSince(lastReloadTime)
+        if remaining <= 0 {
+            pendingReload?.cancel()
+            pendingReload = nil
+            lastReloadTime = now()
+            requestReload()
+        } else if pendingReload == nil {
+            let work = DispatchWorkItem { [weak self] in
+                guard let self else { return }
+                self.lock.lock()
+                defer { self.lock.unlock() }
+                guard self.pendingReload != nil else { return }
+                self.pendingReload = nil
+                self.lastReloadTime = self.now()
+                self.requestReload()
+            }
+            pendingReload = work
+            DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + remaining, execute: work)
         }
     }
 

--- a/Claude UsageTests/WidgetSnapshotServiceTests.swift
+++ b/Claude UsageTests/WidgetSnapshotServiceTests.swift
@@ -6,7 +6,22 @@ final class WidgetSnapshotServiceTests: XCTestCase {
     /// Fixed reference clock so heartbeat/throttle behavior is deterministic.
     private var currentDate = Date(timeIntervalSince1970: 1_700_000_000)
     private var writtenSnapshots: [WidgetSnapshot] = []
-    private var reloadCount = 0
+
+    /// Incremented from the deferred-reload utility queue while the test
+    /// thread reads it, so all access goes through a lock.
+    private let reloadCountLock = NSLock()
+    private var _reloadCount = 0
+    private var reloadCount: Int {
+        reloadCountLock.lock()
+        defer { reloadCountLock.unlock() }
+        return _reloadCount
+    }
+
+    private func incrementReloadCount() {
+        reloadCountLock.lock()
+        defer { reloadCountLock.unlock() }
+        _reloadCount += 1
+    }
 
     private func makeService(
         heartbeatInterval: TimeInterval = 300,
@@ -15,7 +30,7 @@ final class WidgetSnapshotServiceTests: XCTestCase {
         WidgetSnapshotService(
             now: { self.currentDate },
             writeSnapshot: { self.writtenSnapshots.append($0) },
-            requestReload: { self.reloadCount += 1 },
+            requestReload: { self.incrementReloadCount() },
             heartbeatInterval: heartbeatInterval,
             reloadInterval: reloadInterval
         )
@@ -99,6 +114,16 @@ final class WidgetSnapshotServiceTests: XCTestCase {
     }
 
     // MARK: - Reload throttling
+
+    func testEmptyEntriesClearSnapshot() {
+        let service = makeService(reloadInterval: 0)
+        service.publish(entries: [makeEntry()])
+        service.publish(entries: [])
+
+        XCTAssertEqual(writtenSnapshots.count, 2)
+        XCTAssertTrue(writtenSnapshots[1].profiles.isEmpty)
+        XCTAssertEqual(reloadCount, 2)
+    }
 
     func testThrottledReloadIsDeferredNotDropped() {
         // Real (non-mocked) delay: the deferred reload is scheduled with

--- a/Claude UsageTests/WidgetSnapshotServiceTests.swift
+++ b/Claude UsageTests/WidgetSnapshotServiceTests.swift
@@ -120,4 +120,31 @@ final class WidgetSnapshotServiceTests: XCTestCase {
         }
         XCTAssertEqual(reloadCount, 2, "throttled reload must fire once the window reopens")
     }
+
+    // MARK: - Profile name sanitization
+
+    func testEmailShapedNameKeepsOnlyLocalPart() {
+        XCTAssertEqual(WidgetSnapshotService.sanitizedProfileName("user@example.com"), "user")
+    }
+
+    func testPlainNameIsUnchanged() {
+        XCTAssertEqual(WidgetSnapshotService.sanitizedProfileName("Work laptop"), "Work laptop")
+    }
+
+    func testAtWithoutDomainDotIsNotTreatedAsEmail() {
+        XCTAssertEqual(WidgetSnapshotService.sanitizedProfileName("team@lab"), "team@lab")
+    }
+
+    func testLeadingAtIsNotTreatedAsEmail() {
+        XCTAssertEqual(WidgetSnapshotService.sanitizedProfileName("@handle.dev"), "@handle.dev")
+    }
+
+    func testControlCharactersAreStrippedAndLengthCapped() {
+        let raw = "bad\u{0000}name\n" + String(repeating: "x", count: 100)
+        let sanitized = WidgetSnapshotService.sanitizedProfileName(raw)
+        XCTAssertFalse(sanitized.contains("\u{0000}"))
+        XCTAssertFalse(sanitized.contains("\n"))
+        XCTAssertEqual(sanitized.count, 64)
+        XCTAssertTrue(sanitized.hasPrefix("badname"))
+    }
 }

--- a/Claude UsageTests/WidgetSnapshotServiceTests.swift
+++ b/Claude UsageTests/WidgetSnapshotServiceTests.swift
@@ -1,0 +1,123 @@
+import XCTest
+@testable import Claude_Usage
+
+final class WidgetSnapshotServiceTests: XCTestCase {
+
+    /// Fixed reference clock so heartbeat/throttle behavior is deterministic.
+    private var currentDate = Date(timeIntervalSince1970: 1_700_000_000)
+    private var writtenSnapshots: [WidgetSnapshot] = []
+    private var reloadCount = 0
+
+    private func makeService(
+        heartbeatInterval: TimeInterval = 300,
+        reloadInterval: TimeInterval = 60
+    ) -> WidgetSnapshotService {
+        WidgetSnapshotService(
+            now: { self.currentDate },
+            writeSnapshot: { self.writtenSnapshots.append($0) },
+            requestReload: { self.reloadCount += 1 },
+            heartbeatInterval: heartbeatInterval,
+            reloadInterval: reloadInterval
+        )
+    }
+
+    private func makeEntry(
+        id: UUID = UUID(),
+        name: String = "Test",
+        sessionPercentage: Double = 42,
+        weeklyPercentage: Double = 61
+    ) -> WidgetSnapshot.ProfileEntry {
+        WidgetSnapshot.ProfileEntry(
+            id: id,
+            name: name,
+            isActive: true,
+            isDisplayed: true,
+            sessionPercentage: sessionPercentage,
+            sessionResetTime: Date(timeIntervalSince1970: 1_700_010_000),
+            weeklyPercentage: weeklyPercentage,
+            weeklyResetTime: Date(timeIntervalSince1970: 1_700_080_000),
+            lastUpdated: currentDate
+        )
+    }
+
+    // MARK: - Change detection
+
+    func testFirstPublishWritesAndReloads() {
+        let service = makeService()
+        service.publish(entries: [makeEntry()])
+
+        XCTAssertEqual(writtenSnapshots.count, 1)
+        XCTAssertEqual(reloadCount, 1)
+    }
+
+    func testSubPercentJitterDoesNotRewrite() {
+        let service = makeService()
+        let id = UUID()
+        service.publish(entries: [makeEntry(id: id, sessionPercentage: 42.2)])
+        currentDate += 30
+        service.publish(entries: [makeEntry(id: id, sessionPercentage: 42.8)])
+
+        XCTAssertEqual(writtenSnapshots.count, 1)
+        XCTAssertEqual(reloadCount, 1)
+    }
+
+    func testWholePercentChangeRewrites() {
+        let service = makeService()
+        let id = UUID()
+        service.publish(entries: [makeEntry(id: id, sessionPercentage: 42)])
+        currentDate += 90
+        service.publish(entries: [makeEntry(id: id, sessionPercentage: 43)])
+
+        XCTAssertEqual(writtenSnapshots.count, 2)
+        XCTAssertEqual(reloadCount, 2)
+    }
+
+    // MARK: - Heartbeat
+
+    func testHeartbeatRewritesWithoutReload() {
+        let service = makeService(heartbeatInterval: 300)
+        service.publish(entries: [makeEntry()])
+        let entry = writtenSnapshots[0].profiles[0]
+
+        currentDate += 301
+        service.publish(entries: [entry])
+
+        XCTAssertEqual(writtenSnapshots.count, 2, "heartbeat must rewrite the snapshot")
+        XCTAssertEqual(reloadCount, 1, "an unchanged heartbeat write must not spend a reload")
+        XCTAssertEqual(writtenSnapshots[1].generatedAt, currentDate)
+    }
+
+    func testUnchangedBeforeHeartbeatDoesNotRewrite() {
+        let service = makeService(heartbeatInterval: 300)
+        service.publish(entries: [makeEntry()])
+        let entry = writtenSnapshots[0].profiles[0]
+
+        currentDate += 120
+        service.publish(entries: [entry])
+
+        XCTAssertEqual(writtenSnapshots.count, 1)
+    }
+
+    // MARK: - Reload throttling
+
+    func testThrottledReloadIsDeferredNotDropped() {
+        // Real (non-mocked) delay: the deferred reload is scheduled with
+        // DispatchQueue.asyncAfter, so use a short real interval.
+        let service = makeService(reloadInterval: 0.2)
+        let id = UUID()
+        service.publish(entries: [makeEntry(id: id, sessionPercentage: 10)])
+        XCTAssertEqual(reloadCount, 1)
+
+        // Meaningful change inside the throttle window: snapshot written,
+        // reload deferred instead of dropped.
+        service.publish(entries: [makeEntry(id: id, sessionPercentage: 50)])
+        XCTAssertEqual(writtenSnapshots.count, 2)
+        XCTAssertEqual(reloadCount, 1)
+
+        let deadline = Date().addingTimeInterval(2)
+        while reloadCount < 2 && Date() < deadline {
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        }
+        XCTAssertEqual(reloadCount, 2, "throttled reload must fire once the window reopens")
+    }
+}

--- a/Claude UsageTests/WidgetSnapshotTests.swift
+++ b/Claude UsageTests/WidgetSnapshotTests.swift
@@ -59,6 +59,21 @@ final class WidgetSnapshotTests: XCTestCase {
         XCTAssertTrue(path.hasSuffix("Library/Application Support/Claude Usage/widget/snapshot.json"))
     }
 
+    // MARK: - Schema version
+
+    func testLoadRejectsUnknownSchemaVersion() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("WidgetSnapshotTests-\(UUID().uuidString)")
+            .appendingPathComponent("snapshot.json")
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+
+        var snapshot = WidgetSnapshot(generatedAt: Date(), profiles: [makeEntry()])
+        snapshot.schemaVersion = WidgetSnapshot.currentSchemaVersion + 1
+        try snapshot.write(to: url)
+
+        XCTAssertNil(WidgetSnapshot.load(from: url))
+    }
+
     // MARK: - Write and load
 
     func testWriteAndLoad() throws {

--- a/Claude UsageTests/WidgetSnapshotTests.swift
+++ b/Claude UsageTests/WidgetSnapshotTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+@testable import Claude_Usage
+
+final class WidgetSnapshotTests: XCTestCase {
+
+    private func makeEntry(
+        name: String = "Test",
+        isActive: Bool = true,
+        sessionPercentage: Double = 42,
+        weeklyPercentage: Double = 61
+    ) -> WidgetSnapshot.ProfileEntry {
+        WidgetSnapshot.ProfileEntry(
+            id: UUID(),
+            name: name,
+            isActive: isActive,
+            sessionPercentage: sessionPercentage,
+            sessionResetTime: Date().addingTimeInterval(3600),
+            weeklyPercentage: weeklyPercentage,
+            weeklyResetTime: Date().addingTimeInterval(86400),
+            lastUpdated: Date()
+        )
+    }
+
+    // MARK: - Codable round trip
+
+    func testSnapshotRoundTrip() throws {
+        let snapshot = WidgetSnapshot(generatedAt: Date(), profiles: [makeEntry()])
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(snapshot)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(WidgetSnapshot.self, from: data)
+
+        XCTAssertEqual(decoded.schemaVersion, 1)
+        XCTAssertEqual(decoded.profiles.count, 1)
+        XCTAssertEqual(decoded.profiles[0].name, "Test")
+        XCTAssertEqual(decoded.profiles[0].sessionPercentage, 42, accuracy: 0.01)
+        // ISO8601 has second precision; anything closer is fine
+        XCTAssertEqual(
+            decoded.profiles[0].sessionResetTime.timeIntervalSince1970,
+            snapshot.profiles[0].sessionResetTime.timeIntervalSince1970,
+            accuracy: 1.0
+        )
+    }
+
+    // MARK: - Snapshot location
+
+    func testSnapshotURLIsOutsideAnyContainer() {
+        // The widget reads via a home-relative-path exception entitlement, so
+        // the path must resolve against the real user home, never a sandbox
+        // container translocation.
+        let path = WidgetSnapshot.snapshotURL.path
+        XCTAssertFalse(path.contains("/Containers/"))
+        XCTAssertTrue(path.hasSuffix("Library/Application Support/Claude Usage/widget/snapshot.json"))
+    }
+
+    // MARK: - Write and load
+
+    func testWriteAndLoad() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("WidgetSnapshotTests-\(UUID().uuidString)")
+            .appendingPathComponent("snapshot.json")
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+
+        let snapshot = WidgetSnapshot(generatedAt: Date(), profiles: [makeEntry(name: "RoundTrip")])
+        try snapshot.write(to: url)
+
+        let loaded = WidgetSnapshot.load(from: url)
+        XCTAssertNotNil(loaded)
+        XCTAssertEqual(loaded?.profiles.first?.name, "RoundTrip")
+    }
+}

--- a/Claude UsageTests/WidgetSnapshotTests.swift
+++ b/Claude UsageTests/WidgetSnapshotTests.swift
@@ -6,6 +6,7 @@ final class WidgetSnapshotTests: XCTestCase {
     private func makeEntry(
         name: String = "Test",
         isActive: Bool = true,
+        isDisplayed: Bool = true,
         sessionPercentage: Double = 42,
         weeklyPercentage: Double = 61
     ) -> WidgetSnapshot.ProfileEntry {
@@ -13,6 +14,7 @@ final class WidgetSnapshotTests: XCTestCase {
             id: UUID(),
             name: name,
             isActive: isActive,
+            isDisplayed: isDisplayed,
             sessionPercentage: sessionPercentage,
             sessionResetTime: Date().addingTimeInterval(3600),
             weeklyPercentage: weeklyPercentage,

--- a/ClaudeUsageWidget/ClaudeUsageWidget.entitlements
+++ b/ClaudeUsageWidget/ClaudeUsageWidget.entitlements
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<!-- Read-only access to the snapshot the main app publishes.
+	     Deliberately NOT an App Group: group entitlements trigger Keychain
+	     prompts for Developer ID distribution (see CONTRIBUTING guidelines). -->
+	<key>com.apple.security.temporary-exception.files.home-relative-path.read-only</key>
+	<array>
+		<string>/Library/Application Support/Claude Usage/widget/</string>
+	</array>
+</dict>
+</plist>

--- a/ClaudeUsageWidget/ClaudeUsageWidgetBundle.swift
+++ b/ClaudeUsageWidget/ClaudeUsageWidgetBundle.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+import WidgetKit
+
+@main
+struct ClaudeUsageWidgetBundle: WidgetBundle {
+    var body: some Widget {
+        SessionUsageWidget()
+        UsageOverviewWidget()
+    }
+}

--- a/ClaudeUsageWidget/Info.plist
+++ b/ClaudeUsageWidget/Info.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/ClaudeUsageWidget/Resources/de.lproj/Localizable.strings
+++ b/ClaudeUsageWidget/Resources/de.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* Claude Usage Widget */
+"widget.no_data" = "Öffne Claude Usage, um Nutzungsdaten zu laden";
+"widget.session" = "Sitzung";
+"widget.weekly" = "Wöchentlich";
+"widget.session.name" = "Sitzungsnutzung";
+"widget.session.desc" = "Aktuelle 5-Stunden-Sitzungsnutzung des aktiven Profils.";
+"widget.overview.name" = "Nutzungsübersicht";
+"widget.overview.desc" = "Sitzungs- und Wochennutzung aller angezeigten Profile.";

--- a/ClaudeUsageWidget/Resources/en.lproj/Localizable.strings
+++ b/ClaudeUsageWidget/Resources/en.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* Claude Usage Widget */
+"widget.no_data" = "Open Claude Usage to load usage data";
+"widget.session" = "Session";
+"widget.weekly" = "Weekly";
+"widget.session.name" = "Session Usage";
+"widget.session.desc" = "Current 5-hour session usage for the active profile.";
+"widget.overview.name" = "Usage Overview";
+"widget.overview.desc" = "Session and weekly usage for all displayed profiles.";

--- a/ClaudeUsageWidget/Resources/es.lproj/Localizable.strings
+++ b/ClaudeUsageWidget/Resources/es.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* Claude Usage Widget */
+"widget.no_data" = "Abre Claude Usage para cargar los datos de uso";
+"widget.session" = "Sesión";
+"widget.weekly" = "Semanal";
+"widget.session.name" = "Uso de sesión";
+"widget.session.desc" = "Uso actual de la sesión de 5 horas del perfil activo.";
+"widget.overview.name" = "Resumen de uso";
+"widget.overview.desc" = "Uso de sesión y semanal de todos los perfiles mostrados.";

--- a/ClaudeUsageWidget/Resources/fr.lproj/Localizable.strings
+++ b/ClaudeUsageWidget/Resources/fr.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* Claude Usage Widget */
+"widget.no_data" = "Ouvrez Claude Usage pour charger les données d'utilisation";
+"widget.session" = "Session";
+"widget.weekly" = "Hebdomadaire";
+"widget.session.name" = "Utilisation de session";
+"widget.session.desc" = "Utilisation actuelle de la session de 5 heures du profil actif.";
+"widget.overview.name" = "Aperçu de l'utilisation";
+"widget.overview.desc" = "Utilisation de session et hebdomadaire de tous les profils affichés.";

--- a/ClaudeUsageWidget/Resources/it.lproj/Localizable.strings
+++ b/ClaudeUsageWidget/Resources/it.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* Claude Usage Widget */
+"widget.no_data" = "Apri Claude Usage per caricare i dati di utilizzo";
+"widget.session" = "Sessione";
+"widget.weekly" = "Settimanale";
+"widget.session.name" = "Utilizzo sessione";
+"widget.session.desc" = "Utilizzo attuale della sessione di 5 ore del profilo attivo.";
+"widget.overview.name" = "Panoramica utilizzo";
+"widget.overview.desc" = "Utilizzo di sessione e settimanale di tutti i profili visualizzati.";

--- a/ClaudeUsageWidget/Resources/ja.lproj/Localizable.strings
+++ b/ClaudeUsageWidget/Resources/ja.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* Claude Usage Widget */
+"widget.no_data" = "Claude Usage を起動すると使用状況が表示されます";
+"widget.session" = "セッション";
+"widget.weekly" = "週間";
+"widget.session.name" = "セッション使用量";
+"widget.session.desc" = "アクティブなプロファイルの5時間セッション使用量。";
+"widget.overview.name" = "使用量オーバービュー";
+"widget.overview.desc" = "表示中の全プロファイルのセッション・週間使用量。";

--- a/ClaudeUsageWidget/Resources/ko.lproj/Localizable.strings
+++ b/ClaudeUsageWidget/Resources/ko.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* Claude Usage Widget */
+"widget.no_data" = "Claude Usage를 실행하면 사용량이 표시됩니다";
+"widget.session" = "세션";
+"widget.weekly" = "주간";
+"widget.session.name" = "세션 사용량";
+"widget.session.desc" = "활성 프로필의 5시간 세션 사용량입니다.";
+"widget.overview.name" = "사용량 개요";
+"widget.overview.desc" = "표시된 모든 프로필의 세션 및 주간 사용량입니다.";

--- a/ClaudeUsageWidget/Resources/pt-BR.lproj/Localizable.strings
+++ b/ClaudeUsageWidget/Resources/pt-BR.lproj/Localizable.strings
@@ -5,4 +5,4 @@
 "widget.session.name" = "Uso da sessão";
 "widget.session.desc" = "Uso atual da sessão de 5 horas do perfil ativo.";
 "widget.overview.name" = "Visão geral de uso";
-"widget.overview.desc" = "Uso de sessão e semanal de todos os perfis exibidos.";
+"widget.overview.desc" = "Uso da sessão e uso semanal de todos os perfis exibidos.";

--- a/ClaudeUsageWidget/Resources/pt-BR.lproj/Localizable.strings
+++ b/ClaudeUsageWidget/Resources/pt-BR.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* Claude Usage Widget */
+"widget.no_data" = "Abra o Claude Usage para carregar os dados de uso";
+"widget.session" = "Sessão";
+"widget.weekly" = "Semanal";
+"widget.session.name" = "Uso da sessão";
+"widget.session.desc" = "Uso atual da sessão de 5 horas do perfil ativo.";
+"widget.overview.name" = "Visão geral de uso";
+"widget.overview.desc" = "Uso de sessão e semanal de todos os perfis exibidos.";

--- a/ClaudeUsageWidget/Resources/pt.lproj/Localizable.strings
+++ b/ClaudeUsageWidget/Resources/pt.lproj/Localizable.strings
@@ -5,4 +5,4 @@
 "widget.session.name" = "Utilização da sessão";
 "widget.session.desc" = "Utilização atual da sessão de 5 horas do perfil ativo.";
 "widget.overview.name" = "Visão geral da utilização";
-"widget.overview.desc" = "Utilização de sessão e semanal de todos os perfis apresentados.";
+"widget.overview.desc" = "Utilização da sessão e utilização semanal de todos os perfis apresentados.";

--- a/ClaudeUsageWidget/Resources/pt.lproj/Localizable.strings
+++ b/ClaudeUsageWidget/Resources/pt.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* Claude Usage Widget */
+"widget.no_data" = "Abra o Claude Usage para carregar os dados de utilização";
+"widget.session" = "Sessão";
+"widget.weekly" = "Semanal";
+"widget.session.name" = "Utilização da sessão";
+"widget.session.desc" = "Utilização atual da sessão de 5 horas do perfil ativo.";
+"widget.overview.name" = "Visão geral da utilização";
+"widget.overview.desc" = "Utilização de sessão e semanal de todos os perfis apresentados.";

--- a/ClaudeUsageWidget/Resources/tr.lproj/Localizable.strings
+++ b/ClaudeUsageWidget/Resources/tr.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* Claude Usage Widget */
+"widget.no_data" = "Kullanım verilerini yüklemek için Claude Usage'ı açın";
+"widget.session" = "Oturum";
+"widget.weekly" = "Haftalık";
+"widget.session.name" = "Oturum Kullanımı";
+"widget.session.desc" = "Etkin profilin mevcut 5 saatlik oturum kullanımı.";
+"widget.overview.name" = "Kullanım Özeti";
+"widget.overview.desc" = "Görüntülenen tüm profillerin oturum ve haftalık kullanımı.";

--- a/ClaudeUsageWidget/Resources/uk.lproj/Localizable.strings
+++ b/ClaudeUsageWidget/Resources/uk.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* Claude Usage Widget */
+"widget.no_data" = "Відкрийте Claude Usage, щоб завантажити дані використання";
+"widget.session" = "Сесія";
+"widget.weekly" = "Тиждень";
+"widget.session.name" = "Використання сесії";
+"widget.session.desc" = "Поточне використання 5-годинної сесії активного профілю.";
+"widget.overview.name" = "Огляд використання";
+"widget.overview.desc" = "Сесійне та тижневе використання всіх відображених профілів.";

--- a/ClaudeUsageWidget/Resources/zh-Hans.lproj/Localizable.strings
+++ b/ClaudeUsageWidget/Resources/zh-Hans.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* Claude Usage Widget */
+"widget.no_data" = "打开 Claude Usage 以加载使用数据";
+"widget.session" = "会话";
+"widget.weekly" = "每周";
+"widget.session.name" = "会话用量";
+"widget.session.desc" = "当前活跃配置文件的 5 小时会话用量。";
+"widget.overview.name" = "用量概览";
+"widget.overview.desc" = "所有显示的配置文件的会话及每周用量。";

--- a/ClaudeUsageWidget/Resources/zh-Hant.lproj/Localizable.strings
+++ b/ClaudeUsageWidget/Resources/zh-Hant.lproj/Localizable.strings
@@ -1,0 +1,8 @@
+/* Claude Usage Widget */
+"widget.no_data" = "開啟 Claude Usage 以載入使用資料";
+"widget.session" = "工作階段";
+"widget.weekly" = "每週";
+"widget.session.name" = "工作階段用量";
+"widget.session.desc" = "目前使用中設定檔的 5 小時工作階段用量。";
+"widget.overview.name" = "用量總覽";
+"widget.overview.desc" = "所有顯示設定檔的工作階段與每週用量。";

--- a/ClaudeUsageWidget/UsageTimelineProvider.swift
+++ b/ClaudeUsageWidget/UsageTimelineProvider.swift
@@ -5,13 +5,22 @@ struct UsageEntry: TimelineEntry {
     let date: Date
     let snapshot: WidgetSnapshot?
 
-    /// Snapshots older than this are rendered dimmed — the app is probably
-    /// not running, so the numbers can no longer be trusted.
+    /// Data older than this is rendered dimmed — the app is probably not
+    /// running (or a profile stopped refreshing), so the numbers can no
+    /// longer be trusted. The app writes a heartbeat snapshot every 5 min.
     static let staleInterval: TimeInterval = 15 * 60
 
+    /// Whole-snapshot staleness: the app stopped publishing entirely.
     var isStale: Bool {
         guard let snapshot else { return true }
         return Date().timeIntervalSince(snapshot.generatedAt) > Self.staleInterval
+    }
+
+    /// Per-profile staleness. The single-profile refresh path only updates
+    /// the active profile, so other profiles can be stale even while the
+    /// snapshot itself is fresh.
+    func isProfileStale(_ profile: WidgetSnapshot.ProfileEntry) -> Bool {
+        isStale || Date().timeIntervalSince(profile.lastUpdated) > Self.staleInterval
     }
 
     static func placeholderSnapshot() -> WidgetSnapshot {
@@ -22,6 +31,7 @@ struct UsageEntry: TimelineEntry {
                     id: UUID(),
                     name: "Claude",
                     isActive: true,
+                    isDisplayed: true,
                     sessionPercentage: 42,
                     sessionResetTime: Date().addingTimeInterval(3 * 3600),
                     weeklyPercentage: 61,

--- a/ClaudeUsageWidget/UsageTimelineProvider.swift
+++ b/ClaudeUsageWidget/UsageTimelineProvider.swift
@@ -1,0 +1,57 @@
+import Foundation
+import WidgetKit
+
+struct UsageEntry: TimelineEntry {
+    let date: Date
+    let snapshot: WidgetSnapshot?
+
+    /// Snapshots older than this are rendered dimmed — the app is probably
+    /// not running, so the numbers can no longer be trusted.
+    static let staleInterval: TimeInterval = 15 * 60
+
+    var isStale: Bool {
+        guard let snapshot else { return true }
+        return Date().timeIntervalSince(snapshot.generatedAt) > Self.staleInterval
+    }
+
+    static func placeholderSnapshot() -> WidgetSnapshot {
+        WidgetSnapshot(
+            generatedAt: Date(),
+            profiles: [
+                WidgetSnapshot.ProfileEntry(
+                    id: UUID(),
+                    name: "Claude",
+                    isActive: true,
+                    sessionPercentage: 42,
+                    sessionResetTime: Date().addingTimeInterval(3 * 3600),
+                    weeklyPercentage: 61,
+                    weeklyResetTime: Date().addingTimeInterval(2 * 86400),
+                    lastUpdated: Date()
+                )
+            ]
+        )
+    }
+}
+
+/// Reads the snapshot the main app publishes to Application Support.
+///
+/// The app requests a timeline reload after every refresh cycle, so entries
+/// here only need a coarse fallback cadence for the case where the app quit.
+struct UsageTimelineProvider: TimelineProvider {
+    func placeholder(in context: Context) -> UsageEntry {
+        UsageEntry(date: Date(), snapshot: UsageEntry.placeholderSnapshot())
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (UsageEntry) -> Void) {
+        let snapshot = context.isPreview
+            ? UsageEntry.placeholderSnapshot()
+            : WidgetSnapshot.load()
+        completion(UsageEntry(date: Date(), snapshot: snapshot))
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<UsageEntry>) -> Void) {
+        let entry = UsageEntry(date: Date(), snapshot: WidgetSnapshot.load())
+        let refresh = Date().addingTimeInterval(15 * 60)
+        completion(Timeline(entries: [entry], policy: .after(refresh)))
+    }
+}

--- a/ClaudeUsageWidget/UsageTimelineProvider.swift
+++ b/ClaudeUsageWidget/UsageTimelineProvider.swift
@@ -11,16 +11,18 @@ struct UsageEntry: TimelineEntry {
     static let staleInterval: TimeInterval = 15 * 60
 
     /// Whole-snapshot staleness: the app stopped publishing entirely.
+    /// Evaluated against the entry's own date so that a boundary entry in
+    /// the timeline flips the dimming at the right moment.
     var isStale: Bool {
         guard let snapshot else { return true }
-        return Date().timeIntervalSince(snapshot.generatedAt) > Self.staleInterval
+        return date.timeIntervalSince(snapshot.generatedAt) > Self.staleInterval
     }
 
     /// Per-profile staleness. The single-profile refresh path only updates
     /// the active profile, so other profiles can be stale even while the
     /// snapshot itself is fresh.
     func isProfileStale(_ profile: WidgetSnapshot.ProfileEntry) -> Bool {
-        isStale || Date().timeIntervalSince(profile.lastUpdated) > Self.staleInterval
+        isStale || date.timeIntervalSince(profile.lastUpdated) > Self.staleInterval
     }
 
     static func placeholderSnapshot() -> WidgetSnapshot {
@@ -48,6 +50,8 @@ struct UsageEntry: TimelineEntry {
 /// The app requests a timeline reload after every refresh cycle, so entries
 /// here only need a coarse fallback cadence for the case where the app quit.
 struct UsageTimelineProvider: TimelineProvider {
+    private static let refreshInterval: TimeInterval = 15 * 60
+
     func placeholder(in context: Context) -> UsageEntry {
         UsageEntry(date: Date(), snapshot: UsageEntry.placeholderSnapshot())
     }
@@ -60,8 +64,28 @@ struct UsageTimelineProvider: TimelineProvider {
     }
 
     func getTimeline(in context: Context, completion: @escaping (Timeline<UsageEntry>) -> Void) {
-        let entry = UsageEntry(date: Date(), snapshot: WidgetSnapshot.load())
-        let refresh = Date().addingTimeInterval(15 * 60)
-        completion(Timeline(entries: [entry], policy: .after(refresh)))
+        let snapshot = WidgetSnapshot.load()
+        let now = Date()
+        let refresh = now.addingTimeInterval(Self.refreshInterval)
+
+        // Besides the immediate entry, add entries at the moments the
+        // rendering changes on its own: staleness boundaries (dimming) and
+        // reset times (countdown disappears). Without them those transitions
+        // would lag until the next reload, up to `refreshInterval` late.
+        var dates: Set<Date> = [now]
+        if let snapshot {
+            var boundaries = [snapshot.generatedAt.addingTimeInterval(UsageEntry.staleInterval)]
+            for profile in snapshot.profiles {
+                boundaries.append(profile.lastUpdated.addingTimeInterval(UsageEntry.staleInterval))
+                boundaries.append(profile.sessionResetTime)
+                boundaries.append(profile.weeklyResetTime)
+            }
+            for boundary in boundaries where boundary > now && boundary < refresh {
+                dates.insert(boundary)
+            }
+        }
+
+        let entries = dates.sorted().map { UsageEntry(date: $0, snapshot: snapshot) }
+        completion(Timeline(entries: entries, policy: .after(refresh)))
     }
 }

--- a/ClaudeUsageWidget/UsageWidgetViews.swift
+++ b/ClaudeUsageWidget/UsageWidgetViews.swift
@@ -15,6 +15,9 @@ private struct UsageBar: View {
     let label: LocalizedStringKey
     let percentage: Double
     let resetTime: Date
+    /// The timeline entry's date — comparisons must use it (not `Date()`)
+    /// so pre-rendered future entries evaluate correctly.
+    let now: Date
 
     var body: some View {
         VStack(alignment: .leading, spacing: 2) {
@@ -30,7 +33,7 @@ private struct UsageBar: View {
             ProgressView(value: min(max(percentage, 0), 100), total: 100)
                 .progressViewStyle(.linear)
                 .tint(usageColor(percentage))
-            if resetTime > Date() {
+            if resetTime > now {
                 Text(resetTime, style: .relative)
                     .font(.system(size: 9))
                     .foregroundStyle(.tertiary)
@@ -136,12 +139,14 @@ struct UsageOverviewWidgetView: View {
                             UsageBar(
                                 label: "widget.session",
                                 percentage: profile.sessionPercentage,
-                                resetTime: profile.sessionResetTime
+                                resetTime: profile.sessionResetTime,
+                                now: entry.date
                             )
                             UsageBar(
                                 label: "widget.weekly",
                                 percentage: profile.weeklyPercentage,
-                                resetTime: profile.weeklyResetTime
+                                resetTime: profile.weeklyResetTime,
+                                now: entry.date
                             )
                         }
                         // Per-row: a profile can go stale on its own — the

--- a/ClaudeUsageWidget/UsageWidgetViews.swift
+++ b/ClaudeUsageWidget/UsageWidgetViews.swift
@@ -18,16 +18,19 @@ private struct UsageBar: View {
     /// The timeline entry's date — comparisons must use it (not `Date()`)
     /// so pre-rendered future entries evaluate correctly.
     let now: Date
+    /// Compact sizing for the medium family's tight rows; the large family
+    /// has room for more legible type.
+    var compact = true
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 2) {
+        VStack(alignment: .leading, spacing: compact ? 2 : 3) {
             HStack {
                 Text(label)
-                    .font(.caption2)
+                    .font(compact ? .caption2 : .caption)
                     .foregroundStyle(.secondary)
                 Spacer()
                 Text("\(Int(percentage))%")
-                    .font(.caption2.monospacedDigit().bold())
+                    .font((compact ? Font.caption2 : .caption).monospacedDigit().bold())
                     .foregroundStyle(usageColor(percentage))
             }
             ProgressView(value: min(max(percentage, 0), 100), total: 100)
@@ -35,7 +38,7 @@ private struct UsageBar: View {
                 .tint(usageColor(percentage))
             if resetTime > now {
                 Text(resetTime, style: .relative)
-                    .font(.system(size: 9))
+                    .font(compact ? .system(size: 9) : .caption2)
                     .foregroundStyle(.tertiary)
             }
         }
@@ -115,49 +118,106 @@ struct SessionUsageWidget: Widget {
     }
 }
 
-// MARK: - Medium widget: all display-selected profiles
+// MARK: - Medium/large widget: all display-selected profiles
 
 struct UsageOverviewWidgetView: View {
+    @Environment(\.widgetFamily) private var family
     let entry: UsageEntry
 
     private var profiles: [WidgetSnapshot.ProfileEntry] {
-        Array((entry.snapshot?.profiles ?? []).filter(\.isDisplayed).prefix(4))
+        let selected = (entry.snapshot?.profiles ?? []).filter(\.isDisplayed)
+        return Array(selected.prefix(family == .systemLarge ? 6 : 4))
     }
 
     var body: some View {
         Group {
             if profiles.isEmpty {
                 NoDataView()
+            } else if family == .systemLarge {
+                largeLayout
             } else {
-                VStack(alignment: .leading, spacing: 8) {
-                    ForEach(profiles) { profile in
-                        HStack(alignment: .top, spacing: 10) {
-                            Text(profile.name)
-                                .font(.caption.bold())
-                                .lineLimit(1)
-                                .frame(width: 78, alignment: .leading)
-                            UsageBar(
-                                label: "widget.session",
-                                percentage: profile.sessionPercentage,
-                                resetTime: profile.sessionResetTime,
-                                now: entry.date
-                            )
-                            UsageBar(
-                                label: "widget.weekly",
-                                percentage: profile.weeklyPercentage,
-                                resetTime: profile.weeklyResetTime,
-                                now: entry.date
-                            )
-                        }
-                        // Per-row: a profile can go stale on its own — the
-                        // single-profile refresh path only updates the
-                        // active profile.
-                        .opacity(entry.isProfileStale(profile) ? 0.4 : 1)
-                    }
-                }
+                mediumLayout
             }
         }
         .containerBackground(.fill.tertiary, for: .widget)
+    }
+
+    /// Large: one card per profile — name as a header line, both bars at
+    /// full width beneath it. Rows share the vertical space equally so the
+    /// content fills the widget instead of clustering in the center.
+    private var largeLayout: some View {
+        VStack(spacing: 6) {
+            ForEach(Array(profiles.enumerated()), id: \.element.id) { index, profile in
+                if index > 0 {
+                    Divider()
+                }
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack(spacing: 4) {
+                        Text(profile.name)
+                            .font(.subheadline.bold())
+                            .lineLimit(1)
+                        if profile.isActive {
+                            Image(systemName: "sparkle")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                        Spacer(minLength: 0)
+                    }
+                    HStack(alignment: .top, spacing: 16) {
+                        UsageBar(
+                            label: "widget.session",
+                            percentage: profile.sessionPercentage,
+                            resetTime: profile.sessionResetTime,
+                            now: entry.date,
+                            compact: false
+                        )
+                        UsageBar(
+                            label: "widget.weekly",
+                            percentage: profile.weeklyPercentage,
+                            resetTime: profile.weeklyResetTime,
+                            now: entry.date,
+                            compact: false
+                        )
+                    }
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                // Per-row: a profile can go stale on its own — the
+                // single-profile refresh path only updates the
+                // active profile.
+                .opacity(entry.isProfileStale(profile) ? 0.4 : 1)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    /// Medium: one compact line per profile, name in a fixed column so the
+    /// bars align across rows. Rows share the vertical space equally.
+    private var mediumLayout: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            ForEach(profiles) { profile in
+                HStack(alignment: .top, spacing: 10) {
+                    Text(profile.name)
+                        .font(.caption.bold())
+                        .lineLimit(1)
+                        .frame(width: 78, alignment: .leading)
+                    UsageBar(
+                        label: "widget.session",
+                        percentage: profile.sessionPercentage,
+                        resetTime: profile.sessionResetTime,
+                        now: entry.date
+                    )
+                    UsageBar(
+                        label: "widget.weekly",
+                        percentage: profile.weeklyPercentage,
+                        resetTime: profile.weeklyResetTime,
+                        now: entry.date
+                    )
+                }
+                .frame(maxHeight: .infinity)
+                .opacity(entry.isProfileStale(profile) ? 0.4 : 1)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 }
 

--- a/ClaudeUsageWidget/UsageWidgetViews.swift
+++ b/ClaudeUsageWidget/UsageWidgetViews.swift
@@ -1,0 +1,162 @@
+import SwiftUI
+import WidgetKit
+
+// MARK: - Shared helpers
+
+private func usageColor(_ percentage: Double) -> Color {
+    switch percentage {
+    case ..<75: return .green
+    case ..<90: return .orange
+    default: return .red
+    }
+}
+
+private struct UsageBar: View {
+    let label: LocalizedStringKey
+    let percentage: Double
+    let resetTime: Date
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack {
+                Text(label)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Text("\(Int(percentage))%")
+                    .font(.caption2.monospacedDigit().bold())
+                    .foregroundStyle(usageColor(percentage))
+            }
+            ProgressView(value: min(max(percentage, 0), 100), total: 100)
+                .progressViewStyle(.linear)
+                .tint(usageColor(percentage))
+            if resetTime > Date() {
+                Text(resetTime, style: .relative)
+                    .font(.system(size: 9))
+                    .foregroundStyle(.tertiary)
+            }
+        }
+    }
+}
+
+private struct NoDataView: View {
+    var body: some View {
+        VStack(spacing: 6) {
+            Image(systemName: "chart.bar.doc.horizontal")
+                .font(.title2)
+                .foregroundStyle(.secondary)
+            Text("widget.no_data")
+                .font(.caption2)
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+
+// MARK: - Small widget: active profile session usage
+
+struct SessionUsageWidgetView: View {
+    let entry: UsageEntry
+
+    private var profile: WidgetSnapshot.ProfileEntry? {
+        entry.snapshot?.profiles.first(where: \.isActive) ?? entry.snapshot?.profiles.first
+    }
+
+    var body: some View {
+        Group {
+            if let profile {
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack(spacing: 4) {
+                        Image(systemName: "sparkle")
+                            .font(.caption2)
+                        Text(profile.name)
+                            .font(.caption.bold())
+                            .lineLimit(1)
+                    }
+                    Gauge(value: min(max(profile.sessionPercentage, 0), 100), in: 0...100) {
+                        Text("widget.session")
+                    } currentValueLabel: {
+                        Text("\(Int(profile.sessionPercentage))%")
+                            .font(.callout.monospacedDigit().bold())
+                    }
+                    .gaugeStyle(.accessoryCircularCapacity)
+                    .tint(usageColor(profile.sessionPercentage))
+                    .frame(maxWidth: .infinity)
+                    if profile.sessionResetTime > entry.date {
+                        Text(profile.sessionResetTime, style: .relative)
+                            .font(.system(size: 9))
+                            .foregroundStyle(.tertiary)
+                            .frame(maxWidth: .infinity, alignment: .center)
+                    }
+                }
+                .opacity(entry.isStale ? 0.4 : 1)
+            } else {
+                NoDataView()
+            }
+        }
+        .containerBackground(.fill.tertiary, for: .widget)
+    }
+}
+
+struct SessionUsageWidget: Widget {
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: "SessionUsageWidget", provider: UsageTimelineProvider()) { entry in
+            SessionUsageWidgetView(entry: entry)
+        }
+        .configurationDisplayName(String(localized: "widget.session.name"))
+        .description(String(localized: "widget.session.desc"))
+        .supportedFamilies([.systemSmall])
+    }
+}
+
+// MARK: - Medium widget: all display-selected profiles
+
+struct UsageOverviewWidgetView: View {
+    let entry: UsageEntry
+
+    private var profiles: [WidgetSnapshot.ProfileEntry] {
+        Array((entry.snapshot?.profiles ?? []).prefix(4))
+    }
+
+    var body: some View {
+        Group {
+            if profiles.isEmpty {
+                NoDataView()
+            } else {
+                VStack(alignment: .leading, spacing: 8) {
+                    ForEach(profiles) { profile in
+                        HStack(alignment: .top, spacing: 10) {
+                            Text(profile.name)
+                                .font(.caption.bold())
+                                .lineLimit(1)
+                                .frame(width: 78, alignment: .leading)
+                            UsageBar(
+                                label: "widget.session",
+                                percentage: profile.sessionPercentage,
+                                resetTime: profile.sessionResetTime
+                            )
+                            UsageBar(
+                                label: "widget.weekly",
+                                percentage: profile.weeklyPercentage,
+                                resetTime: profile.weeklyResetTime
+                            )
+                        }
+                    }
+                }
+                .opacity(entry.isStale ? 0.4 : 1)
+            }
+        }
+        .containerBackground(.fill.tertiary, for: .widget)
+    }
+}
+
+struct UsageOverviewWidget: Widget {
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: "UsageOverviewWidget", provider: UsageTimelineProvider()) { entry in
+            UsageOverviewWidgetView(entry: entry)
+        }
+        .configurationDisplayName(String(localized: "widget.overview.name"))
+        .description(String(localized: "widget.overview.desc"))
+        .supportedFamilies([.systemMedium, .systemLarge])
+    }
+}

--- a/ClaudeUsageWidget/UsageWidgetViews.swift
+++ b/ClaudeUsageWidget/UsageWidgetViews.swift
@@ -59,7 +59,10 @@ struct SessionUsageWidgetView: View {
     let entry: UsageEntry
 
     private var profile: WidgetSnapshot.ProfileEntry? {
-        entry.snapshot?.profiles.first(where: \.isActive) ?? entry.snapshot?.profiles.first
+        let profiles = entry.snapshot?.profiles ?? []
+        return profiles.first(where: \.isActive)
+            ?? profiles.first(where: \.isDisplayed)
+            ?? profiles.first
     }
 
     var body: some View {
@@ -89,7 +92,7 @@ struct SessionUsageWidgetView: View {
                             .frame(maxWidth: .infinity, alignment: .center)
                     }
                 }
-                .opacity(entry.isStale ? 0.4 : 1)
+                .opacity(entry.isProfileStale(profile) ? 0.4 : 1)
             } else {
                 NoDataView()
             }
@@ -115,7 +118,7 @@ struct UsageOverviewWidgetView: View {
     let entry: UsageEntry
 
     private var profiles: [WidgetSnapshot.ProfileEntry] {
-        Array((entry.snapshot?.profiles ?? []).prefix(4))
+        Array((entry.snapshot?.profiles ?? []).filter(\.isDisplayed).prefix(4))
     }
 
     var body: some View {
@@ -141,9 +144,12 @@ struct UsageOverviewWidgetView: View {
                                 resetTime: profile.weeklyResetTime
                             )
                         }
+                        // Per-row: a profile can go stale on its own — the
+                        // single-profile refresh path only updates the
+                        // active profile.
+                        .opacity(entry.isProfileStale(profile) ? 0.4 : 1)
                     }
                 }
-                .opacity(entry.isStale ? 0.4 : 1)
             }
         }
         .containerBackground(.fill.tertiary, for: .widget)

--- a/WidgetShared/WidgetSnapshot.swift
+++ b/WidgetShared/WidgetSnapshot.swift
@@ -14,10 +14,18 @@ struct WidgetSnapshot: Codable {
         let id: UUID
         let name: String
         let isActive: Bool
+        /// Whether the profile is selected for menu bar display. The active
+        /// profile is always included in the snapshot even when deselected
+        /// (the small widget needs it); the overview widget shows only
+        /// displayed profiles.
+        let isDisplayed: Bool
         let sessionPercentage: Double
         let sessionResetTime: Date
         let weeklyPercentage: Double
         let weeklyResetTime: Date
+        /// When this profile's usage was last fetched. Can lag behind
+        /// `generatedAt`: the single-profile refresh path only updates the
+        /// active profile, so per-profile staleness must use this value.
         let lastUpdated: Date
     }
 

--- a/WidgetShared/WidgetSnapshot.swift
+++ b/WidgetShared/WidgetSnapshot.swift
@@ -1,0 +1,82 @@
+import Darwin
+import Foundation
+
+/// Lightweight usage snapshot shared with the WidgetKit extension.
+///
+/// The main app writes this file after every successful usage refresh and the
+/// widget extension reads it from its sandbox (granted read-only access to the
+/// snapshot directory). No App Groups are used — see the contribution
+/// guidelines: App Group entitlements trigger Keychain prompts for Developer
+/// ID distribution, so data is shared through a plain JSON file instead,
+/// following the same pattern as the statusline usage cache.
+struct WidgetSnapshot: Codable {
+    struct ProfileEntry: Codable, Identifiable {
+        let id: UUID
+        let name: String
+        let isActive: Bool
+        let sessionPercentage: Double
+        let sessionResetTime: Date
+        let weeklyPercentage: Double
+        let weeklyResetTime: Date
+        let lastUpdated: Date
+    }
+
+    /// Bump when the on-disk format changes so an old widget build can
+    /// detect a snapshot written by a newer app (and vice versa).
+    var schemaVersion: Int = 1
+    let generatedAt: Date
+    let profiles: [ProfileEntry]
+
+    // MARK: - Location
+
+    /// Directory holding the snapshot:
+    /// `~/Library/Application Support/Claude Usage/widget/`
+    ///
+    /// Resolved against the *real* user home (via `getpwuid`) rather than
+    /// `NSHomeDirectory()`, because inside the sandboxed widget extension the
+    /// latter points at the container, not the path covered by the read-only
+    /// exception entitlement.
+    static var snapshotDirectory: URL {
+        let home: String
+        if let pw = getpwuid(getuid()), let dir = pw.pointee.pw_dir {
+            home = String(cString: dir)
+        } else {
+            home = NSHomeDirectory()
+        }
+        return URL(fileURLWithPath: home)
+            .appendingPathComponent("Library/Application Support/Claude Usage/widget", isDirectory: true)
+    }
+
+    static var snapshotURL: URL {
+        snapshotDirectory.appendingPathComponent("snapshot.json")
+    }
+
+    // MARK: - Coding
+
+    private static var encoder: JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys]
+        return encoder
+    }
+
+    private static var decoder: JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+
+    func write(to url: URL = Self.snapshotURL) throws {
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let data = try Self.encoder.encode(self)
+        try data.write(to: url, options: .atomic)
+    }
+
+    static func load(from url: URL = snapshotURL) -> WidgetSnapshot? {
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        return try? decoder.decode(WidgetSnapshot.self, from: data)
+    }
+}

--- a/WidgetShared/WidgetSnapshot.swift
+++ b/WidgetShared/WidgetSnapshot.swift
@@ -31,7 +31,10 @@ struct WidgetSnapshot: Codable {
 
     /// Bump when the on-disk format changes so an old widget build can
     /// detect a snapshot written by a newer app (and vice versa).
-    var schemaVersion: Int = 1
+    /// `load` rejects snapshots whose version doesn't match.
+    static let currentSchemaVersion = 1
+
+    var schemaVersion: Int = WidgetSnapshot.currentSchemaVersion
     let generatedAt: Date
     let profiles: [ProfileEntry]
 
@@ -84,7 +87,9 @@ struct WidgetSnapshot: Codable {
     }
 
     static func load(from url: URL = snapshotURL) -> WidgetSnapshot? {
-        guard let data = try? Data(contentsOf: url) else { return nil }
-        return try? decoder.decode(WidgetSnapshot.self, from: data)
+        guard let data = try? Data(contentsOf: url),
+              let snapshot = try? decoder.decode(WidgetSnapshot.self, from: data),
+              snapshot.schemaVersion == currentSchemaVersion else { return nil }
+        return snapshot
     }
 }


### PR DESCRIPTION
## Summary

Adds **macOS desktop widgets** (WidgetKit) so usage can be monitored without opening the menu bar popover:

- **Session Usage** (small): circular gauge of the active profile's 5-hour session usage, with a live countdown to reset
- **Usage Overview** (medium/large): session + weekly bars for every display-selected profile (up to 4 in medium, 6 in large), each with reset countdowns

Prior art: #94 / #96 / #169 all attempted desktop widgets and were closed unmerged — #169 relied on **App Group data sharing**, which the contribution guidelines now prohibit (group entitlements trigger Keychain prompts under Developer ID distribution). This implementation deliberately avoids App Groups.

## How data sharing works (no App Groups)

Follows the exact pattern of the existing statusline usage cache (`StatuslineService.writeUsageCache`):

1. After every successful refresh cycle (both the single-profile and multi-profile paths), `WidgetSnapshotService` writes a small JSON snapshot of all display-selected profiles to `~/Library/Application Support/Claude Usage/widget/snapshot.json`
2. The sandboxed widget extension reads it via a **read-only `home-relative-path` exception entitlement** scoped to that one directory
3. `WidgetCenter.reloadAllTimelines()` is requested only when whole-percent values or reset times actually change, throttled to ≥60 s, so the WidgetKit reload budget is preserved
4. Snapshots older than 15 minutes render dimmed (app quit → data no longer trustworthy)

No credentials or session keys ever touch the snapshot — profile name, percentages, and reset times only. Profile names are additionally sanitized before persisting (email-shaped names keep only their local part, control characters stripped, 64-char cap), since the file is readable outside the sandbox.

## Changes

| Area | Change |
|---|---|
| `ClaudeUsageWidget/` (new target) | Widget bundle, timeline provider, small/medium/large views, Info.plist, sandbox entitlements |
| `WidgetShared/WidgetSnapshot.swift` | Codable snapshot model compiled into both app and widget targets; resolves the real user home via `getpwuid` so the sandboxed extension escapes container path resolution |
| `Shared/Services/WidgetSnapshotService.swift` | Snapshot publisher with change detection + reload throttling |
| `MenuBar/MenuBarManager.swift` | Two publish hooks after successful refresh (multi-profile and single-profile paths) |
| `project.pbxproj` | New appex target, embed phase, target dependency (readable explicit IDs to keep the diff reviewable) |
| Localization | All widget-facing strings localized in the 13 supported languages |
| `.github/workflows/release.yml` | Sign the embedded `Claude UsageWidget.appex` (with its entitlements) before the outer app, since signing omits `--deep` |
| `Claude UsageTests/WidgetSnapshotTests.swift` | Codable round-trip, snapshot path stability, write/load round-trip |

## Test plan

- [x] `xcodebuild build` — **BUILD SUCCEEDED**, appex embedded and validated in `Contents/PlugIns/`
- [x] Full unit suite passes (9 widget-related tests added)
- [x] `codesign -d --entitlements` on the built appex confirms sandbox + read-only exception only
- [x] `pluginkit -m -p com.apple.widgetkit-extension` shows `HamedElfayome.Claude-Usage.widget(3.2.0)` after registration
- [x] Widget renders live data for 4 real profiles from a published snapshot
- [x] Screenshots attached below (mock data)

## Checklist

- [x] I have tested these changes on a running build
- [x] I have attached screenshots/recordings for any visual changes
- [x] I have not introduced App Group or grouped Keychain usage
- [x] I have added localization keys for any new user-facing strings (13 locales)

## Screenshots (mock data)

Rendered from the actual widget SwiftUI views with a **mock snapshot** (4 fictitious profiles), so no real account data is shown. Captured headlessly via `ImageRenderer`; the native `ProgressView` / `Gauge` styles are AppKit-backed and cannot be captured that way, so they are substituted with visually equivalent SwiftUI drawings — layout, typography, colors, and stale-dimming logic are the real widget code.

| | Light | Dark |
|---|---|---|
| **Session Usage** (small) | <img src="https://raw.githubusercontent.com/keito4/Claude-Usage-Tracker/widget-screenshots/docs/screenshots/widget-small-light.png" width="194"> | <img src="https://raw.githubusercontent.com/keito4/Claude-Usage-Tracker/widget-screenshots/docs/screenshots/widget-small-dark.png" width="194"> |
| **Usage Overview** (medium) | <img src="https://raw.githubusercontent.com/keito4/Claude-Usage-Tracker/widget-screenshots/docs/screenshots/widget-medium-light.png" width="388"> | <img src="https://raw.githubusercontent.com/keito4/Claude-Usage-Tracker/widget-screenshots/docs/screenshots/widget-medium-dark.png" width="388"> |
| **Usage Overview** (large) | <img src="https://raw.githubusercontent.com/keito4/Claude-Usage-Tracker/widget-screenshots/docs/screenshots/widget-large-light.png" width="388"> | <img src="https://raw.githubusercontent.com/keito4/Claude-Usage-Tracker/widget-screenshots/docs/screenshots/widget-large-dark.png" width="388"> |

<sub>Images live on the `widget-screenshots` branch (`docs/screenshots/`), kept out of this feature branch's diff.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


