### PR TITLE
fix(popover): show the popover on the active Space

### DIFF
--- a/Claude Usage/MenuBar/MenuBarManager.swift
+++ b/Claude Usage/MenuBar/MenuBarManager.swift
@@ -587,11 +587,7 @@ class MenuBarManager: NSObject, ObservableObject {
                     // the @Published profile properties set earlier in this method
                     popover.close()
                     stopMonitoringForOutsideClicks()
-                    // Activate first so the popover appears over a full-screen Space.
-                    // An .accessory app that isn't active renders the popover on the
-                    // desktop Space, hidden behind any frontmost full-screen app.
-                    NSApp.activate(ignoringOtherApps: true)
-                    popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+                    showPopover(popover, from: button)
                     currentPopoverButton = button
                     startMonitoringForOutsideClicks()
                 }
@@ -611,10 +607,7 @@ class MenuBarManager: NSObject, ObservableObject {
                 stopMonitoringForOutsideClicks()
                 // Update content view controller for current profile data
                 popover.contentViewController = createContentViewController()
-                // Activate first so the popover appears over a full-screen Space
-                // (otherwise an inactive .accessory app draws it on the desktop Space).
-                NSApp.activate(ignoringOtherApps: true)
-                popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+                showPopover(popover, from: button)
                 currentPopoverButton = button
                 startMonitoringForOutsideClicks()
             }
@@ -640,10 +633,15 @@ class MenuBarManager: NSObject, ObservableObject {
         popover.behavior = .transient
         popover.animates = true
         popover.contentViewController = NSHostingController(rootView: PeakHoursPopoverView())
-        // Activate first so the popover appears over a full-screen Space.
-        NSApp.activate(ignoringOtherApps: true)
-        popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+        showPopover(popover, from: button)
         peakHoursPopover = popover
+    }
+
+    /// Shows `popover` anchored to a status bar button and gives its backing window
+    /// the Space placement a menu bar popover needs to appear over a full-screen app.
+    private func showPopover(_ popover: NSPopover, from button: NSStatusBarButton) {
+        popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+        popover.contentViewController?.view.window?.enableDisplayOnFullScreenSpaces()
     }
 
     /// Shows a lightweight context menu (Refresh / Settings / Quit) anchored to the

--- a/Claude Usage/MenuBar/PopoverContentView.swift
+++ b/Claude Usage/MenuBar/PopoverContentView.swift
@@ -1386,6 +1386,20 @@ struct StatusBannerView: View {
     var onTap: (() -> Void)? = nil
 
     var body: some View {
+        // A Button rather than a tap gesture: the popover belongs to an inactive
+        // accessory app, and AppKit only delivers a click-through mouse-down to views
+        // that accept first mouse, which a bare tap gesture does not.
+        if let onTap {
+            Button(action: onTap) {
+                bannerContent
+            }
+            .buttonStyle(.plain)
+        } else {
+            bannerContent
+        }
+    }
+
+    private var bannerContent: some View {
         HStack(spacing: 8) {
             Image(systemName: icon)
                 .font(.system(size: 11))
@@ -1405,8 +1419,8 @@ struct StatusBannerView: View {
         .padding(.vertical, 6)
         .background(color.opacity(0.12))
         .cornerRadius(6)
+        .contentShape(Rectangle())
         .padding(.horizontal, 10)
         .padding(.top, 4)
-        .onTapGesture { onTap?() }
     }
 }

--- a/Claude Usage/Shared/Extensions/NSWindow+FullScreenSpaces.swift
+++ b/Claude Usage/Shared/Extensions/NSWindow+FullScreenSpaces.swift
@@ -1,0 +1,31 @@
+//
+//  NSWindow+FullScreenSpaces.swift
+//  Claude Usage
+//
+//  Created by Claude Code on 2026-08-18.
+//
+
+import Cocoa
+
+// MARK: - Space Placement for Menu Bar Windows
+extension NSWindow {
+    /// Makes the window appear on every Space, including another app's full-screen Space.
+    ///
+    /// A status bar popover's backing window is created without a Spaces behavior, which
+    /// leaves it associated with the one Space this accessory agent occupies.
+    ///
+    /// `NSPopover` has no backing window until it is first shown, so this has to be called
+    /// on `contentViewController?.view.window` after `show(relativeTo:of:preferredEdge:)`.
+    ///
+    /// Collection behavior outside the Spaces group is preserved.
+    func enableDisplayOnFullScreenSpaces() {
+        // Setting both Spaces behaviors raises NSInternalInconsistencyException at runtime
+        // (undocumented — the SDK only promises an assertion for the tiling pair), so the
+        // conflicting one has to go before the new one is inserted.
+        collectionBehavior.remove(.moveToActiveSpace)
+
+        // `.canJoinAllSpaces` covers ordinary Spaces; a full-screen Space admits another
+        // app's window only with `.fullScreenAuxiliary`, so both are required.
+        collectionBehavior.insert([.canJoinAllSpaces, .fullScreenAuxiliary])
+    }
+}

--- a/Claude UsageTests/NSWindowFullScreenSpacesTests.swift
+++ b/Claude UsageTests/NSWindowFullScreenSpacesTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+import AppKit
+@testable import Claude_Usage
+
+final class NSWindowFullScreenSpacesTests: XCTestCase {
+
+    // MARK: - Space Membership
+
+    func testEnableDisplayJoinsAllSpacesAndFullScreenSpaces() {
+        let window = makeWindow()
+        window.collectionBehavior = []
+
+        window.enableDisplayOnFullScreenSpaces()
+
+        XCTAssertTrue(window.collectionBehavior.contains(.canJoinAllSpaces))
+        XCTAssertTrue(window.collectionBehavior.contains(.fullScreenAuxiliary))
+    }
+
+    func testEnableDisplayClearsMoveToActiveSpace() {
+        let window = makeWindow()
+        window.collectionBehavior = [.moveToActiveSpace]
+
+        // Guards an AppKit exception, not a preference: inserting .canJoinAllSpaces
+        // alongside .moveToActiveSpace raises NSInternalInconsistencyException, so
+        // dropping the remove() aborts this test rather than failing it.
+        window.enableDisplayOnFullScreenSpaces()
+
+        XCTAssertFalse(window.collectionBehavior.contains(.moveToActiveSpace))
+        XCTAssertTrue(window.collectionBehavior.contains(.canJoinAllSpaces))
+    }
+
+    func testEnableDisplayPreservesUnrelatedCollectionBehavior() {
+        let window = makeWindow()
+        window.collectionBehavior = [.ignoresCycle, .stationary]
+
+        window.enableDisplayOnFullScreenSpaces()
+
+        XCTAssertTrue(window.collectionBehavior.contains(.ignoresCycle))
+        XCTAssertTrue(window.collectionBehavior.contains(.stationary))
+    }
+
+    // MARK: - Helpers
+
+    private func makeWindow() -> NSWindow {
+        // defer: true keeps the window device from being created — these tests only
+        // exercise the window's Spaces behavior.
+        NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 100, height: 100),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: true
+        )
+    }
+}


### PR DESCRIPTION
## Description

Fixes #298.

Logging the popover's backing window on 26.5 shows `.ignoresCycle` and no `Spaces` collection behavior, so the window manager keeps it on whichever Space the app occupies. With another app full screen, the popover ends up on the desktop Space and the click looks like it did nothing.

Setting `.canJoinAllSpaces` and `.fullScreenAuxiliary` on that window after `show()` fixes it. @johnib pointed at this on #257, which covered the detached panel; this does the same for the popover window.

It also drops the `NSApp.activate(ignoringOtherApps:)` calls. Activation placed the popover only as a side effect of the app becoming active, which isn't something placement should depend on, and it took focus from the foreground app.

The bug is intermittent, possibly because activation sometimes succeeds. I can't trigger it on demand on 26.5, only intermittently.

## Changes

- `NSWindow.enableDisplayOnFullScreenSpaces()` in `Shared/Extensions/`. Clears `.moveToActiveSpace` first: setting both Spaces behaviors raises `NSInternalInconsistencyException` at runtime, which the SDK documents only for the tiling pair.
- One `showPopover(_:from:)` in `MenuBarManager` replaces the three activate + show pairs (main popover, profile re-anchor, peak hours).
- `StatusBannerView` is a `Button` instead of `.onTapGesture`. Without activation AppKit won't deliver a click-through mouse-down to a view that refuses first mouse, so the credentials and refresh banners would have needed two clicks. Same appearance and tap area.
- 3 unit tests on the helper.
- Open popover now follows you across a Space switch. It's hidden during the switch animation and returns on the new Space; `popoverDidClose` doesn't fire and one click still closes it.
- The popover is no longer key, so Escape no longer dismisses it. Nothing in it takes keyboard input, and this is how it behaved before v3.2.0.

CI on my fork is green including the tests:
https://github.com/carloronconi/Claude-Usage-Tracker/actions/runs/32253543784.

## Screenshots / Screen Recordings

- Fixed full-screen behavior: https://github.com/user-attachments/assets/53ace065-18e4-413a-81bd-dee297cc384f
- Preserved desktop behavior: https://github.com/user-attachments/assets/17a5e9ed-6acf-4dd1-bb27-e9ed0448cee6

## Checklist

- [x] I have tested these changes on a running build
- [x] I have attached screenshots/recordings for any visual changes
- [x] I have not introduced App Group or grouped Keychain usage
- [x] I have added localization keys for any new user-facing strings
