### PR TITLE
fix(api): carry Cloudflare cf_clearance on claude.ai requests (E3006 right after a successful sign-in)

### DIFF
--- a/Claude Usage/Shared/Services/ClaudeAPIService.swift
+++ b/Claude Usage/Shared/Services/ClaudeAPIService.swift
@@ -132,14 +132,67 @@ class ClaudeAPIService: APIServiceProtocol {
     /// challenged or rejected with E3000 permission errors even when the
     /// session is valid (#204, #277) — every claude.ai call must go through
     /// this, not just `performRequest`.
-    static func sessionCookieHeader(sessionKey: String, url: URL) -> String {
+    static func sessionCookieHeader(sessionKey: String, url: URL, storage: HTTPCookieStorage = .shared) -> String {
         var cookiePairs = ["sessionKey=\(sessionKey)"]
-        if let stored = HTTPCookieStorage.shared.cookies(for: url) {
-            for cookie in stored where ["cf_clearance", "__cf_bm", "anthropic-device-id"].contains(cookie.name) {
-                cookiePairs.append("\(cookie.name)=\(cookie.value)")
-            }
+        for cookie in clearanceCookies(host: url.host ?? "", in: storage.cookies ?? []) {
+            cookiePairs.append("\(cookie.name)=\(cookie.value)")
         }
         return cookiePairs.joined(separator: "; ")
+    }
+
+    /// Cookies (besides `sessionKey`) that claude.ai's Cloudflare front expects
+    /// to see next to a session.
+    static let clearanceCookieNames: Set<String> = ["cf_clearance", "__cf_bm", "anthropic-device-id"]
+
+    /// Picks the clearance cookies for `host` out of a cookie-jar snapshot.
+    ///
+    /// On current macOS `HTTPCookieStorage.cookies(for:)` leaves out partitioned
+    /// cookies (CHIPS), and Cloudflare sets `cf_clearance` with the
+    /// `Partitioned` attribute. So the one cookie that proves the sign-in
+    /// webview passed a challenge never reached the header: every request went
+    /// out as `sessionKey; __cf_bm; anthropic-device-id`, which Cloudflare
+    /// challenges again on networks it distrusts — a 403 "Just a moment" page
+    /// (E3006) seconds after a successful sign-in. `HTTPCookieStorage.cookies`
+    /// does include partitioned entries, so match the whole jar by cookie
+    /// domain instead and keep the freshest unexpired cookie per name.
+    static func clearanceCookies(host: String, in jar: [HTTPCookie]) -> [HTTPCookie] {
+        let host = host.lowercased()
+        let createdKey = HTTPCookiePropertyKey("Created")
+        var byName: [String: HTTPCookie] = [:]
+
+        // A domain cookie (".claude.ai") covers the host and its subdomains; a
+        // host-only cookie ("claude.ai") covers exactly that host.
+        func matchesHost(_ cookie: HTTPCookie) -> Bool {
+            let domain = cookie.domain.lowercased()
+            guard !domain.isEmpty else { return false }
+            if domain.hasPrefix(".") {
+                let bare = String(domain.dropFirst())
+                return host == bare || host.hasSuffix("." + bare)
+            }
+            return host == domain
+        }
+        // Newest wins on duplicates: the jar records each cookie's creation
+        // time, and Cloudflare stamps a fresh expiry on every clearance it
+        // issues. Creation time decides, expiry breaks ties, and the value is a
+        // last resort so the header is deterministic.
+        func created(_ cookie: HTTPCookie) -> Double {
+            (cookie.properties?[createdKey] as? NSNumber)?.doubleValue ?? 0
+        }
+        func isFresher(_ candidate: HTTPCookie, than current: HTTPCookie) -> Bool {
+            if created(candidate) != created(current) { return created(candidate) > created(current) }
+            let candidateExpiry = candidate.expiresDate ?? .distantPast
+            let currentExpiry = current.expiresDate ?? .distantPast
+            if candidateExpiry != currentExpiry { return candidateExpiry > currentExpiry }
+            return candidate.value > current.value
+        }
+
+        for cookie in jar {
+            guard clearanceCookieNames.contains(cookie.name), matchesHost(cookie) else { continue }
+            if let expiry = cookie.expiresDate, expiry < Date() { continue }
+            if let current = byName[cookie.name], !isFresher(cookie, than: current) { continue }
+            byName[cookie.name] = cookie
+        }
+        return byName.values.sorted { $0.name < $1.name }
     }
 
     /// Builds an authenticated request with the appropriate headers for the auth type

--- a/Claude UsageTests/ClearanceCookieTests.swift
+++ b/Claude UsageTests/ClearanceCookieTests.swift
@@ -1,0 +1,86 @@
+//
+//  ClearanceCookieTests.swift
+//  Claude UsageTests
+//
+//  Cloudflare's cf_clearance is a partitioned cookie, which
+//  HTTPCookieStorage.cookies(for:) does not return. These tests pin the jar
+//  scan that puts it back into the claude.ai Cookie header.
+//
+
+import XCTest
+@testable import Claude_Usage
+
+final class ClearanceCookieTests: XCTestCase {
+    private let host = "claude.ai"
+
+    private func cookie(
+        _ name: String,
+        domain: String = ".claude.ai",
+        value: String = "v",
+        expires: Date? = Date().addingTimeInterval(3600),
+        created: Double? = nil
+    ) -> HTTPCookie {
+        var props: [HTTPCookiePropertyKey: Any] = [.name: name, .value: value, .domain: domain, .path: "/", .secure: "TRUE"]
+        if let expires { props[.expires] = expires }
+        if let created { props[HTTPCookiePropertyKey("Created")] = created }
+        return HTTPCookie(properties: props)!
+    }
+
+    func testClearanceCookiesAreTakenFromTheJar() {
+        let jar = [cookie("__cf_bm"), cookie("anthropic-device-id", domain: "claude.ai"), cookie("sessionKey"), cookie("cf_clearance")]
+        let names = ClaudeAPIService.clearanceCookies(host: host, in: jar).map(\.name)
+        XCTAssertEqual(names, ["__cf_bm", "anthropic-device-id", "cf_clearance"])
+    }
+
+    func testForeignDomainsAndExpiredCookiesAreIgnored() {
+        let jar = [
+            cookie("cf_clearance", domain: ".notclaude.ai"),
+            cookie("cf_clearance", domain: "evil-claude.ai"),
+            cookie("cf_clearance", expires: Date().addingTimeInterval(-60)),
+            cookie("__cf_bm", domain: ".google.com"),
+        ]
+        XCTAssertTrue(ClaudeAPIService.clearanceCookies(host: host, in: jar).isEmpty)
+    }
+
+    func testCreationTimeBeatsExpiryWhenChoosingBetweenDuplicates() {
+        let older = cookie("cf_clearance", value: "old", expires: Date().addingTimeInterval(7200), created: 100)
+        let newer = cookie("cf_clearance", value: "new", expires: Date().addingTimeInterval(3600), created: 200)
+        XCTAssertEqual(ClaudeAPIService.clearanceCookies(host: host, in: [older, newer]).map(\.value), ["new"])
+        XCTAssertEqual(ClaudeAPIService.clearanceCookies(host: host, in: [newer, older]).map(\.value), ["new"])
+    }
+
+    func testLaterExpiryBreaksCreationTimeTies() {
+        let shorter = cookie("cf_clearance", value: "short", expires: Date().addingTimeInterval(3600), created: 100)
+        let longer = cookie("cf_clearance", value: "long", expires: Date().addingTimeInterval(7200), created: 100)
+        XCTAssertEqual(ClaudeAPIService.clearanceCookies(host: host, in: [shorter, longer]).map(\.value), ["long"])
+        XCTAssertEqual(ClaudeAPIService.clearanceCookies(host: host, in: [longer, shorter]).map(\.value), ["long"])
+    }
+
+    func testSessionKeyIsNeverPulledFromTheJar() {
+        XCTAssertTrue(ClaudeAPIService.clearanceCookies(host: host, in: [cookie("sessionKey", value: "stale")]).isEmpty)
+    }
+
+    func testSubdomainMatchesDomainCookieButNotHostOnlyCookie() {
+        let domainCookie = [cookie("cf_clearance", domain: ".claude.ai")]
+        XCTAssertEqual(ClaudeAPIService.clearanceCookies(host: "api.claude.ai", in: domainCookie).count, 1)
+        let hostOnlyCookie = [cookie("cf_clearance", domain: "claude.ai")]
+        XCTAssertEqual(ClaudeAPIService.clearanceCookies(host: "api.claude.ai", in: hostOnlyCookie).count, 0)
+        XCTAssertEqual(ClaudeAPIService.clearanceCookies(host: "claude.ai", in: hostOnlyCookie).count, 1)
+    }
+
+    /// End-to-end through `sessionCookieHeader` with a private jar. A Secure
+    /// cookie queried through an http:// URL is a deterministic public stand-in
+    /// for "present in the jar, absent from `cookies(for:)`" — exactly the
+    /// shape of the partitioned cf_clearance bug.
+    func testHeaderCarriesClearanceThatCookiesForURLWouldHide() throws {
+        let storage = try XCTUnwrap(URLSessionConfiguration.ephemeral.httpCookieStorage)
+        storage.setCookie(cookie("cf_clearance", value: "clearance"))
+        storage.setCookie(cookie("__cf_bm", value: "bm"))
+        let url = try XCTUnwrap(URL(string: "http://claude.ai/api/organizations"))
+        // Precondition for the stand-in: the URL view must hide them.
+        XCTAssertEqual(storage.cookies(for: url)?.count ?? 0, 0)
+
+        let header = ClaudeAPIService.sessionCookieHeader(sessionKey: "sk-test", url: url, storage: storage)
+        XCTAssertEqual(header, "sessionKey=sk-test; __cf_bm=bm; cf_clearance=clearance")
+    }
+}


### PR DESCRIPTION
Fixes #319

## Description

On networks that Cloudflare distrusts (VPN / proxy exits, some ISPs), the claude.ai path fails with **E3006 "Request blocked by Cloudflare protection"** on every refresh, and re-signing in does not help: the sign-in webview passes the Turnstile challenge, the sheet closes, and the very next `/api/organizations` request is challenged again 2–3 seconds later. The 30-second refresh then fails indefinitely.

Root cause: `ClaudeAPIService.sessionCookieHeader` builds the `Cookie` header from `HTTPCookieStorage.shared.cookies(for: url)`. Cloudflare sets `cf_clearance` with the `Partitioned` attribute (CHIPS), and `cookies(for:)` **does not return partitioned cookies**. So the one cookie that proves the webview passed the challenge never reaches the header, even though the webview stored it in the same cookie jar. Every claude.ai request goes out as `sessionKey; __cf_bm; anthropic-device-id`, which Cloudflare treats as an unverified client.

`HTTPCookieStorage.shared.cookies` (the full jar) does include partitioned entries — the cookie shows up there with a `StoragePartition` property. This PR merges both views by cookie domain, drops expired entries and keeps the freshest cookie per name, so `cf_clearance` rides along on every claude.ai call (usage, organizations, statusline script, auto-start sessions — everything that already goes through `sessionCookieHeader`).

Related: #277 / #303 (which made the challenge show as E3006 instead of a false "credentials expired"; this PR fixes the reason the challenge keeps coming back). Possibly also the "still occurs" reports on #266 and the 3.3.0 follow-up in #312, where users see 0% / errors on networks that get challenged.

### Evidence (macOS 26.6, app 3.3.0, proxy exit that Cloudflare challenges)

Release build, unified log, two independent sign-ins:

| | sign-in sheet closes (login done, Turnstile passed) | first `/api/organizations` after that | result |
|---|---|---|---|
| attempt 1 | 00:36:45.3 | 00:36:46.9 → 403, 00:36:50 → 403, 00:36:56 → 403 | E3006 |
| attempt 2 | 01:24:48.7 | 01:24:51.8 → 403, 01:24:55 → 403, 01:25:01 → 403 | E3006 |

A probe running under the app's bundle id, calling the same API the app calls:

```
cookies(for: https://claude.ai/api/organizations)
  -> 14 cookies: sessionKey, __cf_bm, anthropic-device-id, … (no cf_clearance)
HTTPCookieStorage.shared.cookies (full jar)
  -> same + cf_clearance  (properties include "StoragePartition")
header the app actually sends -> sessionKey; __cf_bm; anthropic-device-id
```

Sending the webview's `cf_clearance` by hand with the app's exact User-Agent and headers: `GET /login` → 200; the same request without it → 403 `cf-mitigated: challenge`.

Patched Debug build on the same machine, same network, same cookie jar, 10 minutes later: sign-in sheet closed 01:36:49.5, `/api/organizations` → **200** at 01:36:52 ("found 2 organization(s)"). Relaunching the unpatched release build right after: 403 / E3006 on every refresh again (01:38:44 → 01:40:45).

## Changes

- `ClaudeAPIService.sessionCookieHeader` now scans the full `HTTPCookieStorage.cookies` snapshot (a superset of `cookies(for:)`) instead of the URL view, matching by cookie domain (a domain cookie `.claude.ai` covers `claude.ai` and its subdomains; a host-only cookie covers exactly that host), dropping expired cookies and keeping the freshest per name (creation time, then expiry, then value so the header is deterministic). Only the three names the header already carried are considered (`cf_clearance`, `__cf_bm`, `anthropic-device-id`); `sessionKey` still comes from the profile, never from the jar. The storage is injectable (`storage:` defaults to `.shared`) so the header can be tested against a private jar.
- New `ClaudeAPIService.clearanceCookies(host:in:)` — pure function over a jar snapshot.
- `Claude UsageTests/ClearanceCookieTests.swift` — 7 tests: clearance names taken from the jar; foreign domains and expired cookies ignored; creation time beats expiry between duplicates; later expiry breaks creation-time ties; `sessionKey` never pulled from the jar; domain cookie matches subdomains while a host-only cookie does not; and an end-to-end header test against an ephemeral `HTTPCookieStorage` where Secure cookies queried through an `http://` URL stand in for "present in the jar, hidden from `cookies(for:)`". Full suite: all tests pass.

No new user-facing strings, no UI changes, no keychain changes.

## Screenshots / Screen Recordings

N/A - no visual changes

## Checklist

- [x] I have tested these changes on a running build (Debug build, live sign-in on a challenged network; see Evidence)
- [x] I have attached screenshots/recordings for any visual changes (N/A)
- [x] I have not introduced App Group or grouped Keychain usage
- [x] I have added localization keys for any new user-facing strings (none added)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
