### PR TITLE
feat(notify): publish usage to a phone's Lock Screen and Home Screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Claude Usage Tracker will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Major Features
+
+- **Notify! publishing**: your usage can now go to your phone. Link a [Notify!](https://getnotifyapp.com) device in Settings → Notify! and the app pushes the active profile's windows to three surfaces — a Live Activity tile carrying up to six windows side by side, a Lock Screen widget showing one window as a ring or a bar, and a Home Screen widget carrying the same tile but staying where you put it. Each surface can be switched off on its own, and the Lock Screen widget's window can be picked or left on "whichever needs attention most". Off by default. What leaves the Mac is provider names, window labels, percentages and reset countdowns, and nothing else. The device token uses the same hardened Keychain path as the per-profile secrets (#292), the save is confirmed by reading it back, and it is never written anywhere else — so **the app must be signed to link a device**: an ad-hoc build (Xcode with no development team) can reach no Keychain at all, and the pane says so rather than reporting a link that did not save. See [docs/features/notify.md](docs/features/notify.md). Ported from the same feature in ClaudeBar.
+
 ## [3.3.0] - 2026-08-29
 
 ### Major Features

--- a/Claude Usage/App/AppDelegate.swift
+++ b/Claude Usage/App/AppDelegate.swift
@@ -62,6 +62,16 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
             object: nil
         )
 
+        // Notify! publishing (opt-in): push usage to the user's phone as a Live
+        // Activity and two widgets, and react to the settings toggle at runtime.
+        updateNotifyPublishing()
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleNotifySettingChanged),
+            name: .notifySettingsChanged,
+            object: nil
+        )
+
         if !shouldShowSetupWizard() {
             // Initialize menu bar with active profile
             menuBarManager?.setup()
@@ -238,6 +248,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         // Cleanup
         NotchHookServer.shared.stop()
         NotchHUDController.shared.stop()
+        NotifyPublishDriver.shared.stop()
         menuBarManager?.cleanup()
     }
 
@@ -263,6 +274,23 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         } else {
             NotchHookServer.shared.stop()
             NotchHUDController.shared.stop()
+        }
+    }
+
+    // MARK: - Notify!
+
+    @objc private func handleNotifySettingChanged() {
+        updateNotifyPublishing()
+    }
+
+    /// Brings publishing up and down with the master switch. The driver's own
+    /// `start()` and `stop()` are idempotent, so this is safe to call on every
+    /// save, including the ones that only changed a surface toggle.
+    private func updateNotifyPublishing() {
+        if NotifySettingsStore.shared.isEnabled() {
+            NotifyPublishDriver.shared.start()
+        } else {
+            NotifyPublishDriver.shared.stop()
         }
     }
 

--- a/Claude Usage/Resources/de.lproj/Localizable.strings
+++ b/Claude Usage/Resources/de.lproj/Localizable.strings
@@ -1093,3 +1093,129 @@
 "support.popup_signature" = "das Ein-Personen-Team hinter Claude Usage";
 "support.popup_body" = "Kostenlos, Open Source, von einer Person gebaut — ohne Werbung, ohne Tracking. Hat es dich je vor einem verbrannten Session-Limit bewahrt, hält ein Kaffee es am Leben.";
 "support.popup_days" = "Behält deine Limits seit %d Tagen im Blick — für immer kostenlos";
+
+/* NOTE: the Notify! strings below are still in English and need translating. */
+
+/* ==================== */
+/* MARK: - Notify! (publish usage to a phone) */
+/* ==================== */
+"notify.title" = "Notify!";
+"notify.subtitle" = "Put your usage on your phone's Lock Screen and Home Screen";
+
+/* Sections */
+"notify.section.publishing" = "Publishing";
+"notify.section.publishing_desc" = "Send your usage to the Notify! app on your phone";
+"notify.section.device" = "Linked Device";
+"notify.section.device_desc" = "Copy the device ID and token from the Notify! app";
+"notify.section.surfaces" = "What to Show";
+"notify.section.surfaces_desc" = "Each surface can be switched off on its own";
+"notify.section.gauge" = "Lock Screen Widget";
+"notify.section.gauge_desc" = "Which window the widget's ring shows";
+"notify.section.publish" = "Send Now";
+"notify.section.publish_desc" = "Push your current usage without waiting for the next update";
+"notify.section.privacy" = "Privacy";
+
+/* Master switch */
+"notify.enable" = "Publish to Notify!";
+"notify.enable_desc" = "Off until you link a device. Your usage is sent to Notify!, which is not Anthropic or OpenAI.";
+
+/* Device link */
+"notify.device_id" = "Device ID";
+"notify.device_id.placeholder" = "Paste the device ID, or the whole notification link";
+"notify.device_token" = "Device Token";
+"notify.device_token.placeholder" = "Paste the device token";
+"notify.verify" = "Verify Device";
+"notify.verifying" = "Checking…";
+"notify.save_link" = "Save Link";
+"notify.unlink" = "Unlink";
+
+/* Surfaces */
+"notify.surface.live_activity" = "Live Activity";
+"notify.surface.live_activity_desc" = "A tile on the Lock Screen with every window side by side. iPhone and iPad only.";
+"notify.surface.lock_screen" = "Lock Screen Widget";
+"notify.surface.lock_screen_desc" = "One window as a ring or a bar, for a glance without unlocking.";
+"notify.surface.home_screen" = "Home Screen Widget";
+"notify.surface.home_screen_desc" = "The same tile as the Live Activity, but it stays where you put it. Needs a recent Notify!.";
+
+/* Gauge picker */
+"notify.gauge.window" = "Show";
+"notify.gauge.automatic" = "Whichever needs attention most";
+
+/* Publish */
+"notify.publish_now" = "Send Now";
+"notify.publishing" = "Sending…";
+
+/* Privacy */
+"notify.privacy.what_leaves" = "What leaves this Mac: provider names, window labels, percentages left, balances and reset countdowns.";
+"notify.privacy.where_it_goes" = "Where it goes: push.getnotifyapp.com, and from there to your own phone.";
+"notify.privacy.off_by_default" = "Off by default, and it stays off until you link a device.";
+"notify.privacy.token_secret" = "Your device token is kept in the macOS Keychain and is never written to the app's settings.";
+
+/* Status messages */
+"notify.status.link_saved" = "Device link saved.";
+"notify.status.unlinked" = "Device unlinked. Anything already on your phone stays there until you remove it in Notify!.";
+"notify.status.verified" = "Linked to %@.";
+"notify.status.published" = "Sent.";
+"notify.status.switched_off" = "Publishing to Notify! is switched off.";
+"notify.status.all_surfaces_off" = "The Live Activity, the Lock Screen widget and the Home Screen widget are all switched off, so there is nothing to send.";
+"notify.status.no_usage_yet" = "There is no usage to send yet. Give the app a moment to fetch some.";
+"notify.status.holding_off" = "Notify! is still holding off Live Activity starts. The app will retry on its own.";
+"notify.status.home_screen_not_served" = "Notify! is not serving Home Screen widgets yet. The app will try again later.";
+
+/* Device kinds */
+"notify.device_kind.app_device" = "iPhone or iPad";
+"notify.device_kind.mac" = "Mac";
+"notify.device_kind.web" = "browser";
+"notify.device_kind.group" = "group";
+"notify.device_kind.unknown" = "device";
+
+/* What a device cannot carry */
+"notify.unsupported.live_activity_mac" = "This is a Mac ID. A Live Activity is an iPhone and iPad feature, so it cannot be started here. The widgets still work.";
+"notify.unsupported.live_activity_web" = "This is a browser ID. A Live Activity is an iPhone and iPad feature, so it cannot be started here. The widgets still work.";
+"notify.unsupported.live_activity_generic" = "A Live Activity only exists on an iPhone or iPad, so use the device ID and token from the Notify! app on your phone instead.";
+"notify.unsupported.group" = "This is a group ID. A group sends a notification out to its members and owns no Lock Screen of its own, so use the device ID and token for a single device instead.";
+"notify.unsupported.widget_generic" = "A group owns no Lock Screen of its own, so use the device ID and token for a single device instead.";
+"notify.unsupported.screen_widget_generic" = "A group owns no Home Screen of its own, so use the device ID and token for a single device instead.";
+
+/* Windows shown on the phone */
+"notify.window.session" = "5h";
+"notify.window.weekly" = "7d";
+"notify.window.opus" = "Opus 7d";
+"notify.window.sonnet" = "Sonnet 7d";
+"notify.window.design" = "Design 7d";
+"notify.window.fable" = "Fable 7d";
+"notify.window.spend" = "Spend";
+"notify.window.extra_usage" = "Extra usage";
+"notify.window.credits" = "Credits";
+
+/* Sentences written onto the tile and the widget */
+"notify.summary.balance_left" = "%@ left";
+"notify.summary.percent_left" = "%d%% left";
+"notify.summary.resets_soon" = "resets soon";
+"notify.summary.resets_in" = "resets in %@";
+
+/* Waits */
+"notify.wait.a_minute" = "a minute";
+"notify.wait.minutes" = "%d minutes";
+"notify.wait.an_hour" = "an hour";
+"notify.wait.hours" = "%d hours";
+
+/* Errors */
+"notify.error.not_linked" = "Add your Notify! device ID and token before publishing.";
+"notify.error.rejected_credentials" = "Notify! rejected these credentials. Copy the device ID and token again from the Notify! app.";
+"notify.error.live_activity_unavailable" = "This device cannot show a Live Activity yet. Open the Notify! app once on the device.";
+"notify.error.tile_gone" = "The Live Activity was dismissed on the device. A new one will be started.";
+"notify.error.backoff" = "Notify! is waiting %@ before another Live Activity.";
+"notify.error.backoff_open_app" = "Notify! is waiting %@ before another Live Activity. Opening the Notify! app on the device may clear it sooner.";
+"notify.error.invalid_payload" = "Notify! rejected the content of this update.";
+"notify.error.delivery_unconfirmed" = "Notify! could not confirm the Live Activity started. It will be checked again on the next update.";
+"notify.error.transport_failed" = "Could not reach Notify!: %@";
+"notify.error.surface_switched_off" = "Notify! has this widget switched off at the moment. The app will try again later.";
+"notify.error.unexpected_status" = "Notify! answered with HTTP %d.";
+"notify.error.malformed_response" = "Notify! sent a response the app could not read.";
+"notify.error.link_is_group" = "That link points at a Notify! group. This needs a device link, not a group.";
+"notify.error.bad_host" = "The Notify! host is not a usable URL.";
+"notify.error.encode_failed" = "This update could not be encoded.";
+
+/* Notify! — token storage */
+"notify.status.link_save_failed" = "Could not save the device token to the Keychain, so nothing was linked. The Keychain needs the app to be signed, and a copy built locally without a development team is not. Use a signed build — a release download, or set your team under Signing & Capabilities in Xcode.";

--- a/Claude Usage/Resources/en.lproj/Localizable.strings
+++ b/Claude Usage/Resources/en.lproj/Localizable.strings
@@ -1089,3 +1089,127 @@
 "support.popup_signature" = "the one-person team behind Claude Usage";
 "support.popup_body" = "Free, open source, built by one person — no ads, no tracking. If it has ever saved you from burning a session limit, a coffee keeps it going.";
 "support.popup_days" = "Watching your limits for %d days — always free";
+
+/* ==================== */
+/* MARK: - Notify! (publish usage to a phone) */
+/* ==================== */
+"notify.title" = "Notify!";
+"notify.subtitle" = "Put your usage on your phone's Lock Screen and Home Screen";
+
+/* Sections */
+"notify.section.publishing" = "Publishing";
+"notify.section.publishing_desc" = "Send your usage to the Notify! app on your phone";
+"notify.section.device" = "Linked Device";
+"notify.section.device_desc" = "Copy the device ID and token from the Notify! app";
+"notify.section.surfaces" = "What to Show";
+"notify.section.surfaces_desc" = "Each surface can be switched off on its own";
+"notify.section.gauge" = "Lock Screen Widget";
+"notify.section.gauge_desc" = "Which window the widget's ring shows";
+"notify.section.publish" = "Send Now";
+"notify.section.publish_desc" = "Push your current usage without waiting for the next update";
+"notify.section.privacy" = "Privacy";
+
+/* Master switch */
+"notify.enable" = "Publish to Notify!";
+"notify.enable_desc" = "Off until you link a device. Your usage is sent to Notify!, which is not Anthropic or OpenAI.";
+
+/* Device link */
+"notify.device_id" = "Device ID";
+"notify.device_id.placeholder" = "Paste the device ID, or the whole notification link";
+"notify.device_token" = "Device Token";
+"notify.device_token.placeholder" = "Paste the device token";
+"notify.verify" = "Verify Device";
+"notify.verifying" = "Checking…";
+"notify.save_link" = "Save Link";
+"notify.unlink" = "Unlink";
+
+/* Surfaces */
+"notify.surface.live_activity" = "Live Activity";
+"notify.surface.live_activity_desc" = "A tile on the Lock Screen with every window side by side. iPhone and iPad only.";
+"notify.surface.lock_screen" = "Lock Screen Widget";
+"notify.surface.lock_screen_desc" = "One window as a ring or a bar, for a glance without unlocking.";
+"notify.surface.home_screen" = "Home Screen Widget";
+"notify.surface.home_screen_desc" = "The same tile as the Live Activity, but it stays where you put it. Needs a recent Notify!.";
+
+/* Gauge picker */
+"notify.gauge.window" = "Show";
+"notify.gauge.automatic" = "Whichever needs attention most";
+
+/* Publish */
+"notify.publish_now" = "Send Now";
+"notify.publishing" = "Sending…";
+
+/* Privacy */
+"notify.privacy.what_leaves" = "What leaves this Mac: provider names, window labels, percentages left, balances and reset countdowns.";
+"notify.privacy.where_it_goes" = "Where it goes: push.getnotifyapp.com, and from there to your own phone.";
+"notify.privacy.off_by_default" = "Off by default, and it stays off until you link a device.";
+"notify.privacy.token_secret" = "Your device token is kept in the macOS Keychain and is never written to the app's settings.";
+
+/* Status messages */
+"notify.status.link_saved" = "Device link saved.";
+"notify.status.unlinked" = "Device unlinked. Anything already on your phone stays there until you remove it in Notify!.";
+"notify.status.verified" = "Linked to %@.";
+"notify.status.published" = "Sent.";
+"notify.status.switched_off" = "Publishing to Notify! is switched off.";
+"notify.status.all_surfaces_off" = "The Live Activity, the Lock Screen widget and the Home Screen widget are all switched off, so there is nothing to send.";
+"notify.status.no_usage_yet" = "There is no usage to send yet. Give the app a moment to fetch some.";
+"notify.status.holding_off" = "Notify! is still holding off Live Activity starts. The app will retry on its own.";
+"notify.status.home_screen_not_served" = "Notify! is not serving Home Screen widgets yet. The app will try again later.";
+
+/* Device kinds */
+"notify.device_kind.app_device" = "iPhone or iPad";
+"notify.device_kind.mac" = "Mac";
+"notify.device_kind.web" = "browser";
+"notify.device_kind.group" = "group";
+"notify.device_kind.unknown" = "device";
+
+/* What a device cannot carry */
+"notify.unsupported.live_activity_mac" = "This is a Mac ID. A Live Activity is an iPhone and iPad feature, so it cannot be started here. The widgets still work.";
+"notify.unsupported.live_activity_web" = "This is a browser ID. A Live Activity is an iPhone and iPad feature, so it cannot be started here. The widgets still work.";
+"notify.unsupported.live_activity_generic" = "A Live Activity only exists on an iPhone or iPad, so use the device ID and token from the Notify! app on your phone instead.";
+"notify.unsupported.group" = "This is a group ID. A group sends a notification out to its members and owns no Lock Screen of its own, so use the device ID and token for a single device instead.";
+"notify.unsupported.widget_generic" = "A group owns no Lock Screen of its own, so use the device ID and token for a single device instead.";
+"notify.unsupported.screen_widget_generic" = "A group owns no Home Screen of its own, so use the device ID and token for a single device instead.";
+
+/* Windows shown on the phone */
+"notify.window.session" = "5h";
+"notify.window.weekly" = "7d";
+"notify.window.opus" = "Opus 7d";
+"notify.window.sonnet" = "Sonnet 7d";
+"notify.window.design" = "Design 7d";
+"notify.window.fable" = "Fable 7d";
+"notify.window.spend" = "Spend";
+"notify.window.extra_usage" = "Extra usage";
+"notify.window.credits" = "Credits";
+
+/* Sentences written onto the tile and the widget */
+"notify.summary.balance_left" = "%@ left";
+"notify.summary.percent_left" = "%d%% left";
+"notify.summary.resets_soon" = "resets soon";
+"notify.summary.resets_in" = "resets in %@";
+
+/* Waits */
+"notify.wait.a_minute" = "a minute";
+"notify.wait.minutes" = "%d minutes";
+"notify.wait.an_hour" = "an hour";
+"notify.wait.hours" = "%d hours";
+
+/* Errors */
+"notify.error.not_linked" = "Add your Notify! device ID and token before publishing.";
+"notify.error.rejected_credentials" = "Notify! rejected these credentials. Copy the device ID and token again from the Notify! app.";
+"notify.error.live_activity_unavailable" = "This device cannot show a Live Activity yet. Open the Notify! app once on the device.";
+"notify.error.tile_gone" = "The Live Activity was dismissed on the device. A new one will be started.";
+"notify.error.backoff" = "Notify! is waiting %@ before another Live Activity.";
+"notify.error.backoff_open_app" = "Notify! is waiting %@ before another Live Activity. Opening the Notify! app on the device may clear it sooner.";
+"notify.error.invalid_payload" = "Notify! rejected the content of this update.";
+"notify.error.delivery_unconfirmed" = "Notify! could not confirm the Live Activity started. It will be checked again on the next update.";
+"notify.error.transport_failed" = "Could not reach Notify!: %@";
+"notify.error.surface_switched_off" = "Notify! has this widget switched off at the moment. The app will try again later.";
+"notify.error.unexpected_status" = "Notify! answered with HTTP %d.";
+"notify.error.malformed_response" = "Notify! sent a response the app could not read.";
+"notify.error.link_is_group" = "That link points at a Notify! group. This needs a device link, not a group.";
+"notify.error.bad_host" = "The Notify! host is not a usable URL.";
+"notify.error.encode_failed" = "This update could not be encoded.";
+
+/* Notify! — token storage */
+"notify.status.link_save_failed" = "Could not save the device token to the Keychain, so nothing was linked. The Keychain needs the app to be signed, and a copy built locally without a development team is not. Use a signed build — a release download, or set your team under Signing & Capabilities in Xcode.";

--- a/Claude Usage/Resources/es.lproj/Localizable.strings
+++ b/Claude Usage/Resources/es.lproj/Localizable.strings
@@ -1074,3 +1074,129 @@
 "support.popup_signature" = "el equipo unipersonal detrás de Claude Usage";
 "support.popup_body" = "Esta app es gratuita y de código abierto: sin anuncios, sin rastreo, sin muros de pago. Cada actualización se construye en mis tardes y fines de semana. Si Claude Usage te ha salvado alguna vez de quemar un límite de sesión, un café es lo que la mantiene viva y mejorando.";
 "support.popup_days" = "Vigilando tus límites desde hace %d días — siempre gratis";
+
+/* NOTE: the Notify! strings below are still in English and need translating. */
+
+/* ==================== */
+/* MARK: - Notify! (publish usage to a phone) */
+/* ==================== */
+"notify.title" = "Notify!";
+"notify.subtitle" = "Put your usage on your phone's Lock Screen and Home Screen";
+
+/* Sections */
+"notify.section.publishing" = "Publishing";
+"notify.section.publishing_desc" = "Send your usage to the Notify! app on your phone";
+"notify.section.device" = "Linked Device";
+"notify.section.device_desc" = "Copy the device ID and token from the Notify! app";
+"notify.section.surfaces" = "What to Show";
+"notify.section.surfaces_desc" = "Each surface can be switched off on its own";
+"notify.section.gauge" = "Lock Screen Widget";
+"notify.section.gauge_desc" = "Which window the widget's ring shows";
+"notify.section.publish" = "Send Now";
+"notify.section.publish_desc" = "Push your current usage without waiting for the next update";
+"notify.section.privacy" = "Privacy";
+
+/* Master switch */
+"notify.enable" = "Publish to Notify!";
+"notify.enable_desc" = "Off until you link a device. Your usage is sent to Notify!, which is not Anthropic or OpenAI.";
+
+/* Device link */
+"notify.device_id" = "Device ID";
+"notify.device_id.placeholder" = "Paste the device ID, or the whole notification link";
+"notify.device_token" = "Device Token";
+"notify.device_token.placeholder" = "Paste the device token";
+"notify.verify" = "Verify Device";
+"notify.verifying" = "Checking…";
+"notify.save_link" = "Save Link";
+"notify.unlink" = "Unlink";
+
+/* Surfaces */
+"notify.surface.live_activity" = "Live Activity";
+"notify.surface.live_activity_desc" = "A tile on the Lock Screen with every window side by side. iPhone and iPad only.";
+"notify.surface.lock_screen" = "Lock Screen Widget";
+"notify.surface.lock_screen_desc" = "One window as a ring or a bar, for a glance without unlocking.";
+"notify.surface.home_screen" = "Home Screen Widget";
+"notify.surface.home_screen_desc" = "The same tile as the Live Activity, but it stays where you put it. Needs a recent Notify!.";
+
+/* Gauge picker */
+"notify.gauge.window" = "Show";
+"notify.gauge.automatic" = "Whichever needs attention most";
+
+/* Publish */
+"notify.publish_now" = "Send Now";
+"notify.publishing" = "Sending…";
+
+/* Privacy */
+"notify.privacy.what_leaves" = "What leaves this Mac: provider names, window labels, percentages left, balances and reset countdowns.";
+"notify.privacy.where_it_goes" = "Where it goes: push.getnotifyapp.com, and from there to your own phone.";
+"notify.privacy.off_by_default" = "Off by default, and it stays off until you link a device.";
+"notify.privacy.token_secret" = "Your device token is kept in the macOS Keychain and is never written to the app's settings.";
+
+/* Status messages */
+"notify.status.link_saved" = "Device link saved.";
+"notify.status.unlinked" = "Device unlinked. Anything already on your phone stays there until you remove it in Notify!.";
+"notify.status.verified" = "Linked to %@.";
+"notify.status.published" = "Sent.";
+"notify.status.switched_off" = "Publishing to Notify! is switched off.";
+"notify.status.all_surfaces_off" = "The Live Activity, the Lock Screen widget and the Home Screen widget are all switched off, so there is nothing to send.";
+"notify.status.no_usage_yet" = "There is no usage to send yet. Give the app a moment to fetch some.";
+"notify.status.holding_off" = "Notify! is still holding off Live Activity starts. The app will retry on its own.";
+"notify.status.home_screen_not_served" = "Notify! is not serving Home Screen widgets yet. The app will try again later.";
+
+/* Device kinds */
+"notify.device_kind.app_device" = "iPhone or iPad";
+"notify.device_kind.mac" = "Mac";
+"notify.device_kind.web" = "browser";
+"notify.device_kind.group" = "group";
+"notify.device_kind.unknown" = "device";
+
+/* What a device cannot carry */
+"notify.unsupported.live_activity_mac" = "This is a Mac ID. A Live Activity is an iPhone and iPad feature, so it cannot be started here. The widgets still work.";
+"notify.unsupported.live_activity_web" = "This is a browser ID. A Live Activity is an iPhone and iPad feature, so it cannot be started here. The widgets still work.";
+"notify.unsupported.live_activity_generic" = "A Live Activity only exists on an iPhone or iPad, so use the device ID and token from the Notify! app on your phone instead.";
+"notify.unsupported.group" = "This is a group ID. A group sends a notification out to its members and owns no Lock Screen of its own, so use the device ID and token for a single device instead.";
+"notify.unsupported.widget_generic" = "A group owns no Lock Screen of its own, so use the device ID and token for a single device instead.";
+"notify.unsupported.screen_widget_generic" = "A group owns no Home Screen of its own, so use the device ID and token for a single device instead.";
+
+/* Windows shown on the phone */
+"notify.window.session" = "5h";
+"notify.window.weekly" = "7d";
+"notify.window.opus" = "Opus 7d";
+"notify.window.sonnet" = "Sonnet 7d";
+"notify.window.design" = "Design 7d";
+"notify.window.fable" = "Fable 7d";
+"notify.window.spend" = "Spend";
+"notify.window.extra_usage" = "Extra usage";
+"notify.window.credits" = "Credits";
+
+/* Sentences written onto the tile and the widget */
+"notify.summary.balance_left" = "%@ left";
+"notify.summary.percent_left" = "%d%% left";
+"notify.summary.resets_soon" = "resets soon";
+"notify.summary.resets_in" = "resets in %@";
+
+/* Waits */
+"notify.wait.a_minute" = "a minute";
+"notify.wait.minutes" = "%d minutes";
+"notify.wait.an_hour" = "an hour";
+"notify.wait.hours" = "%d hours";
+
+/* Errors */
+"notify.error.not_linked" = "Add your Notify! device ID and token before publishing.";
+"notify.error.rejected_credentials" = "Notify! rejected these credentials. Copy the device ID and token again from the Notify! app.";
+"notify.error.live_activity_unavailable" = "This device cannot show a Live Activity yet. Open the Notify! app once on the device.";
+"notify.error.tile_gone" = "The Live Activity was dismissed on the device. A new one will be started.";
+"notify.error.backoff" = "Notify! is waiting %@ before another Live Activity.";
+"notify.error.backoff_open_app" = "Notify! is waiting %@ before another Live Activity. Opening the Notify! app on the device may clear it sooner.";
+"notify.error.invalid_payload" = "Notify! rejected the content of this update.";
+"notify.error.delivery_unconfirmed" = "Notify! could not confirm the Live Activity started. It will be checked again on the next update.";
+"notify.error.transport_failed" = "Could not reach Notify!: %@";
+"notify.error.surface_switched_off" = "Notify! has this widget switched off at the moment. The app will try again later.";
+"notify.error.unexpected_status" = "Notify! answered with HTTP %d.";
+"notify.error.malformed_response" = "Notify! sent a response the app could not read.";
+"notify.error.link_is_group" = "That link points at a Notify! group. This needs a device link, not a group.";
+"notify.error.bad_host" = "The Notify! host is not a usable URL.";
+"notify.error.encode_failed" = "This update could not be encoded.";
+
+/* Notify! — token storage */
+"notify.status.link_save_failed" = "Could not save the device token to the Keychain, so nothing was linked. The Keychain needs the app to be signed, and a copy built locally without a development team is not. Use a signed build — a release download, or set your team under Signing & Capabilities in Xcode.";

--- a/Claude Usage/Resources/fr.lproj/Localizable.strings
+++ b/Claude Usage/Resources/fr.lproj/Localizable.strings
@@ -1071,3 +1071,129 @@
 "support.popup_signature" = "l'équipe d'une seule personne derrière Claude Usage";
 "support.popup_body" = "Gratuit, open source, fait par une seule personne — sans pubs ni pistage. Si Claude Usage vous a déjà évité de griller une limite de session, un café le fait vivre.";
 "support.popup_days" = "Veille sur vos limites depuis %d jours — toujours gratuit";
+
+/* NOTE: the Notify! strings below are still in English and need translating. */
+
+/* ==================== */
+/* MARK: - Notify! (publish usage to a phone) */
+/* ==================== */
+"notify.title" = "Notify!";
+"notify.subtitle" = "Put your usage on your phone's Lock Screen and Home Screen";
+
+/* Sections */
+"notify.section.publishing" = "Publishing";
+"notify.section.publishing_desc" = "Send your usage to the Notify! app on your phone";
+"notify.section.device" = "Linked Device";
+"notify.section.device_desc" = "Copy the device ID and token from the Notify! app";
+"notify.section.surfaces" = "What to Show";
+"notify.section.surfaces_desc" = "Each surface can be switched off on its own";
+"notify.section.gauge" = "Lock Screen Widget";
+"notify.section.gauge_desc" = "Which window the widget's ring shows";
+"notify.section.publish" = "Send Now";
+"notify.section.publish_desc" = "Push your current usage without waiting for the next update";
+"notify.section.privacy" = "Privacy";
+
+/* Master switch */
+"notify.enable" = "Publish to Notify!";
+"notify.enable_desc" = "Off until you link a device. Your usage is sent to Notify!, which is not Anthropic or OpenAI.";
+
+/* Device link */
+"notify.device_id" = "Device ID";
+"notify.device_id.placeholder" = "Paste the device ID, or the whole notification link";
+"notify.device_token" = "Device Token";
+"notify.device_token.placeholder" = "Paste the device token";
+"notify.verify" = "Verify Device";
+"notify.verifying" = "Checking…";
+"notify.save_link" = "Save Link";
+"notify.unlink" = "Unlink";
+
+/* Surfaces */
+"notify.surface.live_activity" = "Live Activity";
+"notify.surface.live_activity_desc" = "A tile on the Lock Screen with every window side by side. iPhone and iPad only.";
+"notify.surface.lock_screen" = "Lock Screen Widget";
+"notify.surface.lock_screen_desc" = "One window as a ring or a bar, for a glance without unlocking.";
+"notify.surface.home_screen" = "Home Screen Widget";
+"notify.surface.home_screen_desc" = "The same tile as the Live Activity, but it stays where you put it. Needs a recent Notify!.";
+
+/* Gauge picker */
+"notify.gauge.window" = "Show";
+"notify.gauge.automatic" = "Whichever needs attention most";
+
+/* Publish */
+"notify.publish_now" = "Send Now";
+"notify.publishing" = "Sending…";
+
+/* Privacy */
+"notify.privacy.what_leaves" = "What leaves this Mac: provider names, window labels, percentages left, balances and reset countdowns.";
+"notify.privacy.where_it_goes" = "Where it goes: push.getnotifyapp.com, and from there to your own phone.";
+"notify.privacy.off_by_default" = "Off by default, and it stays off until you link a device.";
+"notify.privacy.token_secret" = "Your device token is kept in the macOS Keychain and is never written to the app's settings.";
+
+/* Status messages */
+"notify.status.link_saved" = "Device link saved.";
+"notify.status.unlinked" = "Device unlinked. Anything already on your phone stays there until you remove it in Notify!.";
+"notify.status.verified" = "Linked to %@.";
+"notify.status.published" = "Sent.";
+"notify.status.switched_off" = "Publishing to Notify! is switched off.";
+"notify.status.all_surfaces_off" = "The Live Activity, the Lock Screen widget and the Home Screen widget are all switched off, so there is nothing to send.";
+"notify.status.no_usage_yet" = "There is no usage to send yet. Give the app a moment to fetch some.";
+"notify.status.holding_off" = "Notify! is still holding off Live Activity starts. The app will retry on its own.";
+"notify.status.home_screen_not_served" = "Notify! is not serving Home Screen widgets yet. The app will try again later.";
+
+/* Device kinds */
+"notify.device_kind.app_device" = "iPhone or iPad";
+"notify.device_kind.mac" = "Mac";
+"notify.device_kind.web" = "browser";
+"notify.device_kind.group" = "group";
+"notify.device_kind.unknown" = "device";
+
+/* What a device cannot carry */
+"notify.unsupported.live_activity_mac" = "This is a Mac ID. A Live Activity is an iPhone and iPad feature, so it cannot be started here. The widgets still work.";
+"notify.unsupported.live_activity_web" = "This is a browser ID. A Live Activity is an iPhone and iPad feature, so it cannot be started here. The widgets still work.";
+"notify.unsupported.live_activity_generic" = "A Live Activity only exists on an iPhone or iPad, so use the device ID and token from the Notify! app on your phone instead.";
+"notify.unsupported.group" = "This is a group ID. A group sends a notification out to its members and owns no Lock Screen of its own, so use the device ID and token for a single device instead.";
+"notify.unsupported.widget_generic" = "A group owns no Lock Screen of its own, so use the device ID and token for a single device instead.";
+"notify.unsupported.screen_widget_generic" = "A group owns no Home Screen of its own, so use the device ID and token for a single device instead.";
+
+/* Windows shown on the phone */
+"notify.window.session" = "5h";
+"notify.window.weekly" = "7d";
+"notify.window.opus" = "Opus 7d";
+"notify.window.sonnet" = "Sonnet 7d";
+"notify.window.design" = "Design 7d";
+"notify.window.fable" = "Fable 7d";
+"notify.window.spend" = "Spend";
+"notify.window.extra_usage" = "Extra usage";
+"notify.window.credits" = "Credits";
+
+/* Sentences written onto the tile and the widget */
+"notify.summary.balance_left" = "%@ left";
+"notify.summary.percent_left" = "%d%% left";
+"notify.summary.resets_soon" = "resets soon";
+"notify.summary.resets_in" = "resets in %@";
+
+/* Waits */
+"notify.wait.a_minute" = "a minute";
+"notify.wait.minutes" = "%d minutes";
+"notify.wait.an_hour" = "an hour";
+"notify.wait.hours" = "%d hours";
+
+/* Errors */
+"notify.error.not_linked" = "Add your Notify! device ID and token before publishing.";
+"notify.error.rejected_credentials" = "Notify! rejected these credentials. Copy the device ID and token again from the Notify! app.";
+"notify.error.live_activity_unavailable" = "This device cannot show a Live Activity yet. Open the Notify! app once on the device.";
+"notify.error.tile_gone" = "The Live Activity was dismissed on the device. A new one will be started.";
+"notify.error.backoff" = "Notify! is waiting %@ before another Live Activity.";
+"notify.error.backoff_open_app" = "Notify! is waiting %@ before another Live Activity. Opening the Notify! app on the device may clear it sooner.";
+"notify.error.invalid_payload" = "Notify! rejected the content of this update.";
+"notify.error.delivery_unconfirmed" = "Notify! could not confirm the Live Activity started. It will be checked again on the next update.";
+"notify.error.transport_failed" = "Could not reach Notify!: %@";
+"notify.error.surface_switched_off" = "Notify! has this widget switched off at the moment. The app will try again later.";
+"notify.error.unexpected_status" = "Notify! answered with HTTP %d.";
+"notify.error.malformed_response" = "Notify! sent a response the app could not read.";
+"notify.error.link_is_group" = "That link points at a Notify! group. This needs a device link, not a group.";
+"notify.error.bad_host" = "The Notify! host is not a usable URL.";
+"notify.error.encode_failed" = "This update could not be encoded.";
+
+/* Notify! — token storage */
+"notify.status.link_save_failed" = "Could not save the device token to the Keychain, so nothing was linked. The Keychain needs the app to be signed, and a copy built locally without a development team is not. Use a signed build — a release download, or set your team under Signing & Capabilities in Xcode.";

--- a/Claude Usage/Resources/it.lproj/Localizable.strings
+++ b/Claude Usage/Resources/it.lproj/Localizable.strings
@@ -1093,3 +1093,129 @@
 "support.popup_signature" = "il team di una sola persona dietro Claude Usage";
 "support.popup_body" = "Gratuita, open source, fatta da una sola persona — senza pubblicità né tracciamento. Se ti ha mai evitato di bruciare un limite di sessione, un caffè la tiene viva.";
 "support.popup_days" = "Sorveglia i tuoi limiti da %d giorni — sempre gratis";
+
+/* NOTE: the Notify! strings below are still in English and need translating. */
+
+/* ==================== */
+/* MARK: - Notify! (publish usage to a phone) */
+/* ==================== */
+"notify.title" = "Notify!";
+"notify.subtitle" = "Put your usage on your phone's Lock Screen and Home Screen";
+
+/* Sections */
+"notify.section.publishing" = "Publishing";
+"notify.section.publishing_desc" = "Send your usage to the Notify! app on your phone";
+"notify.section.device" = "Linked Device";
+"notify.section.device_desc" = "Copy the device ID and token from the Notify! app";
+"notify.section.surfaces" = "What to Show";
+"notify.section.surfaces_desc" = "Each surface can be switched off on its own";
+"notify.section.gauge" = "Lock Screen Widget";
+"notify.section.gauge_desc" = "Which window the widget's ring shows";
+"notify.section.publish" = "Send Now";
+"notify.section.publish_desc" = "Push your current usage without waiting for the next update";
+"notify.section.privacy" = "Privacy";
+
+/* Master switch */
+"notify.enable" = "Publish to Notify!";
+"notify.enable_desc" = "Off until you link a device. Your usage is sent to Notify!, which is not Anthropic or OpenAI.";
+
+/* Device link */
+"notify.device_id" = "Device ID";
+"notify.device_id.placeholder" = "Paste the device ID, or the whole notification link";
+"notify.device_token" = "Device Token";
+"notify.device_token.placeholder" = "Paste the device token";
+"notify.verify" = "Verify Device";
+"notify.verifying" = "Checking…";
+"notify.save_link" = "Save Link";
+"notify.unlink" = "Unlink";
+
+/* Surfaces */
+"notify.surface.live_activity" = "Live Activity";
+"notify.surface.live_activity_desc" = "A tile on the Lock Screen with every window side by side. iPhone and iPad only.";
+"notify.surface.lock_screen" = "Lock Screen Widget";
+"notify.surface.lock_screen_desc" = "One window as a ring or a bar, for a glance without unlocking.";
+"notify.surface.home_screen" = "Home Screen Widget";
+"notify.surface.home_screen_desc" = "The same tile as the Live Activity, but it stays where you put it. Needs a recent Notify!.";
+
+/* Gauge picker */
+"notify.gauge.window" = "Show";
+"notify.gauge.automatic" = "Whichever needs attention most";
+
+/* Publish */
+"notify.publish_now" = "Send Now";
+"notify.publishing" = "Sending…";
+
+/* Privacy */
+"notify.privacy.what_leaves" = "What leaves this Mac: provider names, window labels, percentages left, balances and reset countdowns.";
+"notify.privacy.where_it_goes" = "Where it goes: push.getnotifyapp.com, and from there to your own phone.";
+"notify.privacy.off_by_default" = "Off by default, and it stays off until you link a device.";
+"notify.privacy.token_secret" = "Your device token is kept in the macOS Keychain and is never written to the app's settings.";
+
+/* Status messages */
+"notify.status.link_saved" = "Device link saved.";
+"notify.status.unlinked" = "Device unlinked. Anything already on your phone stays there until you remove it in Notify!.";
+"notify.status.verified" = "Linked to %@.";
+"notify.status.published" = "Sent.";
+"notify.status.switched_off" = "Publishing to Notify! is switched off.";
+"notify.status.all_surfaces_off" = "The Live Activity, the Lock Screen widget and the Home Screen widget are all switched off, so there is nothing to send.";
+"notify.status.no_usage_yet" = "There is no usage to send yet. Give the app a moment to fetch some.";
+"notify.status.holding_off" = "Notify! is still holding off Live Activity starts. The app will retry on its own.";
+"notify.status.home_screen_not_served" = "Notify! is not serving Home Screen widgets yet. The app will try again later.";
+
+/* Device kinds */
+"notify.device_kind.app_device" = "iPhone or iPad";
+"notify.device_kind.mac" = "Mac";
+"notify.device_kind.web" = "browser";
+"notify.device_kind.group" = "group";
+"notify.device_kind.unknown" = "device";
+
+/* What a device cannot carry */
+"notify.unsupported.live_activity_mac" = "This is a Mac ID. A Live Activity is an iPhone and iPad feature, so it cannot be started here. The widgets still work.";
+"notify.unsupported.live_activity_web" = "This is a browser ID. A Live Activity is an iPhone and iPad feature, so it cannot be started here. The widgets still work.";
+"notify.unsupported.live_activity_generic" = "A Live Activity only exists on an iPhone or iPad, so use the device ID and token from the Notify! app on your phone instead.";
+"notify.unsupported.group" = "This is a group ID. A group sends a notification out to its members and owns no Lock Screen of its own, so use the device ID and token for a single device instead.";
+"notify.unsupported.widget_generic" = "A group owns no Lock Screen of its own, so use the device ID and token for a single device instead.";
+"notify.unsupported.screen_widget_generic" = "A group owns no Home Screen of its own, so use the device ID and token for a single device instead.";
+
+/* Windows shown on the phone */
+"notify.window.session" = "5h";
+"notify.window.weekly" = "7d";
+"notify.window.opus" = "Opus 7d";
+"notify.window.sonnet" = "Sonnet 7d";
+"notify.window.design" = "Design 7d";
+"notify.window.fable" = "Fable 7d";
+"notify.window.spend" = "Spend";
+"notify.window.extra_usage" = "Extra usage";
+"notify.window.credits" = "Credits";
+
+/* Sentences written onto the tile and the widget */
+"notify.summary.balance_left" = "%@ left";
+"notify.summary.percent_left" = "%d%% left";
+"notify.summary.resets_soon" = "resets soon";
+"notify.summary.resets_in" = "resets in %@";
+
+/* Waits */
+"notify.wait.a_minute" = "a minute";
+"notify.wait.minutes" = "%d minutes";
+"notify.wait.an_hour" = "an hour";
+"notify.wait.hours" = "%d hours";
+
+/* Errors */
+"notify.error.not_linked" = "Add your Notify! device ID and token before publishing.";
+"notify.error.rejected_credentials" = "Notify! rejected these credentials. Copy the device ID and token again from the Notify! app.";
+"notify.error.live_activity_unavailable" = "This device cannot show a Live Activity yet. Open the Notify! app once on the device.";
+"notify.error.tile_gone" = "The Live Activity was dismissed on the device. A new one will be started.";
+"notify.error.backoff" = "Notify! is waiting %@ before another Live Activity.";
+"notify.error.backoff_open_app" = "Notify! is waiting %@ before another Live Activity. Opening the Notify! app on the device may clear it sooner.";
+"notify.error.invalid_payload" = "Notify! rejected the content of this update.";
+"notify.error.delivery_unconfirmed" = "Notify! could not confirm the Live Activity started. It will be checked again on the next update.";
+"notify.error.transport_failed" = "Could not reach Notify!: %@";
+"notify.error.surface_switched_off" = "Notify! has this widget switched off at the moment. The app will try again later.";
+"notify.error.unexpected_status" = "Notify! answered with HTTP %d.";
+"notify.error.malformed_response" = "Notify! sent a response the app could not read.";
+"notify.error.link_is_group" = "That link points at a Notify! group. This needs a device link, not a group.";
+"notify.error.bad_host" = "The Notify! host is not a usable URL.";
+"notify.error.encode_failed" = "This update could not be encoded.";
+
+/* Notify! — token storage */
+"notify.status.link_save_failed" = "Could not save the device token to the Keychain, so nothing was linked. The Keychain needs the app to be signed, and a copy built locally without a development team is not. Use a signed build — a release download, or set your team under Signing & Capabilities in Xcode.";

--- a/Claude Usage/Resources/ja.lproj/Localizable.strings
+++ b/Claude Usage/Resources/ja.lproj/Localizable.strings
@@ -1093,3 +1093,129 @@
 "support.popup_signature" = "Claude Usage を一人で作っています";
 "support.popup_body" = "無料・オープンソース・個人開発。広告もトラッキングもありません。セッション上限の浪費を防いだことがあるなら、一杯のコーヒーが開発を支えます。";
 "support.popup_days" = "あなたの上限を見守って %d 日 — ずっと無料";
+
+/* NOTE: the Notify! strings below are still in English and need translating. */
+
+/* ==================== */
+/* MARK: - Notify! (publish usage to a phone) */
+/* ==================== */
+"notify.title" = "Notify!";
+"notify.subtitle" = "Put your usage on your phone's Lock Screen and Home Screen";
+
+/* Sections */
+"notify.section.publishing" = "Publishing";
+"notify.section.publishing_desc" = "Send your usage to the Notify! app on your phone";
+"notify.section.device" = "Linked Device";
+"notify.section.device_desc" = "Copy the device ID and token from the Notify! app";
+"notify.section.surfaces" = "What to Show";
+"notify.section.surfaces_desc" = "Each surface can be switched off on its own";
+"notify.section.gauge" = "Lock Screen Widget";
+"notify.section.gauge_desc" = "Which window the widget's ring shows";
+"notify.section.publish" = "Send Now";
+"notify.section.publish_desc" = "Push your current usage without waiting for the next update";
+"notify.section.privacy" = "Privacy";
+
+/* Master switch */
+"notify.enable" = "Publish to Notify!";
+"notify.enable_desc" = "Off until you link a device. Your usage is sent to Notify!, which is not Anthropic or OpenAI.";
+
+/* Device link */
+"notify.device_id" = "Device ID";
+"notify.device_id.placeholder" = "Paste the device ID, or the whole notification link";
+"notify.device_token" = "Device Token";
+"notify.device_token.placeholder" = "Paste the device token";
+"notify.verify" = "Verify Device";
+"notify.verifying" = "Checking…";
+"notify.save_link" = "Save Link";
+"notify.unlink" = "Unlink";
+
+/* Surfaces */
+"notify.surface.live_activity" = "Live Activity";
+"notify.surface.live_activity_desc" = "A tile on the Lock Screen with every window side by side. iPhone and iPad only.";
+"notify.surface.lock_screen" = "Lock Screen Widget";
+"notify.surface.lock_screen_desc" = "One window as a ring or a bar, for a glance without unlocking.";
+"notify.surface.home_screen" = "Home Screen Widget";
+"notify.surface.home_screen_desc" = "The same tile as the Live Activity, but it stays where you put it. Needs a recent Notify!.";
+
+/* Gauge picker */
+"notify.gauge.window" = "Show";
+"notify.gauge.automatic" = "Whichever needs attention most";
+
+/* Publish */
+"notify.publish_now" = "Send Now";
+"notify.publishing" = "Sending…";
+
+/* Privacy */
+"notify.privacy.what_leaves" = "What leaves this Mac: provider names, window labels, percentages left, balances and reset countdowns.";
+"notify.privacy.where_it_goes" = "Where it goes: push.getnotifyapp.com, and from there to your own phone.";
+"notify.privacy.off_by_default" = "Off by default, and it stays off until you link a device.";
+"notify.privacy.token_secret" = "Your device token is kept in the macOS Keychain and is never written to the app's settings.";
+
+/* Status messages */
+"notify.status.link_saved" = "Device link saved.";
+"notify.status.unlinked" = "Device unlinked. Anything already on your phone stays there until you remove it in Notify!.";
+"notify.status.verified" = "Linked to %@.";
+"notify.status.published" = "Sent.";
+"notify.status.switched_off" = "Publishing to Notify! is switched off.";
+"notify.status.all_surfaces_off" = "The Live Activity, the Lock Screen widget and the Home Screen widget are all switched off, so there is nothing to send.";
+"notify.status.no_usage_yet" = "There is no usage to send yet. Give the app a moment to fetch some.";
+"notify.status.holding_off" = "Notify! is still holding off Live Activity starts. The app will retry on its own.";
+"notify.status.home_screen_not_served" = "Notify! is not serving Home Screen widgets yet. The app will try again later.";
+
+/* Device kinds */
+"notify.device_kind.app_device" = "iPhone or iPad";
+"notify.device_kind.mac" = "Mac";
+"notify.device_kind.web" = "browser";
+"notify.device_kind.group" = "group";
+"notify.device_kind.unknown" = "device";
+
+/* What a device cannot carry */
+"notify.unsupported.live_activity_mac" = "This is a Mac ID. A Live Activity is an iPhone and iPad feature, so it cannot be started here. The widgets still work.";
+"notify.unsupported.live_activity_web" = "This is a browser ID. A Live Activity is an iPhone and iPad feature, so it cannot be started here. The widgets still work.";
+"notify.unsupported.live_activity_generic" = "A Live Activity only exists on an iPhone or iPad, so use the device ID and token from the Notify! app on your phone instead.";
+"notify.unsupported.group" = "This is a group ID. A group sends a notification out to its members and owns no Lock Screen of its own, so use the device ID and token for a single device instead.";
+"notify.unsupported.widget_generic" = "A group owns no Lock Screen of its own, so use the device ID and token for a single device instead.";
+"notify.unsupported.screen_widget_generic" = "A group owns no Home Screen of its own, so use the device ID and token for a single device instead.";
+
+/* Windows shown on the phone */
+"notify.window.session" = "5h";
+"notify.window.weekly" = "7d";
+"notify.window.opus" = "Opus 7d";
+"notify.window.sonnet" = "Sonnet 7d";
+"notify.window.design" = "Design 7d";
+"notify.window.fable" = "Fable 7d";
+"notify.window.spend" = "Spend";
+"notify.window.extra_usage" = "Extra usage";
+"notify.window.credits" = "Credits";
+
+/* Sentences written onto the tile and the widget */
+"notify.summary.balance_left" = "%@ left";
+"notify.summary.percent_left" = "%d%% left";
+"notify.summary.resets_soon" = "resets soon";
+"notify.summary.resets_in" = "resets in %@";
+
+/* Waits */
+"notify.wait.a_minute" = "a minute";
+"notify.wait.minutes" = "%d minutes";
+"notify.wait.an_hour" = "an hour";
+"notify.wait.hours" = "%d hours";
+
+/* Errors */
+"notify.error.not_linked" = "Add your Notify! device ID and token before publishing.";
+"notify.error.rejected_credentials" = "Notify! rejected these credentials. Copy the device ID and token again from the Notify! app.";
+"notify.error.live_activity_unavailable" = "This device cannot show a Live Activity yet. Open the Notify! app once on the device.";
+"notify.error.tile_gone" = "The Live Activity was dismissed on the device. A new one will be started.";
+"notify.error.backoff" = "Notify! is waiting %@ before another Live Activity.";
+"notify.error.backoff_open_app" = "Notify! is waiting %@ before another Live Activity. Opening the Notify! app on the device may clear it sooner.";
+"notify.error.invalid_payload" = "Notify! rejected the content of this update.";
+"notify.error.delivery_unconfirmed" = "Notify! could not confirm the Live Activity started. It will be checked again on the next update.";
+"notify.error.transport_failed" = "Could not reach Notify!: %@";
+"notify.error.surface_switched_off" = "Notify! has this widget switched off at the moment. The app will try again later.";
+"notify.error.unexpected_status" = "Notify! answered with HTTP %d.";
+"notify.error.malformed_response" = "Notify! sent a response the app could not read.";
+"notify.error.link_is_group" = "That link points at a Notify! group. This needs a device link, not a group.";
+"notify.error.bad_host" = "The Notify! host is not a usable URL.";
+"notify.error.encode_failed" = "This update could not be encoded.";
+
+/* Notify! — token storage */
+"notify.status.link_save_failed" = "Could not save the device token to the Keychain, so nothing was linked. The Keychain needs the app to be signed, and a copy built locally without a development team is not. Use a signed build — a release download, or set your team under Signing & Capabilities in Xcode.";

--- a/Claude Usage/Resources/ko.lproj/Localizable.strings
+++ b/Claude Usage/Resources/ko.lproj/Localizable.strings
@@ -1102,3 +1102,129 @@
 "support.popup_signature" = "Claude Usage를 혼자 만드는 1인 팀";
 "support.popup_body" = "무료, 오픈소스, 1인 개발 — 광고도 추적도 없습니다. 세션 한도를 태우는 걸 막아준 적이 있다면, 커피 한 잔이 개발을 이어가게 합니다.";
 "support.popup_days" = "%d일째 당신의 한도를 지키는 중 — 언제나 무료";
+
+/* NOTE: the Notify! strings below are still in English and need translating. */
+
+/* ==================== */
+/* MARK: - Notify! (publish usage to a phone) */
+/* ==================== */
+"notify.title" = "Notify!";
+"notify.subtitle" = "Put your usage on your phone's Lock Screen and Home Screen";
+
+/* Sections */
+"notify.section.publishing" = "Publishing";
+"notify.section.publishing_desc" = "Send your usage to the Notify! app on your phone";
+"notify.section.device" = "Linked Device";
+"notify.section.device_desc" = "Copy the device ID and token from the Notify! app";
+"notify.section.surfaces" = "What to Show";
+"notify.section.surfaces_desc" = "Each surface can be switched off on its own";
+"notify.section.gauge" = "Lock Screen Widget";
+"notify.section.gauge_desc" = "Which window the widget's ring shows";
+"notify.section.publish" = "Send Now";
+"notify.section.publish_desc" = "Push your current usage without waiting for the next update";
+"notify.section.privacy" = "Privacy";
+
+/* Master switch */
+"notify.enable" = "Publish to Notify!";
+"notify.enable_desc" = "Off until you link a device. Your usage is sent to Notify!, which is not Anthropic or OpenAI.";
+
+/* Device link */
+"notify.device_id" = "Device ID";
+"notify.device_id.placeholder" = "Paste the device ID, or the whole notification link";
+"notify.device_token" = "Device Token";
+"notify.device_token.placeholder" = "Paste the device token";
+"notify.verify" = "Verify Device";
+"notify.verifying" = "Checking…";
+"notify.save_link" = "Save Link";
+"notify.unlink" = "Unlink";
+
+/* Surfaces */
+"notify.surface.live_activity" = "Live Activity";
+"notify.surface.live_activity_desc" = "A tile on the Lock Screen with every window side by side. iPhone and iPad only.";
+"notify.surface.lock_screen" = "Lock Screen Widget";
+"notify.surface.lock_screen_desc" = "One window as a ring or a bar, for a glance without unlocking.";
+"notify.surface.home_screen" = "Home Screen Widget";
+"notify.surface.home_screen_desc" = "The same tile as the Live Activity, but it stays where you put it. Needs a recent Notify!.";
+
+/* Gauge picker */
+"notify.gauge.window" = "Show";
+"notify.gauge.automatic" = "Whichever needs attention most";
+
+/* Publish */
+"notify.publish_now" = "Send Now";
+"notify.publishing" = "Sending…";
+
+/* Privacy */
+"notify.privacy.what_leaves" = "What leaves this Mac: provider names, window labels, percentages left, balances and reset countdowns.";
+"notify.privacy.where_it_goes" = "Where it goes: push.getnotifyapp.com, and from there to your own phone.";
+"notify.privacy.off_by_default" = "Off by default, and it stays off until you link a device.";
+"notify.privacy.token_secret" = "Your device token is kept in the macOS Keychain and is never written to the app's settings.";
+
+/* Status messages */
+"notify.status.link_saved" = "Device link saved.";
+"notify.status.unlinked" = "Device unlinked. Anything already on your phone stays there until you remove it in Notify!.";
+"notify.status.verified" = "Linked to %@.";
+"notify.status.published" = "Sent.";
+"notify.status.switched_off" = "Publishing to Notify! is switched off.";
+"notify.status.all_surfaces_off" = "The Live Activity, the Lock Screen widget and the Home Screen widget are all switched off, so there is nothing to send.";
+"notify.status.no_usage_yet" = "There is no usage to send yet. Give the app a moment to fetch some.";
+"notify.status.holding_off" = "Notify! is still holding off Live Activity starts. The app will retry on its own.";
+"notify.status.home_screen_not_served" = "Notify! is not serving Home Screen widgets yet. The app will try again later.";
+
+/* Device kinds */
+"notify.device_kind.app_device" = "iPhone or iPad";
+"notify.device_kind.mac" = "Mac";
+"notify.device_kind.web" = "browser";
+"notify.device_kind.group" = "group";
+"notify.device_kind.unknown" = "device";
+
+/* What a device cannot carry */
+"notify.unsupported.live_activity_mac" = "This is a Mac ID. A Live Activity is an iPhone and iPad feature, so it cannot be started here. The widgets still work.";
+"notify.unsupported.live_activity_web" = "This is a browser ID. A Live Activity is an iPhone and iPad feature, so it cannot be started here. The widgets still work.";
+"notify.unsupported.live_activity_generic" = "A Live Activity only exists on an iPhone or iPad, so use the device ID and token from the Notify! app on your phone instead.";
+"notify.unsupported.group" = "This is a group ID. A group sends a notification out to its members and owns no Lock Screen of its own, so use the device ID and token for a single device instead.";
+"notify.unsupported.widget_generic" = "A group owns no Lock Screen of its own, so use the device ID and token for a single device instead.";
+"notify.unsupported.screen_widget_generic" = "A group owns no Home Screen of its own, so use the device ID and token for a single device instead.";
+
+/* Windows shown on the phone */
+"notify.window.session" = "5h";
+"notify.window.weekly" = "7d";
+"notify.window.opus" = "Opus 7d";
+"notify.window.sonnet" = "Sonnet 7d";
+"notify.window.design" = "Design 7d";
+"notify.window.fable" = "Fable 7d";
+"notify.window.spend" = "Spend";
+"notify.window.extra_usage" = "Extra usage";
+"notify.window.credits" = "Credits";
+
+/* Sentences written onto the tile and the widget */
+"notify.summary.balance_left" = "%@ left";
+"notify.summary.percent_left" = "%d%% left";
+"notify.summary.resets_soon" = "resets soon";
+"notify.summary.resets_in" = "resets in %@";
+
+/* Waits */
+"notify.wait.a_minute" = "a minute";
+"notify.wait.minutes" = "%d minutes";
+"notify.wait.an_hour" = "an hour";
+"notify.wait.hours" = "%d hours";
+
+/* Errors */
+"notify.error.not_linked" = "Add your Notify! device ID and token before publishing.";
+"notify.error.rejected_credentials" = "Notify! rejected these credentials. Copy the device ID and token again from the Notify! app.";
+"notify.error.live_activity_unavailable" = "This device cannot show a Live Activity yet. Open the Notify! app once on the device.";
+"notify.error.tile_gone" = "The Live Activity was dismissed on the device. A new one will be started.";
+"notify.error.backoff" = "Notify! is waiting %@ before another Live Activity.";
+"notify.error.backoff_open_app" = "Notify! is waiting %@ before another Live Activity. Opening the Notify! app on the device may clear it sooner.";
+"notify.error.invalid_payload" = "Notify! rejected the content of this update.";
+"notify.error.delivery_unconfirmed" = "Notify! could not confirm the Live Activity started. It will be checked again on the next update.";
+"notify.error.transport_failed" = "Could not reach Notify!: %@";
+"notify.error.surface_switched_off" = "Notify! has this widget switched off at the moment. The app will try again later.";
+"notify.error.unexpected_status" = "Notify! answered with HTTP %d.";
+"notify.error.malformed_response" = "Notify! sent a response the app could not read.";
+"notify.error.link_is_group" = "That link points at a Notify! group. This needs a device link, not a group.";
+"notify.error.bad_host" = "The Notify! host is not a usable URL.";
+"notify.error.encode_failed" = "This update could not be encoded.";
+
+/* Notify! — token storage */
+"notify.status.link_save_failed" = "Could not save the device token to the Keychain, so nothing was linked. The Keychain needs the app to be signed, and a copy built locally without a development team is not. Use a signed build — a release download, or set your team under Signing & Capabilities in Xcode.";

--- a/Claude Usage/Resources/pt-BR.lproj/Localizable.strings
+++ b/Claude Usage/Resources/pt-BR.lproj/Localizable.strings
@@ -1093,3 +1093,129 @@
 "support.popup_signature" = "o time de uma pessoa só por trás do Claude Usage";
 "support.popup_body" = "Grátis, open source, feito por uma pessoa só — sem anúncios nem rastreamento. Se já salvou você de queimar um limite de sessão, um café o mantém vivo.";
 "support.popup_days" = "De olho nos seus limites há %d dias — sempre grátis";
+
+/* NOTE: the Notify! strings below are still in English and need translating. */
+
+/* ==================== */
+/* MARK: - Notify! (publish usage to a phone) */
+/* ==================== */
+"notify.title" = "Notify!";
+"notify.subtitle" = "Put your usage on your phone's Lock Screen and Home Screen";
+
+/* Sections */
+"notify.section.publishing" = "Publishing";
+"notify.section.publishing_desc" = "Send your usage to the Notify! app on your phone";
+"notify.section.device" = "Linked Device";
+"notify.section.device_desc" = "Copy the device ID and token from the Notify! app";
+"notify.section.surfaces" = "What to Show";
+"notify.section.surfaces_desc" = "Each surface can be switched off on its own";
+"notify.section.gauge" = "Lock Screen Widget";
+"notify.section.gauge_desc" = "Which window the widget's ring shows";
+"notify.section.publish" = "Send Now";
+"notify.section.publish_desc" = "Push your current usage without waiting for the next update";
+"notify.section.privacy" = "Privacy";
+
+/* Master switch */
+"notify.enable" = "Publish to Notify!";
+"notify.enable_desc" = "Off until you link a device. Your usage is sent to Notify!, which is not Anthropic or OpenAI.";
+
+/* Device link */
+"notify.device_id" = "Device ID";
+"notify.device_id.placeholder" = "Paste the device ID, or the whole notification link";
+"notify.device_token" = "Device Token";
+"notify.device_token.placeholder" = "Paste the device token";
+"notify.verify" = "Verify Device";
+"notify.verifying" = "Checking…";
+"notify.save_link" = "Save Link";
+"notify.unlink" = "Unlink";
+
+/* Surfaces */
+"notify.surface.live_activity" = "Live Activity";
+"notify.surface.live_activity_desc" = "A tile on the Lock Screen with every window side by side. iPhone and iPad only.";
+"notify.surface.lock_screen" = "Lock Screen Widget";
+"notify.surface.lock_screen_desc" = "One window as a ring or a bar, for a glance without unlocking.";
+"notify.surface.home_screen" = "Home Screen Widget";
+"notify.surface.home_screen_desc" = "The same tile as the Live Activity, but it stays where you put it. Needs a recent Notify!.";
+
+/* Gauge picker */
+"notify.gauge.window" = "Show";
+"notify.gauge.automatic" = "Whichever needs attention most";
+
+/* Publish */
+"notify.publish_now" = "Send Now";
+"notify.publishing" = "Sending…";
+
+/* Privacy */
+"notify.privacy.what_leaves" = "What leaves this Mac: provider names, window labels, percentages left, balances and reset countdowns.";
+"notify.privacy.where_it_goes" = "Where it goes: push.getnotifyapp.com, and from there to your own phone.";
+"notify.privacy.off_by_default" = "Off by default, and it stays off until you link a device.";
+"notify.privacy.token_secret" = "Your device token is kept in the macOS Keychain and is never written to the app's settings.";
+
+/* Status messages */
+"notify.status.link_saved" = "Device link saved.";
+"notify.status.unlinked" = "Device unlinked. Anything already on your phone stays there until you remove it in Notify!.";
+"notify.status.verified" = "Linked to %@.";
+"notify.status.published" = "Sent.";
+"notify.status.switched_off" = "Publishing to Notify! is switched off.";
+"notify.status.all_surfaces_off" = "The Live Activity, the Lock Screen widget and the Home Screen widget are all switched off, so there is nothing to send.";
+"notify.status.no_usage_yet" = "There is no usage to send yet. Give the app a moment to fetch some.";
+"notify.status.holding_off" = "Notify! is still holding off Live Activity starts. The app will retry on its own.";
+"notify.status.home_screen_not_served" = "Notify! is not serving Home Screen widgets yet. The app will try again later.";
+
+/* Device kinds */
+"notify.device_kind.app_device" = "iPhone or iPad";
+"notify.device_kind.mac" = "Mac";
+"notify.device_kind.web" = "browser";
+"notify.device_kind.group" = "group";
+"notify.device_kind.unknown" = "device";
+
+/* What a device cannot carry */
+"notify.unsupported.live_activity_mac" = "This is a Mac ID. A Live Activity is an iPhone and iPad feature, so it cannot be started here. The widgets still work.";
+"notify.unsupported.live_activity_web" = "This is a browser ID. A Live Activity is an iPhone and iPad feature, so it cannot be started here. The widgets still work.";
+"notify.unsupported.live_activity_generic" = "A Live Activity only exists on an iPhone or iPad, so use the device ID and token from the Notify! app on your phone instead.";
+"notify.unsupported.group" = "This is a group ID. A group sends a notification out to its members and owns no Lock Screen of its own, so use the device ID and token for a single device instead.";
+"notify.unsupported.widget_generic" = "A group owns no Lock Screen of its own, so use the device ID and token for a single device instead.";
+"notify.unsupported.screen_widget_generic" = "A group owns no Home Screen of its own, so use the device ID and token for a single device instead.";
+
+/* Windows shown on the phone */
+"notify.window.session" = "5h";
+"notify.window.weekly" = "7d";
+"notify.window.opus" = "Opus 7d";
+"notify.window.sonnet" = "Sonnet 7d";
+"notify.window.design" = "Design 7d";
+"notify.window.fable" = "Fable 7d";
+"notify.window.spend" = "Spend";
+"notify.window.extra_usage" = "Extra usage";
+"notify.window.credits" = "Credits";
+
+/* Sentences written onto the tile and the widget */
+"notify.summary.balance_left" = "%@ left";
+"notify.summary.percent_left" = "%d%% left";
+"notify.summary.resets_soon" = "resets soon";
+"notify.summary.resets_in" = "resets in %@";
+
+/* Waits */
+"notify.wait.a_minute" = "a minute";
+"notify.wait.minutes" = "%d minutes";
+"notify.wait.an_hour" = "an hour";
+"notify.wait.hours" = "%d hours";
+
+/* Errors */
+"notify.error.not_linked" = "Add your Notify! device ID and token before publishing.";
+"notify.error.rejected_credentials" = "Notify! rejected these credentials. Copy the device ID and token again from the Notify! app.";
+"notify.error.live_activity_unavailable" = "This device cannot show a Live Activity yet. Open the Notify! app once on the device.";
+"notify.error.tile_gone" = "The Live Activity was dismissed on the device. A new one will be started.";
+"notify.error.backoff" = "Notify! is waiting %@ before another Live Activity.";
+"notify.error.backoff_open_app" = "Notify! is waiting %@ before another Live Activity. Opening the Notify! app on the device may clear it sooner.";
+"notify.error.invalid_payload" = "Notify! rejected the content of this update.";
+"notify.error.delivery_unconfirmed" = "Notify! could not confirm the Live Activity started. It will be checked again on the next update.";
+"notify.error.transport_failed" = "Could not reach Notify!: %@";
+"notify.error.surface_switched_off" = "Notify! has this widget switched off at the moment. The app will try again later.";
+"notify.error.unexpected_status" = "Notify! answered with HTTP %d.";
+"notify.error.malformed_response" = "Notify! sent a response the app could not read.";
+"notify.error.link_is_group" = "That link points at a Notify! group. This needs a device link, not a group.";
+"notify.error.bad_host" = "The Notify! host is not a usable URL.";
+"notify.error.encode_failed" = "This update could not be encoded.";
+
+/* Notify! — token storage */
+"notify.status.link_save_failed" = "Could not save the device token to the Keychain, so nothing was linked. The Keychain needs the app to be signed, and a copy built locally without a development team is not. Use a signed build — a release download, or set your team under Signing & Capabilities in Xcode.";

--- a/Claude Usage/Resources/pt.lproj/Localizable.strings
+++ b/Claude Usage/Resources/pt.lproj/Localizable.strings
@@ -1093,3 +1093,129 @@
 "support.popup_signature" = "a equipa de uma só pessoa por trás do Claude Usage";
 "support.popup_body" = "Grátis, open source, feita por uma só pessoa — sem anúncios nem rastreio. Se já te salvou de queimar um limite de sessão, um café mantém-na viva.";
 "support.popup_days" = "A vigiar os teus limites há %d dias — sempre grátis";
+
+/* NOTE: the Notify! strings below are still in English and need translating. */
+
+/* ==================== */
+/* MARK: - Notify! (publish usage to a phone) */
+/* ==================== */
+"notify.title" = "Notify!";
+"notify.subtitle" = "Put your usage on your phone's Lock Screen and Home Screen";
+
+/* Sections */
+"notify.section.publishing" = "Publishing";
+"notify.section.publishing_desc" = "Send your usage to the Notify! app on your phone";
+"notify.section.device" = "Linked Device";
+"notify.section.device_desc" = "Copy the device ID and token from the Notify! app";
+"notify.section.surfaces" = "What to Show";
+"notify.section.surfaces_desc" = "Each surface can be switched off on its own";
+"notify.section.gauge" = "Lock Screen Widget";
+"notify.section.gauge_desc" = "Which window the widget's ring shows";
+"notify.section.publish" = "Send Now";
+"notify.section.publish_desc" = "Push your current usage without waiting for the next update";
+"notify.section.privacy" = "Privacy";
+
+/* Master switch */
+"notify.enable" = "Publish to Notify!";
+"notify.enable_desc" = "Off until you link a device. Your usage is sent to Notify!, which is not Anthropic or OpenAI.";
+
+/* Device link */
+"notify.device_id" = "Device ID";
+"notify.device_id.placeholder" = "Paste the device ID, or the whole notification link";
+"notify.device_token" = "Device Token";
+"notify.device_token.placeholder" = "Paste the device token";
+"notify.verify" = "Verify Device";
+"notify.verifying" = "Checking…";
+"notify.save_link" = "Save Link";
+"notify.unlink" = "Unlink";
+
+/* Surfaces */
+"notify.surface.live_activity" = "Live Activity";
+"notify.surface.live_activity_desc" = "A tile on the Lock Screen with every window side by side. iPhone and iPad only.";
+"notify.surface.lock_screen" = "Lock Screen Widget";
+"notify.surface.lock_screen_desc" = "One window as a ring or a bar, for a glance without unlocking.";
+"notify.surface.home_screen" = "Home Screen Widget";
+"notify.surface.home_screen_desc" = "The same tile as the Live Activity, but it stays where you put it. Needs a recent Notify!.";
+
+/* Gauge picker */
+"notify.gauge.window" = "Show";
+"notify.gauge.automatic" = "Whichever needs attention most";
+
+/* Publish */
+"notify.publish_now" = "Send Now";
+"notify.publishing" = "Sending…";
+
+/* Privacy */
+"notify.privacy.what_leaves" = "What leaves this Mac: provider names, window labels, percentages left, balances and reset countdowns.";
+"notify.privacy.where_it_goes" = "Where it goes: push.getnotifyapp.com, and from there to your own phone.";
+"notify.privacy.off_by_default" = "Off by default, and it stays off until you link a device.";
+"notify.privacy.token_secret" = "Your device token is kept in the macOS Keychain and is never written to the app's settings.";
+
+/* Status messages */
+"notify.status.link_saved" = "Device link saved.";
+"notify.status.unlinked" = "Device unlinked. Anything already on your phone stays there until you remove it in Notify!.";
+"notify.status.verified" = "Linked to %@.";
+"notify.status.published" = "Sent.";
+"notify.status.switched_off" = "Publishing to Notify! is switched off.";
+"notify.status.all_surfaces_off" = "The Live Activity, the Lock Screen widget and the Home Screen widget are all switched off, so there is nothing to send.";
+"notify.status.no_usage_yet" = "There is no usage to send yet. Give the app a moment to fetch some.";
+"notify.status.holding_off" = "Notify! is still holding off Live Activity starts. The app will retry on its own.";
+"notify.status.home_screen_not_served" = "Notify! is not serving Home Screen widgets yet. The app will try again later.";
+
+/* Device kinds */
+"notify.device_kind.app_device" = "iPhone or iPad";
+"notify.device_kind.mac" = "Mac";
+"notify.device_kind.web" = "browser";
+"notify.device_kind.group" = "group";
+"notify.device_kind.unknown" = "device";
+
+/* What a device cannot carry */
+"notify.unsupported.live_activity_mac" = "This is a Mac ID. A Live Activity is an iPhone and iPad feature, so it cannot be started here. The widgets still work.";
+"notify.unsupported.live_activity_web" = "This is a browser ID. A Live Activity is an iPhone and iPad feature, so it cannot be started here. The widgets still work.";
+"notify.unsupported.live_activity_generic" = "A Live Activity only exists on an iPhone or iPad, so use the device ID and token from the Notify! app on your phone instead.";
+"notify.unsupported.group" = "This is a group ID. A group sends a notification out to its members and owns no Lock Screen of its own, so use the device ID and token for a single device instead.";
+"notify.unsupported.widget_generic" = "A group owns no Lock Screen of its own, so use the device ID and token for a single device instead.";
+"notify.unsupported.screen_widget_generic" = "A group owns no Home Screen of its own, so use the device ID and token for a single device instead.";
+
+/* Windows shown on the phone */
+"notify.window.session" = "5h";
+"notify.window.weekly" = "7d";
+"notify.window.opus" = "Opus 7d";
+"notify.window.sonnet" = "Sonnet 7d";
+"notify.window.design" = "Design 7d";
+"notify.window.fable" = "Fable 7d";
+"notify.window.spend" = "Spend";
+"notify.window.extra_usage" = "Extra usage";
+"notify.window.credits" = "Credits";
+
+/* Sentences written onto the tile and the widget */
+"notify.summary.balance_left" = "%@ left";
+"notify.summary.percent_left" = "%d%% left";
+"notify.summary.resets_soon" = "resets soon";
+"notify.summary.resets_in" = "resets in %@";
+
+/* Waits */
+"notify.wait.a_minute" = "a minute";
+"notify.wait.minutes" = "%d minutes";
+"notify.wait.an_hour" = "an hour";
+"notify.wait.hours" = "%d hours";
+
+/* Errors */
+"notify.error.not_linked" = "Add your Notify! device ID and token before publishing.";
+"notify.error.rejected_credentials" = "Notify! rejected these credentials. Copy the device ID and token again from the Notify! app.";
+"notify.error.live_activity_unavailable" = "This device cannot show a Live Activity yet. Open the Notify! app once on the device.";
+"notify.error.tile_gone" = "The Live Activity was dismissed on the device. A new one will be started.";
+"notify.error.backoff" = "Notify! is waiting %@ before another Live Activity.";
+"notify.error.backoff_open_app" = "Notify! is waiting %@ before another Live Activity. Opening the Notify! app on the device may clear it sooner.";
+"notify.error.invalid_payload" = "Notify! rejected the content of this update.";
+"notify.error.delivery_unconfirmed" = "Notify! could not confirm the Live Activity started. It will be checked again on the next update.";
+"notify.error.transport_failed" = "Could not reach Notify!: %@";
+"notify.error.surface_switched_off" = "Notify! has this widget switched off at the moment. The app will try again later.";
+"notify.error.unexpected_status" = "Notify! answered with HTTP %d.";
+"notify.error.malformed_response" = "Notify! sent a response the app could not read.";
+"notify.error.link_is_group" = "That link points at a Notify! group. This needs a device link, not a group.";
+"notify.error.bad_host" = "The Notify! host is not a usable URL.";
+"notify.error.encode_failed" = "This update could not be encoded.";
+
+/* Notify! — token storage */
+"notify.status.link_save_failed" = "Could not save the device token to the Keychain, so nothing was linked. The Keychain needs the app to be signed, and a copy built locally without a development team is not. Use a signed build — a release download, or set your team under Signing & Capabilities in Xcode.";

--- a/Claude Usage/Resources/tr.lproj/Localizable.strings
+++ b/Claude Usage/Resources/tr.lproj/Localizable.strings
@@ -1085,3 +1085,129 @@
 "support.popup_signature" = "Claude Usage'ın arkasındaki tek kişilik ekip";
 "support.popup_body" = "Ücretsiz, açık kaynak, tek kişi tarafından yapıldı — reklam yok, izleme yok. Sizi bir oturum limitini yakmaktan kurtardıysa, bir kahve onu ayakta tutar.";
 "support.popup_days" = "%d gündür limitlerinizi izliyor — her zaman ücretsiz";
+
+/* NOTE: the Notify! strings below are still in English and need translating. */
+
+/* ==================== */
+/* MARK: - Notify! (publish usage to a phone) */
+/* ==================== */
+"notify.title" = "Notify!";
+"notify.subtitle" = "Put your usage on your phone's Lock Screen and Home Screen";
+
+/* Sections */
+"notify.section.publishing" = "Publishing";
+"notify.section.publishing_desc" = "Send your usage to the Notify! app on your phone";
+"notify.section.device" = "Linked Device";
+"notify.section.device_desc" = "Copy the device ID and token from the Notify! app";
+"notify.section.surfaces" = "What to Show";
+"notify.section.surfaces_desc" = "Each surface can be switched off on its own";
+"notify.section.gauge" = "Lock Screen Widget";
+"notify.section.gauge_desc" = "Which window the widget's ring shows";
+"notify.section.publish" = "Send Now";
+"notify.section.publish_desc" = "Push your current usage without waiting for the next update";
+"notify.section.privacy" = "Privacy";
+
+/* Master switch */
+"notify.enable" = "Publish to Notify!";
+"notify.enable_desc" = "Off until you link a device. Your usage is sent to Notify!, which is not Anthropic or OpenAI.";
+
+/* Device link */
+"notify.device_id" = "Device ID";
+"notify.device_id.placeholder" = "Paste the device ID, or the whole notification link";
+"notify.device_token" = "Device Token";
+"notify.device_token.placeholder" = "Paste the device token";
+"notify.verify" = "Verify Device";
+"notify.verifying" = "Checking…";
+"notify.save_link" = "Save Link";
+"notify.unlink" = "Unlink";
+
+/* Surfaces */
+"notify.surface.live_activity" = "Live Activity";
+"notify.surface.live_activity_desc" = "A tile on the Lock Screen with every window side by side. iPhone and iPad only.";
+"notify.surface.lock_screen" = "Lock Screen Widget";
+"notify.surface.lock_screen_desc" = "One window as a ring or a bar, for a glance without unlocking.";
+"notify.surface.home_screen" = "Home Screen Widget";
+"notify.surface.home_screen_desc" = "The same tile as the Live Activity, but it stays where you put it. Needs a recent Notify!.";
+
+/* Gauge picker */
+"notify.gauge.window" = "Show";
+"notify.gauge.automatic" = "Whichever needs attention most";
+
+/* Publish */
+"notify.publish_now" = "Send Now";
+"notify.publishing" = "Sending…";
+
+/* Privacy */
+"notify.privacy.what_leaves" = "What leaves this Mac: provider names, window labels, percentages left, balances and reset countdowns.";
+"notify.privacy.where_it_goes" = "Where it goes: push.getnotifyapp.com, and from there to your own phone.";
+"notify.privacy.off_by_default" = "Off by default, and it stays off until you link a device.";
+"notify.privacy.token_secret" = "Your device token is kept in the macOS Keychain and is never written to the app's settings.";
+
+/* Status messages */
+"notify.status.link_saved" = "Device link saved.";
+"notify.status.unlinked" = "Device unlinked. Anything already on your phone stays there until you remove it in Notify!.";
+"notify.status.verified" = "Linked to %@.";
+"notify.status.published" = "Sent.";
+"notify.status.switched_off" = "Publishing to Notify! is switched off.";
+"notify.status.all_surfaces_off" = "The Live Activity, the Lock Screen widget and the Home Screen widget are all switched off, so there is nothing to send.";
+"notify.status.no_usage_yet" = "There is no usage to send yet. Give the app a moment to fetch some.";
+"notify.status.holding_off" = "Notify! is still holding off Live Activity starts. The app will retry on its own.";
+"notify.status.home_screen_not_served" = "Notify! is not serving Home Screen widgets yet. The app will try again later.";
+
+/* Device kinds */
+"notify.device_kind.app_device" = "iPhone or iPad";
+"notify.device_kind.mac" = "Mac";
+"notify.device_kind.web" = "browser";
+"notify.device_kind.group" = "group";
+"notify.device_kind.unknown" = "device";
+
+/* What a device cannot carry */
+"notify.unsupported.live_activity_mac" = "This is a Mac ID. A Live Activity is an iPhone and iPad feature, so it cannot be started here. The widgets still work.";
+"notify.unsupported.live_activity_web" = "This is a browser ID. A Live Activity is an iPhone and iPad feature, so it cannot be started here. The widgets still work.";
+"notify.unsupported.live_activity_generic" = "A Live Activity only exists on an iPhone or iPad, so use the device ID and token from the Notify! app on your phone instead.";
+"notify.unsupported.group" = "This is a group ID. A group sends a notification out to its members and owns no Lock Screen of its own, so use the device ID and token for a single device instead.";
+"notify.unsupported.widget_generic" = "A group owns no Lock Screen of its own, so use the device ID and token for a single device instead.";
+"notify.unsupported.screen_widget_generic" = "A group owns no Home Screen of its own, so use the device ID and token for a single device instead.";
+
+/* Windows shown on the phone */
+"notify.window.session" = "5h";
+"notify.window.weekly" = "7d";
+"notify.window.opus" = "Opus 7d";
+"notify.window.sonnet" = "Sonnet 7d";
+"notify.window.design" = "Design 7d";
+"notify.window.fable" = "Fable 7d";
+"notify.window.spend" = "Spend";
+"notify.window.extra_usage" = "Extra usage";
+"notify.window.credits" = "Credits";
+
+/* Sentences written onto the tile and the widget */
+"notify.summary.balance_left" = "%@ left";
+"notify.summary.percent_left" = "%d%% left";
+"notify.summary.resets_soon" = "resets soon";
+"notify.summary.resets_in" = "resets in %@";
+
+/* Waits */
+"notify.wait.a_minute" = "a minute";
+"notify.wait.minutes" = "%d minutes";
+"notify.wait.an_hour" = "an hour";
+"notify.wait.hours" = "%d hours";
+
+/* Errors */
+"notify.error.not_linked" = "Add your Notify! device ID and token before publishing.";
+"notify.error.rejected_credentials" = "Notify! rejected these credentials. Copy the device ID and token again from the Notify! app.";
+"notify.error.live_activity_unavailable" = "This device cannot show a Live Activity yet. Open the Notify! app once on the device.";
+"notify.error.tile_gone" = "The Live Activity was dismissed on the device. A new one will be started.";
+"notify.error.backoff" = "Notify! is waiting %@ before another Live Activity.";
+"notify.error.backoff_open_app" = "Notify! is waiting %@ before another Live Activity. Opening the Notify! app on the device may clear it sooner.";
+"notify.error.invalid_payload" = "Notify! rejected the content of this update.";
+"notify.error.delivery_unconfirmed" = "Notify! could not confirm the Live Activity started. It will be checked again on the next update.";
+"notify.error.transport_failed" = "Could not reach Notify!: %@";
+"notify.error.surface_switched_off" = "Notify! has this widget switched off at the moment. The app will try again later.";
+"notify.error.unexpected_status" = "Notify! answered with HTTP %d.";
+"notify.error.malformed_response" = "Notify! sent a response the app could not read.";
+"notify.error.link_is_group" = "That link points at a Notify! group. This needs a device link, not a group.";
+"notify.error.bad_host" = "The Notify! host is not a usable URL.";
+"notify.error.encode_failed" = "This update could not be encoded.";
+
+/* Notify! — token storage */
+"notify.status.link_save_failed" = "Could not save the device token to the Keychain, so nothing was linked. The Keychain needs the app to be signed, and a copy built locally without a development team is not. Use a signed build — a release download, or set your team under Signing & Capabilities in Xcode.";

--- a/Claude Usage/Resources/uk.lproj/Localizable.strings
+++ b/Claude Usage/Resources/uk.lproj/Localizable.strings
@@ -1088,3 +1088,129 @@
 "support.popup_signature" = "команда з однієї людини за Claude Usage";
 "support.popup_body" = "Безплатний, з відкритим кодом, зроблений однією людиною — без реклами й стеження. Якщо він урятував вас від спаленого ліміту сесії, кава тримає його живим.";
 "support.popup_days" = "Пильнує ваші ліміти вже %d днів — завжди безплатно";
+
+/* NOTE: the Notify! strings below are still in English and need translating. */
+
+/* ==================== */
+/* MARK: - Notify! (publish usage to a phone) */
+/* ==================== */
+"notify.title" = "Notify!";
+"notify.subtitle" = "Put your usage on your phone's Lock Screen and Home Screen";
+
+/* Sections */
+"notify.section.publishing" = "Publishing";
+"notify.section.publishing_desc" = "Send your usage to the Notify! app on your phone";
+"notify.section.device" = "Linked Device";
+"notify.section.device_desc" = "Copy the device ID and token from the Notify! app";
+"notify.section.surfaces" = "What to Show";
+"notify.section.surfaces_desc" = "Each surface can be switched off on its own";
+"notify.section.gauge" = "Lock Screen Widget";
+"notify.section.gauge_desc" = "Which window the widget's ring shows";
+"notify.section.publish" = "Send Now";
+"notify.section.publish_desc" = "Push your current usage without waiting for the next update";
+"notify.section.privacy" = "Privacy";
+
+/* Master switch */
+"notify.enable" = "Publish to Notify!";
+"notify.enable_desc" = "Off until you link a device. Your usage is sent to Notify!, which is not Anthropic or OpenAI.";
+
+/* Device link */
+"notify.device_id" = "Device ID";
+"notify.device_id.placeholder" = "Paste the device ID, or the whole notification link";
+"notify.device_token" = "Device Token";
+"notify.device_token.placeholder" = "Paste the device token";
+"notify.verify" = "Verify Device";
+"notify.verifying" = "Checking…";
+"notify.save_link" = "Save Link";
+"notify.unlink" = "Unlink";
+
+/* Surfaces */
+"notify.surface.live_activity" = "Live Activity";
+"notify.surface.live_activity_desc" = "A tile on the Lock Screen with every window side by side. iPhone and iPad only.";
+"notify.surface.lock_screen" = "Lock Screen Widget";
+"notify.surface.lock_screen_desc" = "One window as a ring or a bar, for a glance without unlocking.";
+"notify.surface.home_screen" = "Home Screen Widget";
+"notify.surface.home_screen_desc" = "The same tile as the Live Activity, but it stays where you put it. Needs a recent Notify!.";
+
+/* Gauge picker */
+"notify.gauge.window" = "Show";
+"notify.gauge.automatic" = "Whichever needs attention most";
+
+/* Publish */
+"notify.publish_now" = "Send Now";
+"notify.publishing" = "Sending…";
+
+/* Privacy */
+"notify.privacy.what_leaves" = "What leaves this Mac: provider names, window labels, percentages left, balances and reset countdowns.";
+"notify.privacy.where_it_goes" = "Where it goes: push.getnotifyapp.com, and from there to your own phone.";
+"notify.privacy.off_by_default" = "Off by default, and it stays off until you link a device.";
+"notify.privacy.token_secret" = "Your device token is kept in the macOS Keychain and is never written to the app's settings.";
+
+/* Status messages */
+"notify.status.link_saved" = "Device link saved.";
+"notify.status.unlinked" = "Device unlinked. Anything already on your phone stays there until you remove it in Notify!.";
+"notify.status.verified" = "Linked to %@.";
+"notify.status.published" = "Sent.";
+"notify.status.switched_off" = "Publishing to Notify! is switched off.";
+"notify.status.all_surfaces_off" = "The Live Activity, the Lock Screen widget and the Home Screen widget are all switched off, so there is nothing to send.";
+"notify.status.no_usage_yet" = "There is no usage to send yet. Give the app a moment to fetch some.";
+"notify.status.holding_off" = "Notify! is still holding off Live Activity starts. The app will retry on its own.";
+"notify.status.home_screen_not_served" = "Notify! is not serving Home Screen widgets yet. The app will try again later.";
+
+/* Device kinds */
+"notify.device_kind.app_device" = "iPhone or iPad";
+"notify.device_kind.mac" = "Mac";
+"notify.device_kind.web" = "browser";
+"notify.device_kind.group" = "group";
+"notify.device_kind.unknown" = "device";
+
+/* What a device cannot carry */
+"notify.unsupported.live_activity_mac" = "This is a Mac ID. A Live Activity is an iPhone and iPad feature, so it cannot be started here. The widgets still work.";
+"notify.unsupported.live_activity_web" = "This is a browser ID. A Live Activity is an iPhone and iPad feature, so it cannot be started here. The widgets still work.";
+"notify.unsupported.live_activity_generic" = "A Live Activity only exists on an iPhone or iPad, so use the device ID and token from the Notify! app on your phone instead.";
+"notify.unsupported.group" = "This is a group ID. A group sends a notification out to its members and owns no Lock Screen of its own, so use the device ID and token for a single device instead.";
+"notify.unsupported.widget_generic" = "A group owns no Lock Screen of its own, so use the device ID and token for a single device instead.";
+"notify.unsupported.screen_widget_generic" = "A group owns no Home Screen of its own, so use the device ID and token for a single device instead.";
+
+/* Windows shown on the phone */
+"notify.window.session" = "5h";
+"notify.window.weekly" = "7d";
+"notify.window.opus" = "Opus 7d";
+"notify.window.sonnet" = "Sonnet 7d";
+"notify.window.design" = "Design 7d";
+"notify.window.fable" = "Fable 7d";
+"notify.window.spend" = "Spend";
+"notify.window.extra_usage" = "Extra usage";
+"notify.window.credits" = "Credits";
+
+/* Sentences written onto the tile and the widget */
+"notify.summary.balance_left" = "%@ left";
+"notify.summary.percent_left" = "%d%% left";
+"notify.summary.resets_soon" = "resets soon";
+"notify.summary.resets_in" = "resets in %@";
+
+/* Waits */
+"notify.wait.a_minute" = "a minute";
+"notify.wait.minutes" = "%d minutes";
+"notify.wait.an_hour" = "an hour";
+"notify.wait.hours" = "%d hours";
+
+/* Errors */
+"notify.error.not_linked" = "Add your Notify! device ID and token before publishing.";
+"notify.error.rejected_credentials" = "Notify! rejected these credentials. Copy the device ID and token again from the Notify! app.";
+"notify.error.live_activity_unavailable" = "This device cannot show a Live Activity yet. Open the Notify! app once on the device.";
+"notify.error.tile_gone" = "The Live Activity was dismissed on the device. A new one will be started.";
+"notify.error.backoff" = "Notify! is waiting %@ before another Live Activity.";
+"notify.error.backoff_open_app" = "Notify! is waiting %@ before another Live Activity. Opening the Notify! app on the device may clear it sooner.";
+"notify.error.invalid_payload" = "Notify! rejected the content of this update.";
+"notify.error.delivery_unconfirmed" = "Notify! could not confirm the Live Activity started. It will be checked again on the next update.";
+"notify.error.transport_failed" = "Could not reach Notify!: %@";
+"notify.error.surface_switched_off" = "Notify! has this widget switched off at the moment. The app will try again later.";
+"notify.error.unexpected_status" = "Notify! answered with HTTP %d.";
+"notify.error.malformed_response" = "Notify! sent a response the app could not read.";
+"notify.error.link_is_group" = "That link points at a Notify! group. This needs a device link, not a group.";
+"notify.error.bad_host" = "The Notify! host is not a usable URL.";
+"notify.error.encode_failed" = "This update could not be encoded.";
+
+/* Notify! — token storage */
+"notify.status.link_save_failed" = "Could not save the device token to the Keychain, so nothing was linked. The Keychain needs the app to be signed, and a copy built locally without a development team is not. Use a signed build — a release download, or set your team under Signing & Capabilities in Xcode.";

--- a/Claude Usage/Resources/vi.lproj/Localizable.strings
+++ b/Claude Usage/Resources/vi.lproj/Localizable.strings
@@ -1091,3 +1091,129 @@
 "support.popup_body" = "Miễn phí, mã nguồn mở, do một người xây dựng — không quảng cáo, không theo dõi. Nếu nó từng giúp bạn khỏi lãng phí giới hạn phiên, một ly cà phê sẽ giúp nó tiếp tục.";
 "support.popup_days" = "Đồng hành cùng giới hạn của bạn %d ngày — luôn miễn phí";
 "support.popup_later" = "Để sau";
+
+/* NOTE: the Notify! strings below are still in English and need translating. */
+
+/* ==================== */
+/* MARK: - Notify! (publish usage to a phone) */
+/* ==================== */
+"notify.title" = "Notify!";
+"notify.subtitle" = "Put your usage on your phone's Lock Screen and Home Screen";
+
+/* Sections */
+"notify.section.publishing" = "Publishing";
+"notify.section.publishing_desc" = "Send your usage to the Notify! app on your phone";
+"notify.section.device" = "Linked Device";
+"notify.section.device_desc" = "Copy the device ID and token from the Notify! app";
+"notify.section.surfaces" = "What to Show";
+"notify.section.surfaces_desc" = "Each surface can be switched off on its own";
+"notify.section.gauge" = "Lock Screen Widget";
+"notify.section.gauge_desc" = "Which window the widget's ring shows";
+"notify.section.publish" = "Send Now";
+"notify.section.publish_desc" = "Push your current usage without waiting for the next update";
+"notify.section.privacy" = "Privacy";
+
+/* Master switch */
+"notify.enable" = "Publish to Notify!";
+"notify.enable_desc" = "Off until you link a device. Your usage is sent to Notify!, which is not Anthropic or OpenAI.";
+
+/* Device link */
+"notify.device_id" = "Device ID";
+"notify.device_id.placeholder" = "Paste the device ID, or the whole notification link";
+"notify.device_token" = "Device Token";
+"notify.device_token.placeholder" = "Paste the device token";
+"notify.verify" = "Verify Device";
+"notify.verifying" = "Checking…";
+"notify.save_link" = "Save Link";
+"notify.unlink" = "Unlink";
+
+/* Surfaces */
+"notify.surface.live_activity" = "Live Activity";
+"notify.surface.live_activity_desc" = "A tile on the Lock Screen with every window side by side. iPhone and iPad only.";
+"notify.surface.lock_screen" = "Lock Screen Widget";
+"notify.surface.lock_screen_desc" = "One window as a ring or a bar, for a glance without unlocking.";
+"notify.surface.home_screen" = "Home Screen Widget";
+"notify.surface.home_screen_desc" = "The same tile as the Live Activity, but it stays where you put it. Needs a recent Notify!.";
+
+/* Gauge picker */
+"notify.gauge.window" = "Show";
+"notify.gauge.automatic" = "Whichever needs attention most";
+
+/* Publish */
+"notify.publish_now" = "Send Now";
+"notify.publishing" = "Sending…";
+
+/* Privacy */
+"notify.privacy.what_leaves" = "What leaves this Mac: provider names, window labels, percentages left, balances and reset countdowns.";
+"notify.privacy.where_it_goes" = "Where it goes: push.getnotifyapp.com, and from there to your own phone.";
+"notify.privacy.off_by_default" = "Off by default, and it stays off until you link a device.";
+"notify.privacy.token_secret" = "Your device token is kept in the macOS Keychain and is never written to the app's settings.";
+
+/* Status messages */
+"notify.status.link_saved" = "Device link saved.";
+"notify.status.unlinked" = "Device unlinked. Anything already on your phone stays there until you remove it in Notify!.";
+"notify.status.verified" = "Linked to %@.";
+"notify.status.published" = "Sent.";
+"notify.status.switched_off" = "Publishing to Notify! is switched off.";
+"notify.status.all_surfaces_off" = "The Live Activity, the Lock Screen widget and the Home Screen widget are all switched off, so there is nothing to send.";
+"notify.status.no_usage_yet" = "There is no usage to send yet. Give the app a moment to fetch some.";
+"notify.status.holding_off" = "Notify! is still holding off Live Activity starts. The app will retry on its own.";
+"notify.status.home_screen_not_served" = "Notify! is not serving Home Screen widgets yet. The app will try again later.";
+
+/* Device kinds */
+"notify.device_kind.app_device" = "iPhone or iPad";
+"notify.device_kind.mac" = "Mac";
+"notify.device_kind.web" = "browser";
+"notify.device_kind.group" = "group";
+"notify.device_kind.unknown" = "device";
+
+/* What a device cannot carry */
+"notify.unsupported.live_activity_mac" = "This is a Mac ID. A Live Activity is an iPhone and iPad feature, so it cannot be started here. The widgets still work.";
+"notify.unsupported.live_activity_web" = "This is a browser ID. A Live Activity is an iPhone and iPad feature, so it cannot be started here. The widgets still work.";
+"notify.unsupported.live_activity_generic" = "A Live Activity only exists on an iPhone or iPad, so use the device ID and token from the Notify! app on your phone instead.";
+"notify.unsupported.group" = "This is a group ID. A group sends a notification out to its members and owns no Lock Screen of its own, so use the device ID and token for a single device instead.";
+"notify.unsupported.widget_generic" = "A group owns no Lock Screen of its own, so use the device ID and token for a single device instead.";
+"notify.unsupported.screen_widget_generic" = "A group owns no Home Screen of its own, so use the device ID and token for a single device instead.";
+
+/* Windows shown on the phone */
+"notify.window.session" = "5h";
+"notify.window.weekly" = "7d";
+"notify.window.opus" = "Opus 7d";
+"notify.window.sonnet" = "Sonnet 7d";
+"notify.window.design" = "Design 7d";
+"notify.window.fable" = "Fable 7d";
+"notify.window.spend" = "Spend";
+"notify.window.extra_usage" = "Extra usage";
+"notify.window.credits" = "Credits";
+
+/* Sentences written onto the tile and the widget */
+"notify.summary.balance_left" = "%@ left";
+"notify.summary.percent_left" = "%d%% left";
+"notify.summary.resets_soon" = "resets soon";
+"notify.summary.resets_in" = "resets in %@";
+
+/* Waits */
+"notify.wait.a_minute" = "a minute";
+"notify.wait.minutes" = "%d minutes";
+"notify.wait.an_hour" = "an hour";
+"notify.wait.hours" = "%d hours";
+
+/* Errors */
+"notify.error.not_linked" = "Add your Notify! device ID and token before publishing.";
+"notify.error.rejected_credentials" = "Notify! rejected these credentials. Copy the device ID and token again from the Notify! app.";
+"notify.error.live_activity_unavailable" = "This device cannot show a Live Activity yet. Open the Notify! app once on the device.";
+"notify.error.tile_gone" = "The Live Activity was dismissed on the device. A new one will be started.";
+"notify.error.backoff" = "Notify! is waiting %@ before another Live Activity.";
+"notify.error.backoff_open_app" = "Notify! is waiting %@ before another Live Activity. Opening the Notify! app on the device may clear it sooner.";
+"notify.error.invalid_payload" = "Notify! rejected the content of this update.";
+"notify.error.delivery_unconfirmed" = "Notify! could not confirm the Live Activity started. It will be checked again on the next update.";
+"notify.error.transport_failed" = "Could not reach Notify!: %@";
+"notify.error.surface_switched_off" = "Notify! has this widget switched off at the moment. The app will try again later.";
+"notify.error.unexpected_status" = "Notify! answered with HTTP %d.";
+"notify.error.malformed_response" = "Notify! sent a response the app could not read.";
+"notify.error.link_is_group" = "That link points at a Notify! group. This needs a device link, not a group.";
+"notify.error.bad_host" = "The Notify! host is not a usable URL.";
+"notify.error.encode_failed" = "This update could not be encoded.";
+
+/* Notify! — token storage */
+"notify.status.link_save_failed" = "Could not save the device token to the Keychain, so nothing was linked. The Keychain needs the app to be signed, and a copy built locally without a development team is not. Use a signed build — a release download, or set your team under Signing & Capabilities in Xcode.";

--- a/Claude Usage/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Claude Usage/Resources/zh-Hant.lproj/Localizable.strings
@@ -1079,3 +1079,129 @@
 "support.popup_signature" = "Claude Usage 背後的一人團隊";
 "support.popup_body" = "免費、開源、一人開發——沒有廣告，沒有追蹤。如果它曾幫你避免燒掉工作階段額度，一杯咖啡就能讓它繼續前進。";
 "support.popup_days" = "已守護你的額度 %d 天 — 永遠免費";
+
+/* NOTE: the Notify! strings below are still in English and need translating. */
+
+/* ==================== */
+/* MARK: - Notify! (publish usage to a phone) */
+/* ==================== */
+"notify.title" = "Notify!";
+"notify.subtitle" = "Put your usage on your phone's Lock Screen and Home Screen";
+
+/* Sections */
+"notify.section.publishing" = "Publishing";
+"notify.section.publishing_desc" = "Send your usage to the Notify! app on your phone";
+"notify.section.device" = "Linked Device";
+"notify.section.device_desc" = "Copy the device ID and token from the Notify! app";
+"notify.section.surfaces" = "What to Show";
+"notify.section.surfaces_desc" = "Each surface can be switched off on its own";
+"notify.section.gauge" = "Lock Screen Widget";
+"notify.section.gauge_desc" = "Which window the widget's ring shows";
+"notify.section.publish" = "Send Now";
+"notify.section.publish_desc" = "Push your current usage without waiting for the next update";
+"notify.section.privacy" = "Privacy";
+
+/* Master switch */
+"notify.enable" = "Publish to Notify!";
+"notify.enable_desc" = "Off until you link a device. Your usage is sent to Notify!, which is not Anthropic or OpenAI.";
+
+/* Device link */
+"notify.device_id" = "Device ID";
+"notify.device_id.placeholder" = "Paste the device ID, or the whole notification link";
+"notify.device_token" = "Device Token";
+"notify.device_token.placeholder" = "Paste the device token";
+"notify.verify" = "Verify Device";
+"notify.verifying" = "Checking…";
+"notify.save_link" = "Save Link";
+"notify.unlink" = "Unlink";
+
+/* Surfaces */
+"notify.surface.live_activity" = "Live Activity";
+"notify.surface.live_activity_desc" = "A tile on the Lock Screen with every window side by side. iPhone and iPad only.";
+"notify.surface.lock_screen" = "Lock Screen Widget";
+"notify.surface.lock_screen_desc" = "One window as a ring or a bar, for a glance without unlocking.";
+"notify.surface.home_screen" = "Home Screen Widget";
+"notify.surface.home_screen_desc" = "The same tile as the Live Activity, but it stays where you put it. Needs a recent Notify!.";
+
+/* Gauge picker */
+"notify.gauge.window" = "Show";
+"notify.gauge.automatic" = "Whichever needs attention most";
+
+/* Publish */
+"notify.publish_now" = "Send Now";
+"notify.publishing" = "Sending…";
+
+/* Privacy */
+"notify.privacy.what_leaves" = "What leaves this Mac: provider names, window labels, percentages left, balances and reset countdowns.";
+"notify.privacy.where_it_goes" = "Where it goes: push.getnotifyapp.com, and from there to your own phone.";
+"notify.privacy.off_by_default" = "Off by default, and it stays off until you link a device.";
+"notify.privacy.token_secret" = "Your device token is kept in the macOS Keychain and is never written to the app's settings.";
+
+/* Status messages */
+"notify.status.link_saved" = "Device link saved.";
+"notify.status.unlinked" = "Device unlinked. Anything already on your phone stays there until you remove it in Notify!.";
+"notify.status.verified" = "Linked to %@.";
+"notify.status.published" = "Sent.";
+"notify.status.switched_off" = "Publishing to Notify! is switched off.";
+"notify.status.all_surfaces_off" = "The Live Activity, the Lock Screen widget and the Home Screen widget are all switched off, so there is nothing to send.";
+"notify.status.no_usage_yet" = "There is no usage to send yet. Give the app a moment to fetch some.";
+"notify.status.holding_off" = "Notify! is still holding off Live Activity starts. The app will retry on its own.";
+"notify.status.home_screen_not_served" = "Notify! is not serving Home Screen widgets yet. The app will try again later.";
+
+/* Device kinds */
+"notify.device_kind.app_device" = "iPhone or iPad";
+"notify.device_kind.mac" = "Mac";
+"notify.device_kind.web" = "browser";
+"notify.device_kind.group" = "group";
+"notify.device_kind.unknown" = "device";
+
+/* What a device cannot carry */
+"notify.unsupported.live_activity_mac" = "This is a Mac ID. A Live Activity is an iPhone and iPad feature, so it cannot be started here. The widgets still work.";
+"notify.unsupported.live_activity_web" = "This is a browser ID. A Live Activity is an iPhone and iPad feature, so it cannot be started here. The widgets still work.";
+"notify.unsupported.live_activity_generic" = "A Live Activity only exists on an iPhone or iPad, so use the device ID and token from the Notify! app on your phone instead.";
+"notify.unsupported.group" = "This is a group ID. A group sends a notification out to its members and owns no Lock Screen of its own, so use the device ID and token for a single device instead.";
+"notify.unsupported.widget_generic" = "A group owns no Lock Screen of its own, so use the device ID and token for a single device instead.";
+"notify.unsupported.screen_widget_generic" = "A group owns no Home Screen of its own, so use the device ID and token for a single device instead.";
+
+/* Windows shown on the phone */
+"notify.window.session" = "5h";
+"notify.window.weekly" = "7d";
+"notify.window.opus" = "Opus 7d";
+"notify.window.sonnet" = "Sonnet 7d";
+"notify.window.design" = "Design 7d";
+"notify.window.fable" = "Fable 7d";
+"notify.window.spend" = "Spend";
+"notify.window.extra_usage" = "Extra usage";
+"notify.window.credits" = "Credits";
+
+/* Sentences written onto the tile and the widget */
+"notify.summary.balance_left" = "%@ left";
+"notify.summary.percent_left" = "%d%% left";
+"notify.summary.resets_soon" = "resets soon";
+"notify.summary.resets_in" = "resets in %@";
+
+/* Waits */
+"notify.wait.a_minute" = "a minute";
+"notify.wait.minutes" = "%d minutes";
+"notify.wait.an_hour" = "an hour";
+"notify.wait.hours" = "%d hours";
+
+/* Errors */
+"notify.error.not_linked" = "Add your Notify! device ID and token before publishing.";
+"notify.error.rejected_credentials" = "Notify! rejected these credentials. Copy the device ID and token again from the Notify! app.";
+"notify.error.live_activity_unavailable" = "This device cannot show a Live Activity yet. Open the Notify! app once on the device.";
+"notify.error.tile_gone" = "The Live Activity was dismissed on the device. A new one will be started.";
+"notify.error.backoff" = "Notify! is waiting %@ before another Live Activity.";
+"notify.error.backoff_open_app" = "Notify! is waiting %@ before another Live Activity. Opening the Notify! app on the device may clear it sooner.";
+"notify.error.invalid_payload" = "Notify! rejected the content of this update.";
+"notify.error.delivery_unconfirmed" = "Notify! could not confirm the Live Activity started. It will be checked again on the next update.";
+"notify.error.transport_failed" = "Could not reach Notify!: %@";
+"notify.error.surface_switched_off" = "Notify! has this widget switched off at the moment. The app will try again later.";
+"notify.error.unexpected_status" = "Notify! answered with HTTP %d.";
+"notify.error.malformed_response" = "Notify! sent a response the app could not read.";
+"notify.error.link_is_group" = "That link points at a Notify! group. This needs a device link, not a group.";
+"notify.error.bad_host" = "The Notify! host is not a usable URL.";
+"notify.error.encode_failed" = "This update could not be encoded.";
+
+/* Notify! — token storage */
+"notify.status.link_save_failed" = "Could not save the device token to the Keychain, so nothing was linked. The Keychain needs the app to be signed, and a copy built locally without a development team is not. Use a signed build — a release download, or set your team under Signing & Capabilities in Xcode.";

--- a/Claude Usage/Resources/zh-ch.lproj/Localizable.strings
+++ b/Claude Usage/Resources/zh-ch.lproj/Localizable.strings
@@ -1079,3 +1079,129 @@
 "support.popup_signature" = "Claude Usage 背后的一人团队";
 "support.popup_body" = "免费、开源、一人开发——没有广告，没有跟踪。如果它曾帮你避免烧掉会话额度，一杯咖啡就能让它继续前进。";
 "support.popup_days" = "已守护你的额度 %d 天 — 永久免费";
+
+/* NOTE: the Notify! strings below are still in English and need translating. */
+
+/* ==================== */
+/* MARK: - Notify! (publish usage to a phone) */
+/* ==================== */
+"notify.title" = "Notify!";
+"notify.subtitle" = "Put your usage on your phone's Lock Screen and Home Screen";
+
+/* Sections */
+"notify.section.publishing" = "Publishing";
+"notify.section.publishing_desc" = "Send your usage to the Notify! app on your phone";
+"notify.section.device" = "Linked Device";
+"notify.section.device_desc" = "Copy the device ID and token from the Notify! app";
+"notify.section.surfaces" = "What to Show";
+"notify.section.surfaces_desc" = "Each surface can be switched off on its own";
+"notify.section.gauge" = "Lock Screen Widget";
+"notify.section.gauge_desc" = "Which window the widget's ring shows";
+"notify.section.publish" = "Send Now";
+"notify.section.publish_desc" = "Push your current usage without waiting for the next update";
+"notify.section.privacy" = "Privacy";
+
+/* Master switch */
+"notify.enable" = "Publish to Notify!";
+"notify.enable_desc" = "Off until you link a device. Your usage is sent to Notify!, which is not Anthropic or OpenAI.";
+
+/* Device link */
+"notify.device_id" = "Device ID";
+"notify.device_id.placeholder" = "Paste the device ID, or the whole notification link";
+"notify.device_token" = "Device Token";
+"notify.device_token.placeholder" = "Paste the device token";
+"notify.verify" = "Verify Device";
+"notify.verifying" = "Checking…";
+"notify.save_link" = "Save Link";
+"notify.unlink" = "Unlink";
+
+/* Surfaces */
+"notify.surface.live_activity" = "Live Activity";
+"notify.surface.live_activity_desc" = "A tile on the Lock Screen with every window side by side. iPhone and iPad only.";
+"notify.surface.lock_screen" = "Lock Screen Widget";
+"notify.surface.lock_screen_desc" = "One window as a ring or a bar, for a glance without unlocking.";
+"notify.surface.home_screen" = "Home Screen Widget";
+"notify.surface.home_screen_desc" = "The same tile as the Live Activity, but it stays where you put it. Needs a recent Notify!.";
+
+/* Gauge picker */
+"notify.gauge.window" = "Show";
+"notify.gauge.automatic" = "Whichever needs attention most";
+
+/* Publish */
+"notify.publish_now" = "Send Now";
+"notify.publishing" = "Sending…";
+
+/* Privacy */
+"notify.privacy.what_leaves" = "What leaves this Mac: provider names, window labels, percentages left, balances and reset countdowns.";
+"notify.privacy.where_it_goes" = "Where it goes: push.getnotifyapp.com, and from there to your own phone.";
+"notify.privacy.off_by_default" = "Off by default, and it stays off until you link a device.";
+"notify.privacy.token_secret" = "Your device token is kept in the macOS Keychain and is never written to the app's settings.";
+
+/* Status messages */
+"notify.status.link_saved" = "Device link saved.";
+"notify.status.unlinked" = "Device unlinked. Anything already on your phone stays there until you remove it in Notify!.";
+"notify.status.verified" = "Linked to %@.";
+"notify.status.published" = "Sent.";
+"notify.status.switched_off" = "Publishing to Notify! is switched off.";
+"notify.status.all_surfaces_off" = "The Live Activity, the Lock Screen widget and the Home Screen widget are all switched off, so there is nothing to send.";
+"notify.status.no_usage_yet" = "There is no usage to send yet. Give the app a moment to fetch some.";
+"notify.status.holding_off" = "Notify! is still holding off Live Activity starts. The app will retry on its own.";
+"notify.status.home_screen_not_served" = "Notify! is not serving Home Screen widgets yet. The app will try again later.";
+
+/* Device kinds */
+"notify.device_kind.app_device" = "iPhone or iPad";
+"notify.device_kind.mac" = "Mac";
+"notify.device_kind.web" = "browser";
+"notify.device_kind.group" = "group";
+"notify.device_kind.unknown" = "device";
+
+/* What a device cannot carry */
+"notify.unsupported.live_activity_mac" = "This is a Mac ID. A Live Activity is an iPhone and iPad feature, so it cannot be started here. The widgets still work.";
+"notify.unsupported.live_activity_web" = "This is a browser ID. A Live Activity is an iPhone and iPad feature, so it cannot be started here. The widgets still work.";
+"notify.unsupported.live_activity_generic" = "A Live Activity only exists on an iPhone or iPad, so use the device ID and token from the Notify! app on your phone instead.";
+"notify.unsupported.group" = "This is a group ID. A group sends a notification out to its members and owns no Lock Screen of its own, so use the device ID and token for a single device instead.";
+"notify.unsupported.widget_generic" = "A group owns no Lock Screen of its own, so use the device ID and token for a single device instead.";
+"notify.unsupported.screen_widget_generic" = "A group owns no Home Screen of its own, so use the device ID and token for a single device instead.";
+
+/* Windows shown on the phone */
+"notify.window.session" = "5h";
+"notify.window.weekly" = "7d";
+"notify.window.opus" = "Opus 7d";
+"notify.window.sonnet" = "Sonnet 7d";
+"notify.window.design" = "Design 7d";
+"notify.window.fable" = "Fable 7d";
+"notify.window.spend" = "Spend";
+"notify.window.extra_usage" = "Extra usage";
+"notify.window.credits" = "Credits";
+
+/* Sentences written onto the tile and the widget */
+"notify.summary.balance_left" = "%@ left";
+"notify.summary.percent_left" = "%d%% left";
+"notify.summary.resets_soon" = "resets soon";
+"notify.summary.resets_in" = "resets in %@";
+
+/* Waits */
+"notify.wait.a_minute" = "a minute";
+"notify.wait.minutes" = "%d minutes";
+"notify.wait.an_hour" = "an hour";
+"notify.wait.hours" = "%d hours";
+
+/* Errors */
+"notify.error.not_linked" = "Add your Notify! device ID and token before publishing.";
+"notify.error.rejected_credentials" = "Notify! rejected these credentials. Copy the device ID and token again from the Notify! app.";
+"notify.error.live_activity_unavailable" = "This device cannot show a Live Activity yet. Open the Notify! app once on the device.";
+"notify.error.tile_gone" = "The Live Activity was dismissed on the device. A new one will be started.";
+"notify.error.backoff" = "Notify! is waiting %@ before another Live Activity.";
+"notify.error.backoff_open_app" = "Notify! is waiting %@ before another Live Activity. Opening the Notify! app on the device may clear it sooner.";
+"notify.error.invalid_payload" = "Notify! rejected the content of this update.";
+"notify.error.delivery_unconfirmed" = "Notify! could not confirm the Live Activity started. It will be checked again on the next update.";
+"notify.error.transport_failed" = "Could not reach Notify!: %@";
+"notify.error.surface_switched_off" = "Notify! has this widget switched off at the moment. The app will try again later.";
+"notify.error.unexpected_status" = "Notify! answered with HTTP %d.";
+"notify.error.malformed_response" = "Notify! sent a response the app could not read.";
+"notify.error.link_is_group" = "That link points at a Notify! group. This needs a device link, not a group.";
+"notify.error.bad_host" = "The Notify! host is not a usable URL.";
+"notify.error.encode_failed" = "This update could not be encoded.";
+
+/* Notify! — token storage */
+"notify.status.link_save_failed" = "Could not save the device token to the Keychain, so nothing was linked. The Keychain needs the app to be signed, and a copy built locally without a development team is not. Use a signed build — a release download, or set your team under Signing & Capabilities in Xcode.";

--- a/Claude Usage/Shared/Extensions/Notification+Extensions.swift
+++ b/Claude Usage/Shared/Extensions/Notification+Extensions.swift
@@ -29,4 +29,9 @@ extension Notification.Name {
 
     /// Posted when a Claude Code notch HUD setting is toggled (enabled/auto-hide)
     static let notchHUDSettingChanged = Notification.Name("notchHUDSettingChanged")
+
+    /// Posted when a Notify! setting is saved: the device link, a surface
+    /// switch, or the gauge selection. The publish driver holds those outside
+    /// published state, so this is the only way it hears about a change.
+    static let notifySettingsChanged = Notification.Name("notifySettingsChanged")
 }

--- a/Claude Usage/Shared/Notify/NotifyDeviceLink.swift
+++ b/Claude Usage/Shared/Notify/NotifyDeviceLink.swift
@@ -1,0 +1,344 @@
+//
+//  NotifyDeviceLink.swift
+//  Claude Usage
+//
+//  The credentials that address one Notify! device, and what that device can show.
+//
+
+import Foundation
+
+/// The credentials that let the app write to one Notify! device: the device
+/// id and its per device token.
+///
+/// The settings pane asks for the two values separately, which is how the
+/// Notify! app presents them. The app also offers a ready made notification URL
+/// with both inside it, so `init?(pastedText:)` exists to take whatever the user
+/// actually has on the clipboard: that full URL, or a bare `id token` pair.
+struct NotifyDeviceLink: Sendable, Equatable, Hashable {
+    /// Device id as the gateway spells it. iPhones and iPads use `IO` plus 14 or
+    /// the legacy bare 8 characters, browsers `WB` plus 14, Macs `MC` plus 14,
+    /// and groups `GRP` plus 5.
+    let deviceId: String
+
+    /// The per device secret. Never logged, and never written to UserDefaults:
+    /// it lives in the Keychain.
+    let token: String
+
+    /// Which namespace the id belongs to, and therefore which surfaces this
+    /// link can carry. A group, a Mac and a browser can all receive a Notify!
+    /// notification, but none of them can show a Live Activity or a Lock Screen
+    /// widget, so the app has to know the difference before it writes.
+    var kind: NotifyDeviceKind {
+        NotifyDeviceKind.kind(ofDeviceId: deviceId)
+    }
+
+    /// Whether a Live Activity can be started on this link at all. The gateway
+    /// refuses a start aimed at a Mac or a browser, so this is checked before
+    /// spending the request.
+    var supportsLiveActivity: Bool {
+        kind.supportsLiveActivity
+    }
+
+    /// Whether a widget written to this link would ever be drawn.
+    var supportsWidget: Bool {
+        kind.supportsWidget
+    }
+
+    /// Whether a Home Screen widget can be kept on this link.
+    var supportsScreenWidget: Bool {
+        kind.supportsScreenWidget
+    }
+
+    init?(deviceId: String, token: String) {
+        let id = deviceId.trimmingCharacters(in: .whitespacesAndNewlines)
+        let secret = token.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard Self.isValidDeviceId(id), !secret.isEmpty else { return nil }
+        self.deviceId = id
+        self.token = secret
+    }
+
+    /// Reads a link out of text the user pasted.
+    ///
+    /// Accepts a Notify! URL of any shape the gateway issues, including the
+    /// `/notify/{id}?token=`, `/live-activity/{id}?token=` and
+    /// `/widgets/{id}?token=` forms, and falls back to treating the text as an
+    /// id and token separated by whitespace, a comma, or a colon.
+    init?(pastedText: String) {
+        let text = pastedText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return nil }
+
+        if let link = Self.fromURL(text) {
+            self = link
+            return
+        }
+
+        let parts = text
+            .split(whereSeparator: { $0.isWhitespace || $0 == "," || $0 == ":" })
+            .map(String.init)
+        guard parts.count == 2, let link = NotifyDeviceLink(deviceId: parts[0], token: parts[1]) else {
+            return nil
+        }
+        self = link
+    }
+
+    /// Whether a string is shaped like a gateway id at all.
+    ///
+    /// Deliberately the gateway's own loose sanity check rather than its exact
+    /// grammar, so an id from a namespace Notify! adds later still links. What
+    /// the id can actually carry is `NotifyDeviceKind`'s job, not this one: a
+    /// group or a Mac link is perfectly valid and simply cannot hold a Lock
+    /// Screen surface, which is a thing to explain rather than a parse failure.
+    ///
+    /// Beyond the shape there is nothing to check locally. The gateway answers
+    /// an unknown id and a wrong token with one identical response, on purpose.
+    static func isValidDeviceId(_ value: String) -> Bool {
+        let length = value.count
+        guard length >= 8, length <= 32 else { return false }
+        return value.allSatisfy { $0.isASCII && ($0.isLetter || $0.isNumber) }
+    }
+
+    /// The device id a pasted string names, whether or not a token came with it.
+    ///
+    /// A full link needs both halves, so `init?(pastedText:)` refuses a URL with
+    /// no `?token=` on it. That shape is real: the gateway's own `/link`
+    /// response hands back a `notification_url` with the token deliberately
+    /// stripped. For a settings pane with a field per value, half an answer is
+    /// still worth having, so this fills in the half that is there.
+    static func deviceId(inPastedText text: String) -> String? {
+        let text = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return nil }
+
+        if let identifier = identifier(inURL: text), isValidDeviceId(identifier) {
+            return identifier
+        }
+
+        let parts = text
+            .split(whereSeparator: { $0.isWhitespace || $0 == "," || $0 == ":" })
+            .map(String.init)
+        guard let first = parts.first, isValidDeviceId(first) else { return nil }
+        return first
+    }
+
+    /// The last non empty path segment of a URL, which is where every gateway
+    /// route that carries an id puts it.
+    private static func identifier(inURL text: String) -> String? {
+        guard let components = URLComponents(string: text), components.host != nil else {
+            return nil
+        }
+        return components.path
+            .split(separator: "/")
+            .map(String.init)
+            .last { !$0.isEmpty }
+    }
+
+    private static func fromURL(_ text: String) -> NotifyDeviceLink? {
+        guard let components = URLComponents(string: text), components.host != nil else {
+            return nil
+        }
+        let token = components.queryItems?.first { $0.name == "token" }?.value ?? ""
+        return NotifyDeviceLink(deviceId: identifier(inURL: text) ?? "", token: token)
+    }
+}
+
+/// Which kind of Notify! identity an id names, and therefore what this app can
+/// put on it.
+///
+/// Notify! mints ids in several namespaces, fenced against each other, and they
+/// are not interchangeable destinations. A Live Activity is
+/// gated by the gateway itself: a start aimed at a Mac of either generation or
+/// at a web push browser is refused outright, with the reason given as "the
+/// target device cannot show Live Activities at all". Widgets carry no such
+/// gate, but the only thing that renders one is the iOS widget extension, so a
+/// widget written to a Mac or a browser is a row nothing will ever draw.
+///
+/// The two surfaces are gated differently, and only one of them is gated by the
+/// namespace at all. A Live Activity is refused for a Mac or a browser. A widget
+/// is not: the gateway is explicit that there is no device-type gate on widgets
+/// and that legacy, `WB` and `MC` devices alike can own one, so this app does
+/// not invent a rule the service does not have. A group is the exception to
+/// both, being a fan-out target rather than a device, with no surface of its own.
+///
+/// Note which way round that is. The three that cannot are named, and everything
+/// else is allowed, rather than the other way about. App device ids are not one
+/// fixed shape: the legacy format is 8 characters, the newer iOS namespace is
+/// `IO` plus 14, and more will follow. Listing what may pass would refuse a real
+/// phone the day Notify! mints a format this file has never heard of, and a
+/// refused phone looks like the app being broken.
+enum NotifyDeviceKind: Sendable, Equatable, Hashable, CaseIterable {
+    /// An iPhone or iPad: the `IO` plus 14 namespace, or the legacy 8 character
+    /// format that iOS and older Mac listeners share.
+    ///
+    /// A legacy id cannot be told apart locally from an older poll only Mac
+    /// listener, which uses the same 8 characters and cannot show a Live
+    /// Activity either, so the gateway has the last word on those. An `IO` id
+    /// carries no such ambiguity.
+    case appDevice
+
+    /// A push capable Mac listener, `MC` plus 14 characters.
+    case mac
+
+    /// A web push browser, `WB` plus 14 characters.
+    case web
+
+    /// A notification group, `GRP` plus 5 characters. Not a device at all: it
+    /// fans a notification out to its members, and owns no surface of its own.
+    case group
+
+    /// A well formed id in none of the namespaces named here, which includes any
+    /// app device format added after this was written. Allowed through with both
+    /// surfaces rather than refused: the gateway is the only place that can
+    /// decide, and refusing by default would break every new format on the day
+    /// it ships. It differs from `appDevice` only in what the pane calls it,
+    /// since claiming an unknown id is an iPhone would be a guess.
+    case unrecognized
+
+    /// Classifies an id by the namespace it belongs to.
+    ///
+    /// The grammars are the gateway's own: `GRP[A-Z0-9]{5}`, `WB[A-Z0-9]{14}`,
+    /// `MC[A-Z0-9]{14}`, `IO[A-Z0-9]{14}`, and the legacy `[A-Za-z0-9]{8}`.
+    /// The legacy form is deliberately case insensitive: iOS mints uppercase,
+    /// but older Mac listeners minted mixed case, so lowercase legacy ids exist.
+    ///
+    /// Note that `GRP` plus 5 is eight characters, exactly the length of a
+    /// legacy id, so the two grammars genuinely overlap and something has to
+    /// break the tie. The group prefix is tested first, which is the same tie
+    /// break the gateway itself makes: anything beginning with `GRP` is routed
+    /// to the group fan out and everything else is treated as a device.
+    static func kind(ofDeviceId deviceId: String) -> NotifyDeviceKind {
+        func hasPrefix(_ prefix: String, thenDigits count: Int) -> Bool {
+            guard deviceId.count == prefix.count + count, deviceId.hasPrefix(prefix) else {
+                return false
+            }
+            return deviceId.dropFirst(prefix.count).allSatisfy { character in
+                character.isASCII && (character.isNumber || (character.isLetter && character.isUppercase))
+            }
+        }
+
+        // The three that cannot show a surface are matched first and matched
+        // exactly, prefix and length together. Prefix alone would refuse a
+        // legacy id that merely happens to spell "MC" in its first two
+        // characters, and refusing a working phone is the expensive mistake here.
+        if hasPrefix("GRP", thenDigits: 5) { return .group }
+        if hasPrefix("WB", thenDigits: 14) { return .web }
+        if hasPrefix("MC", thenDigits: 14) { return .mac }
+
+        // The newer iOS namespace, and then the legacy format.
+        if hasPrefix("IO", thenDigits: 14) { return .appDevice }
+        if deviceId.count == 8, deviceId.allSatisfy({ $0.isASCII && ($0.isLetter || $0.isNumber) }) {
+            return .appDevice
+        }
+
+        // Anything else is a device this file has not been taught to name, not a
+        // device that cannot show anything.
+        return .unrecognized
+    }
+
+    /// Whether a Live Activity can be started on this kind of id at all.
+    ///
+    /// The gateway refuses a start for a Mac or a browser with a 400, so asking
+    /// is not merely useless, it burns a request and reads to the user as a
+    /// failure of the app's.
+    var supportsLiveActivity: Bool {
+        switch self {
+        case .appDevice, .unrecognized: return true
+        case .mac, .web, .group: return false
+        }
+    }
+
+    /// Whether a widget can be kept here.
+    ///
+    /// Everything except a group. The gateway says plainly that widgets carry no
+    /// device-type gate and that legacy, `WB` and `MC` devices can all own one,
+    /// so which of them actually draws it is Notify!'s business rather than a
+    /// rule for this app to invent. A group is excluded because it is not a
+    /// device: it fans a notification out to its members and owns nothing.
+    var supportsWidget: Bool {
+        switch self {
+        case .appDevice, .unrecognized, .mac, .web: return true
+        case .group: return false
+        }
+    }
+
+    /// Whether a Home Screen widget can be kept here.
+    ///
+    /// The same answer as the Lock Screen widget and for the same reason: the
+    /// gateway states that screen widgets carry no device-type gate and that
+    /// legacy, `IO`, `WB` and `MC` ids can all own one. Only a group is
+    /// excluded, having no widget list of its own to write to.
+    var supportsScreenWidget: Bool {
+        supportsWidget
+    }
+
+    /// Whether any surface at all is available here.
+    var supportsAnySurface: Bool {
+        supportsLiveActivity || supportsWidget || supportsScreenWidget
+    }
+
+    /// What to call this in the settings pane.
+    var displayName: String {
+        switch self {
+        case .appDevice: return "notify.device_kind.app_device".localized
+        case .mac: return "notify.device_kind.mac".localized
+        case .web: return "notify.device_kind.web".localized
+        case .group: return "notify.device_kind.group".localized
+        case .unrecognized: return "notify.device_kind.unknown".localized
+        }
+    }
+
+    /// One sentence naming why a Live Activity cannot be shown here, or nil when
+    /// it can. Written for the person who has just entered an ID and needs to
+    /// know what to use instead.
+    var liveActivityUnsupportedReason: String? {
+        switch self {
+        case .appDevice, .unrecognized:
+            return nil
+        case .mac:
+            return "notify.unsupported.live_activity_mac".localized
+        case .web:
+            return "notify.unsupported.live_activity_web".localized
+        case .group:
+            return Self.groupReason
+        }
+    }
+
+    /// The Home Screen widget shares the Lock Screen widget's answer.
+    var screenWidgetUnsupportedReason: String? {
+        widgetUnsupportedReason
+    }
+
+    /// The same for the widget, which only a group cannot keep.
+    var widgetUnsupportedReason: String? {
+        switch self {
+        case .appDevice, .unrecognized, .mac, .web:
+            return nil
+        case .group:
+            return Self.groupReason
+        }
+    }
+
+    private static var groupReason: String {
+        "notify.unsupported.group".localized
+    }
+
+}
+
+/// What the gateway knows about a device, as reported by a credential check.
+/// `name` is never empty: the gateway synthesizes one from the platform when
+/// the device has no user chosen name.
+struct NotifyDeviceInfo: Sendable, Equatable {
+    let deviceId: String
+    let name: String
+    let platform: String?
+
+    init(deviceId: String, name: String, platform: String? = nil) {
+        self.deviceId = deviceId
+        self.name = name
+        self.platform = platform
+    }
+
+    /// One line description for the settings pane, e.g. "Apollo (iOS)".
+    var displayDescription: String {
+        guard let platform, !platform.isEmpty else { return name }
+        return "\(name) (\(platform))"
+    }
+}

--- a/Claude Usage/Shared/Notify/NotifyGatewayClient.swift
+++ b/Claude Usage/Shared/Notify/NotifyGatewayClient.swift
@@ -1,0 +1,652 @@
+//
+//  NotifyGatewayClient.swift
+//  Claude Usage
+//
+//  The only file in the Notify! feature that knows HTTP exists.
+//
+
+import Foundation
+
+/// Writes the app's usage state to the Notify! gateway.
+///
+/// The gateway has no notion of a tile or widget "type": the fields present in the JSON body
+/// decide how the thing draws, and an absent field is left alone by the gateway's merge. So this
+/// client sends only the fields this app actually drives and never mentions the rest, which is what
+/// keeps an update from here stomping something the user configured elsewhere.
+///
+/// Routes used:
+/// - `POST /live-activity/{deviceId|activityId}?token=` for the Lock Screen tile
+/// - `POST /widgets/{deviceId|widgetId}?token=` for the gauge widget
+/// - `POST /screenwidgets/{deviceId|screenWidgetId}?token=` for the Home Screen widget
+/// - `DELETE /live-activity/{activityId}?token=&keepFor=` to end the tile
+/// - `GET /link?id=&token=` to check a pasted device link
+///
+/// There is no bearer token: the per device secret travels in `?token=`, and the gateway answers a
+/// missing token, a wrong token, an unknown id and somebody else's id with one identical 403.
+struct NotifyGatewayClient: NotifyPublishing {
+
+    /// The gateway host. The initializer takes another only so tests can point
+    /// the client at a stub.
+    static let defaultHost = URL(string: "https://push.getnotifyapp.com")!
+
+    private static let liveActivityRoute = "/live-activity"
+    private static let widgetsRoute = "/widgets"
+    private static let screenWidgetsRoute = "/screenwidgets"
+    private static let linkRoute = "/link"
+
+    /// The first rung of the gateway's push to start backoff ladder, used when a 429 names no
+    /// wait of its own.
+    static let defaultBackoff: TimeInterval = 1800
+
+    /// The gateway's own ceiling on how long a finished tile may linger.
+    static let maximumKeepFor: TimeInterval = 14400
+
+    private let networkClient: NotifyHTTPClient
+    private let host: URL
+    private let timeout: TimeInterval
+
+    init(
+        networkClient: NotifyHTTPClient = URLSession.shared,
+        host: URL = NotifyGatewayClient.defaultHost,
+        timeout: TimeInterval = 15
+    ) {
+        self.networkClient = networkClient
+        self.host = host
+        self.timeout = timeout
+    }
+
+    // MARK: - NotifyPublishing
+
+    /// Starts the tile when `activityId` is nil, otherwise updates that exact tile.
+    ///
+    /// A start addresses the device id and carries `"new": true`. That flag matters twice over.
+    /// It tells the gateway to start a tile of the app's own instead of taking over whichever
+    /// tile the user last started from some other script, and it is the documented override for
+    /// the sticky dismissal 410, so a tile the user swiped away can be replaced by a fresh one.
+    ///
+    /// An update addresses the returned `LA…` id and sends content only. No control flag belongs
+    /// on an update: `new` there would leave the device with two tiles.
+    func publishTile(
+        _ tile: NotifyTile,
+        link: NotifyDeviceLink,
+        activityId: String?
+    ) async throws -> String {
+        // A Mac of either generation and a web push browser are refused by the gateway itself,
+        // which answers a start aimed at one with a 400 saying the target device cannot show Live
+        // Activities at all, and a group owns no Lock Screen to start one on. So the point of
+        // stopping here is not the saved request. It is which sentence the user ends up reading: a
+        // 400 coming back from a server reads as the app failing at something it should have
+        // managed, while the link's own reason reads as the thing that is actually true about
+        // their device, and it names the fix, which is to paste the link from their phone.
+        guard link.supportsLiveActivity else {
+            throw NotifyPublishError.liveActivityUnavailable(
+                link.kind.liveActivityUnsupportedReason
+                    ?? "notify.unsupported.live_activity_generic".localized
+            )
+        }
+
+        var body = Self.tileBody(tile)
+        let target: String
+        let route: String
+
+        if let activityId {
+            target = activityId
+            route = "POST \(Self.liveActivityRoute) (update)"
+        } else {
+            target = link.deviceId
+            body["new"] = true
+            route = "POST \(Self.liveActivityRoute) (start)"
+            LoggingService.shared.logDebug("Notify!: starting a tile on device \(link.deviceId)")
+        }
+
+        let url = try Self.endpoint(
+            host: host,
+            path: "\(Self.liveActivityRoute)/\(target)",
+            queryItems: [URLQueryItem(name: "token", value: link.token)]
+        )
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.httpBody = try Self.encode(body)
+        Self.applyWriteHeaders(&request, timeout: timeout)
+
+        let data = try await send(request, route: route, accepting: [200])
+
+        guard let decoded = try? JSONDecoder().decode(LiveActivityWriteResponse.self, from: data) else {
+            LoggingService.shared.logError("Notify!: \(route) answered a body the app could not read")
+            throw NotifyPublishError.malformedResponse
+        }
+
+        // `pushed: false` is a success. The content is stored and delivers the moment the device
+        // reports a usable tile token again, so treating it as an error would make the app
+        // restart a tile that is already waiting to appear.
+        if decoded.pushed == false {
+            LoggingService.shared.logDebug("Notify!: tile content stored, no reachable tile token right now")
+        }
+
+        guard let identifier = decoded.activityId ?? activityId else {
+            throw NotifyPublishError.malformedResponse
+        }
+        return identifier
+    }
+
+    /// Creates the widget when `widgetId` is nil, otherwise updates that exact widget.
+    ///
+    /// A create carries `"new": true` for the same "never hijack" reason as a tile start: the
+    /// device dialect would otherwise write over the one widget already sitting there.
+    ///
+    /// A create answers 201, but 200 is accepted too and read the same way, because the gateway
+    /// answers 200 when the call it received turned out to be an update.
+    func publishGauge(
+        _ gauge: NotifyGauge,
+        link: NotifyDeviceLink,
+        widgetId: String?
+    ) async throws -> String {
+        // Only a group is refused, and only because a group is not a device: it fans a
+        // notification out to its members and owns no widget list for one to sit in. Every real
+        // device can keep a widget. The gateway is explicit that widgets carry no device type
+        // gate and that legacy, `WB` and `MC` ids can all own one, so which of them draws it is
+        // Notify!'s business and not a rule for this client to invent.
+        //
+        // `invalidPayload` rather than `liveActivityUnavailable`, because no Live Activity is
+        // involved and that error's remedies, opening the app or waiting out a backoff, would
+        // send the user somewhere useless.
+        guard link.supportsWidget else {
+            throw NotifyPublishError.invalidPayload(
+                link.kind.widgetUnsupportedReason
+                    ?? "notify.unsupported.widget_generic".localized
+            )
+        }
+
+        var body = Self.gaugeBody(gauge)
+        let target: String
+        let route: String
+        let accepting: Set<Int>
+
+        if let widgetId {
+            target = widgetId
+            route = "POST \(Self.widgetsRoute) (update)"
+            accepting = [200]
+        } else {
+            target = link.deviceId
+            body["new"] = true
+            route = "POST \(Self.widgetsRoute) (create)"
+            accepting = [200, 201]
+            LoggingService.shared.logDebug("Notify!: creating a widget on device \(link.deviceId)")
+        }
+
+        let url = try Self.endpoint(
+            host: host,
+            path: "\(Self.widgetsRoute)/\(target)",
+            queryItems: [URLQueryItem(name: "token", value: link.token)]
+        )
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.httpBody = try Self.encode(body)
+        Self.applyWriteHeaders(&request, timeout: timeout)
+
+        let data = try await send(request, route: route, accepting: accepting)
+
+        guard let decoded = try? JSONDecoder().decode(WidgetWriteResponse.self, from: data),
+              let identifier = decoded.widgetId ?? widgetId else {
+            LoggingService.shared.logError("Notify!: \(route) answered a body the app could not read")
+            throw NotifyPublishError.malformedResponse
+        }
+        return identifier
+    }
+
+    /// Creates the Home Screen widget when `screenWidgetId` is nil, otherwise updates that exact
+    /// one.
+    ///
+    /// The body is the tile's, built by the same `tileBody` the Live Activity uses. That is not a
+    /// convenience: the gateway derives this route's content contract from its Live Activity
+    /// module, so the two surfaces take the same fields, the same caps and the same merge rules,
+    /// and one tile value driving both is the entire point of the feature. A second builder here
+    /// could only drift from the first and put two different pictures of one quota on one phone.
+    ///
+    /// A create carries `"new": true` for the same "never hijack" reason as the other two
+    /// surfaces: the device dialect would otherwise write over whichever screen widget is already
+    /// there. A create answers 201, and 200 is accepted alongside it exactly as for the gauge,
+    /// since the gateway answers 200 when the call it received turned out to be an update.
+    func publishScreenTile(
+        _ tile: NotifyTile,
+        link: NotifyDeviceLink,
+        screenWidgetId: String?
+    ) async throws -> String {
+        // Only a group is refused, and for the reason the gauge refuses one: a group is not a
+        // device and owns no widget list to write into. Every real device can keep a screen
+        // widget, the gateway being explicit that this route carries no device type gate at all
+        // and that legacy, `IO`, `WB` and `MC` ids can each own one.
+        guard link.supportsScreenWidget else {
+            throw NotifyPublishError.invalidPayload(
+                link.kind.screenWidgetUnsupportedReason
+                    ?? "notify.unsupported.screen_widget_generic".localized
+            )
+        }
+
+        var body = Self.tileBody(tile)
+        let target: String
+        let route: String
+        let accepting: Set<Int>
+
+        if let screenWidgetId {
+            target = screenWidgetId
+            route = "POST \(Self.screenWidgetsRoute) (update)"
+            accepting = [200]
+        } else {
+            target = link.deviceId
+            body["new"] = true
+            route = "POST \(Self.screenWidgetsRoute) (create)"
+            accepting = [200, 201]
+            LoggingService.shared.logDebug("Notify!: creating a Home Screen widget on device \(link.deviceId)")
+        }
+
+        let url = try Self.endpoint(
+            host: host,
+            path: "\(Self.screenWidgetsRoute)/\(target)",
+            queryItems: [URLQueryItem(name: "token", value: link.token)]
+        )
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.httpBody = try Self.encode(body)
+        Self.applyWriteHeaders(&request, timeout: timeout)
+
+        // Two statuses mean something here that they do not mean anywhere else in this client, so
+        // they are translated where that difference is known rather than inside the shared
+        // `failure` mapping, which every other route would then have to reason about.
+        let data: Data
+        do {
+            data = try await send(request, route: route, accepting: accepting, expected: [503])
+        } catch NotifyPublishError.unexpectedStatus(503) {
+            // The server side kill switch for Home Screen widgets. While it is off, creates and
+            // updates are refused and reads and deletes are deliberately left open so an already
+            // placed tile keeps rendering. Nothing is wrong with the app, the credentials or
+            // the content, so this must not reach the user reading like a failure, and the remedy
+            // is to wait for the day the surface is switched on.
+            //
+            // The gateway's own sentence does not survive `unexpectedStatus`, which carries a
+            // status code and nothing else, and that costs nothing: an empty message picks the
+            // error's own "switched off at the moment, the app will try again later" wording,
+            // which is the sentence to put in front of a user however the server phrased it.
+            throw NotifyPublishError.surfaceSwitchedOff("")
+        } catch NotifyPublishError.liveActivityUnavailable(let message) {
+            // A 409, which the shared mapping reads as a Live Activity problem because that is
+            // what it means on the route it was written for. Here it means the device dialect
+            // found several screen widgets and cannot tell which one was meant. This app creates
+            // its own with `new` and addresses it by `SW…` id afterwards, so it should never see
+            // this, but telling somebody to open the Notify! app about their Live Activities
+            // would be a wrong answer to a question about a Home Screen widget.
+            throw NotifyPublishError.invalidPayload(message)
+        }
+
+        guard let decoded = try? JSONDecoder().decode(ScreenWidgetWriteResponse.self, from: data),
+              let identifier = decoded.screenWidgetId ?? screenWidgetId else {
+            LoggingService.shared.logError("Notify!: \(route) answered a body the app could not read")
+            throw NotifyPublishError.malformedResponse
+        }
+        return identifier
+    }
+
+    /// Ends the tile, leaving it on the Lock Screen for `keepFor` seconds so the final state can
+    /// be read.
+    ///
+    /// A 410 counts as success. It means the tile is already gone, dismissed or ended or reaped,
+    /// which is exactly the outcome the caller asked for.
+    func endTile(link: NotifyDeviceLink, activityId: String, keepFor: TimeInterval) async throws {
+        let url = try Self.endpoint(
+            host: host,
+            path: "\(Self.liveActivityRoute)/\(activityId)",
+            queryItems: [
+                URLQueryItem(name: "token", value: link.token),
+                URLQueryItem(name: "keepFor", value: String(Self.clampedKeepFor(keepFor))),
+            ]
+        )
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "DELETE"
+        Self.applyWriteHeaders(&request, timeout: timeout)
+
+        _ = try await send(
+            request,
+            route: "DELETE \(Self.liveActivityRoute)",
+            accepting: [200, 410]
+        )
+    }
+
+    /// Checks a device id and token pair and describes the device it names.
+    ///
+    /// The gateway rate limits this route to five calls a minute per IP, so it must only ever run
+    /// from an explicit user action such as a "Test connection" button. Nothing on a timer may
+    /// call it.
+    func deviceInfo(link: NotifyDeviceLink) async throws -> NotifyDeviceInfo {
+        let url = try Self.endpoint(
+            host: host,
+            path: Self.linkRoute,
+            queryItems: [
+                URLQueryItem(name: "id", value: link.deviceId),
+                URLQueryItem(name: "token", value: link.token),
+            ]
+        )
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.timeoutInterval = timeout
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        // The only GET in the feature, and its URL carries the device token. URLSession keys its
+        // shared cache by the full request URL and backs that cache with a file in ~/Library/Caches,
+        // so a cacheable answer would write the secret to disk in plaintext, outside the Keychain
+        // this feature is careful to keep it in. Refusing the cache also happens to be the right
+        // semantics: "check these credentials right now" must never be answered from a stale copy.
+        request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+
+        LoggingService.shared.logDebug("Notify!: checking the link for device \(link.deviceId)")
+
+        let data: Data
+        do {
+            data = try await send(request, route: "GET \(Self.linkRoute)", accepting: [200])
+        } catch NotifyPublishError.unexpectedStatus(404) {
+            // This route has an error envelope of its own and answers 404, not 403, for a pair it
+            // does not recognise. It gives that same answer for a wrong token and for an id that
+            // does not exist, so it cannot be used to enumerate ids. To the person who just pasted
+            // their credentials it is the same problem a 403 names, so it gets the same sentence
+            // rather than a bare status code.
+            throw NotifyPublishError.rejectedCredentials
+        }
+
+        guard let decoded = try? JSONDecoder().decode(LinkResponse.self, from: data) else {
+            LoggingService.shared.logError("Notify!: GET \(Self.linkRoute) answered a body the app could not read")
+            throw NotifyPublishError.malformedResponse
+        }
+
+        // The same route describes groups, and a group cannot carry a Live Activity or a widget,
+        // so a group link has to be rejected here rather than failing later with a puzzling 400.
+        guard decoded.type == "device" else {
+            throw NotifyPublishError.invalidPayload(
+                "notify.error.link_is_group".localized
+            )
+        }
+
+        guard let identifier = decoded.id, let name = decoded.name else {
+            throw NotifyPublishError.malformedResponse
+        }
+        return NotifyDeviceInfo(deviceId: identifier, name: name, platform: decoded.platform)
+    }
+
+    // MARK: - Transport
+
+    /// Runs one gateway request and returns its body, translating everything that can go wrong
+    /// into a `NotifyPublishError` so no caller ever sees a `URLError`.
+    ///
+    /// `route` is a bare label such as "POST /live-activity (start)". The real URL carries the per
+    /// device token and the device id, and neither belongs in a log the user is asked to attach to
+    /// a bug report, so only the route and the status code are logged. The device id appears at
+    /// debug level only, which never reaches the log file on disk.
+    /// `expected` names statuses that are a refusal rather than a fault: they
+    /// still throw, but they are logged at info, because writing "error" into
+    /// the file a user attaches to a bug report for something the app then
+    /// tells them is perfectly normal is how a log stops being trusted. The
+    /// Home Screen widget's 503 kill switch is the only one so far.
+    private func send(
+        _ request: URLRequest,
+        route: String,
+        accepting: Set<Int>,
+        expected: Set<Int> = []
+    ) async throws -> Data {
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await networkClient.request(request)
+        } catch {
+            // The code and domain, never the description. Every URL in this
+            // client carries the device token in its query string, and a
+            // transport error's localized description is free to quote the URL
+            // it failed on. `LoggingService.logError` is written to a plaintext file users
+            // are asked to attach to bug reports, so the description goes to the
+            // thrown error, which is shown in the pane and never written down.
+            let failure = error as NSError
+            LoggingService.shared.logError("Notify!: \(route) could not be reached (\(failure.domain) \(failure.code))")
+            throw NotifyPublishError.transportFailed(error.localizedDescription)
+        }
+
+        guard let http = response as? HTTPURLResponse else {
+            LoggingService.shared.logError("Notify!: \(route) answered something that was not an HTTP response")
+            throw NotifyPublishError.malformedResponse
+        }
+
+        LoggingService.shared.logDebug("Notify!: \(route) answered HTTP \(http.statusCode)")
+
+        guard accepting.contains(http.statusCode) else {
+            let mapped = Self.failure(
+                status: http.statusCode,
+                data: data,
+                retryAfterHeader: http.value(forHTTPHeaderField: "Retry-After")
+            )
+            if expected.contains(http.statusCode) {
+                LoggingService.shared.logInfo("Notify!: \(route) answered HTTP \(http.statusCode), which is expected here")
+            } else {
+                LoggingService.shared.logError("Notify!: \(route) failed with HTTP \(http.statusCode)")
+            }
+            throw mapped
+        }
+
+        return data
+    }
+
+    // MARK: - Request Building
+
+    /// Builds a gateway URL through `URLComponents` rather than string interpolation, because the
+    /// per device token is an opaque secret that can contain characters a query string has to
+    /// escape.
+    static func endpoint(host: URL, path: String, queryItems: [URLQueryItem]) throws -> URL {
+        guard var components = URLComponents(url: host, resolvingAgainstBaseURL: false) else {
+            throw NotifyPublishError.invalidPayload("notify.error.bad_host".localized)
+        }
+
+        // A host given with a trailing slash would otherwise produce a doubled separator.
+        let base = components.path.hasSuffix("/") ? String(components.path.dropLast()) : components.path
+        components.path = base + path
+        components.queryItems = queryItems
+
+        guard let url = components.url else {
+            throw NotifyPublishError.invalidPayload("notify.error.bad_host".localized)
+        }
+        return url
+    }
+
+    private static func applyWriteHeaders(_ request: inout URLRequest, timeout: TimeInterval) {
+        request.timeoutInterval = timeout
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+    }
+
+    /// `JSONSerialization` rather than `JSONEncoder`, matching every other HTTP body in the app.
+    /// The bodies are sparse dictionaries whose keys depend on which Domain fields are populated,
+    /// which a `Codable` type would express as a wall of optionals and custom encoding.
+    static func encode(_ body: [String: Any]) throws -> Data {
+        do {
+            return try JSONSerialization.data(withJSONObject: body)
+        } catch {
+            throw NotifyPublishError.invalidPayload("notify.error.encode_failed".localized)
+        }
+    }
+
+    /// The tile's content fields, stating a null for anything the Domain type left nil.
+    ///
+    /// Both the Live Activity and the Home Screen widget are written with this, because the
+    /// gateway builds both routes' content contracts from one module and accepts either body on
+    /// either route unchanged.
+    ///
+    /// `status`, `endsIn`, `steps`, `step` and `button` are deliberately never mentioned. Those
+    /// are the fields the "leave it alone" rule is actually for: an absent field is left alone by
+    /// the gateway's merge, so staying silent about them is what lets an update from here share a
+    /// tile with whatever else the user set up.
+    ///
+    /// `metrics` has no query spelling at all: the gateway reads it from the JSON body only.
+    static func tileBody(_ tile: NotifyTile) -> [String: Any] {
+        var body: [String: Any] = ["title": tile.title]
+
+        // Every field the app drives is stated on every write, as an explicit
+        // null when it has no value. The gateway merges rather than replaces, so
+        // omitting a field it already holds freezes the old value instead of
+        // clearing it: a reset countdown would keep ticking beside a quota that
+        // no longer reports one, and a bar would keep the last percentage after
+        // the headline became a credit balance with no percentage at all.
+        body["body"] = tile.body ?? NSNull()
+        body["symbol"] = tile.symbolName ?? NSNull()
+        body["tint"] = tile.tintHex ?? NSNull()
+        body["progress"] = tile.progress ?? NSNull()
+        body["trailing"] = tile.trailing ?? NSNull()
+
+        if tile.metrics.isEmpty {
+            body["metrics"] = NSNull()
+        } else {
+            body["metrics"] = tile.metrics.map { metric -> [String: Any] in
+                var item: [String: Any] = ["label": metric.label, "value": metric.value]
+                if let unit = metric.unit { item["unit"] = unit }
+                if let color = metric.tintHex { item["color"] = color }
+                return item
+            }
+        }
+        return body
+    }
+
+    /// The widget's content fields, stating a null for anything the Domain type left nil.
+    ///
+    /// The widget is the surface where this matters most. A tile is short lived and gets restarted,
+    /// but the widget the app creates lives under its `WG…` id until the user removes it, so any
+    /// field left unstated survives forever. A gauge showing a credit balance has no percentage and
+    /// no percent sign, and saying so is the only way to take the previous ring off the screen.
+    ///
+    /// `title` is the exception: the gateway treats it as the widget's identity and refuses to
+    /// clear it, so it is always a value and never a null.
+    static func gaugeBody(_ gauge: NotifyGauge) -> [String: Any] {
+        var body: [String: Any] = ["title": gauge.title]
+        body["value"] = gauge.value ?? NSNull()
+        body["unit"] = gauge.unit ?? NSNull()
+        body["detail"] = gauge.detail ?? NSNull()
+        body["symbol"] = gauge.symbolName ?? NSNull()
+        body["tint"] = gauge.tintHex ?? NSNull()
+        body["progress"] = gauge.progress ?? NSNull()
+        return body
+    }
+
+    /// The gateway accepts 0 to 14400 seconds and rejects anything else, so a caller's preference
+    /// is clamped rather than allowed to fail the end call it is only decorating.
+    static func clampedKeepFor(_ keepFor: TimeInterval) -> Int {
+        guard keepFor.isFinite else { return 0 }
+        return Int(min(maximumKeepFor, max(0, keepFor)))
+    }
+
+    // MARK: - Error Mapping
+
+    /// Turns any answer the caller did not accept into the matching Domain error.
+    ///
+    /// Static, and taking the raw body, so tests can drive every status code and every shape of
+    /// error body through it without standing up a network stub.
+    static func failure(status: Int, data: Data, retryAfterHeader: String?) -> NotifyPublishError {
+        let body = try? JSONDecoder().decode(GatewayFailure.self, from: data)
+        let message = body?.message ?? body?.error ?? ""
+
+        switch status {
+        case 400:
+            return .invalidPayload(message)
+        case 403:
+            // Missing, wrong, unknown and somebody else's are one indistinguishable answer here.
+            return .rejectedCredentials
+        case 409:
+            return .liveActivityUnavailable(message)
+        case 410:
+            return .tileGone
+        case 429:
+            return .backoff(
+                retryAfter: retryAfter(bodySeconds: body?.retryAfterSeconds, header: retryAfterHeader),
+                openingTheAppMayHelp: body?.openingTheAppMayHelp ?? false
+            )
+        case 502:
+            // "unknown" means Apple never answered, so a tile may well exist. Retrying a start
+            // would risk a second tile, which is why this keeps the id for a later poll instead.
+            if body?.deliveryState == "unknown" {
+                return .deliveryUnconfirmed(activityId: body?.activityId)
+            }
+            // "not-delivered" means no tile exists and starting again is safe, but not
+            // necessarily useful. The gateway counts every unanswered start toward a push to
+            // start ladder that reaches six hours, so a start that is refused is treated as a
+            // wait rather than as something to try again on the next tick. Its own
+            // retryAfterSeconds is the wait when it names one, and when it does not, the
+            // contract's own reading is that retrying unchanged is pointless, so the ladder's
+            // first rung is used rather than no wait at all.
+            if body?.deliveryState == "not-delivered" {
+                return .backoff(
+                    retryAfter: retryAfter(bodySeconds: body?.retryAfterSeconds, header: retryAfterHeader),
+                    openingTheAppMayHelp: body?.openingTheAppMayHelp ?? false
+                )
+            }
+            return .unexpectedStatus(502)
+        default:
+            return .unexpectedStatus(status)
+        }
+    }
+
+    /// How long to wait after a 429.
+    ///
+    /// The body's own number wins because the gateway computes it from the backoff ladder it is
+    /// actually enforcing. The `Retry-After` header is the HTTP fallback, and only its numeric
+    /// form is read: the HTTP date form would need a clock this app cannot trust to agree with
+    /// the server's. With neither present, 30 minutes is the ladder's first rung and so the safest
+    /// guess available.
+    static func retryAfter(bodySeconds: Double?, header: String?) -> TimeInterval {
+        if let bodySeconds, bodySeconds.isFinite, bodySeconds > 0 {
+            return bodySeconds
+        }
+        if let header,
+           let seconds = Double(header.trimmingCharacters(in: .whitespacesAndNewlines)),
+           seconds.isFinite, seconds > 0 {
+            return seconds
+        }
+        return defaultBackoff
+    }
+}
+
+// MARK: - Response Models
+
+/// The shared error envelope, `{"error": ..., "message": ...}`, plus the extra fields the 429 and
+/// 502 answers add on top of it.
+private struct GatewayFailure: Decodable {
+    let error: String?
+    let message: String?
+    let retryAfterSeconds: Double?
+    let openingTheAppMayHelp: Bool?
+    let deliveryState: String?
+    let activityId: String?
+}
+
+/// A start or an update of the Live Activity. A start always names the new `LA…` id; an update
+/// echoes it and adds `pushed`.
+private struct LiveActivityWriteResponse: Decodable {
+    let activityId: String?
+    let pushed: Bool?
+}
+
+/// The `Widget` object a create (201) and an update (200) both answer with. Only the id is read:
+/// the echoed content is what the app just sent.
+private struct WidgetWriteResponse: Decodable {
+    let widgetId: String?
+}
+
+/// The `ScreenWidget` object, answered by a create (201) and an update (200) alike. Only the id is
+/// read, for the reason the widget's is: the rest of the object is the content the app just sent
+/// back again, plus a `staleAt` the phone owns and the app has no decision to make about.
+private struct ScreenWidgetWriteResponse: Decodable {
+    let screenWidgetId: String?
+}
+
+/// `GET /link`, which answers flat snake_case. Only the four fields the app needs are read, and
+/// none of those four has an underscore in it, so no key mapping is required.
+private struct LinkResponse: Decodable {
+    let type: String?
+    let id: String?
+    let name: String?
+    let platform: String?
+}

--- a/Claude Usage/Shared/Notify/NotifyGauge.swift
+++ b/Claude Usage/Shared/Notify/NotifyGauge.swift
@@ -1,0 +1,60 @@
+//
+//  NotifyGauge.swift
+//  Claude Usage
+//
+//  The content of the Lock Screen widget published to Notify!.
+//
+
+import Foundation
+
+/// The content of the Notify! widget the app keeps on the Lock Screen.
+///
+/// `progress` is the gauge: the gateway draws it as a bar on the rectangular
+/// widget and as a ring on the circular one, which is the whole reason a quota
+/// belongs here. The headline `value` is display text the caller formats, so
+/// the phone never does arithmetic on it.
+struct NotifyGauge: Sendable, Equatable {
+    /// The widget's identity in the phone's widget picker. Stable on purpose:
+    /// a title that changed with the selected quota would rename the widget
+    /// under the user every time they switched.
+    let title: String
+
+    /// Pre-formatted headline, for example "42".
+    let value: String?
+
+    /// Small label beside the value, for example "%".
+    let unit: String?
+
+    /// Quieter second line, for example "Claude 5h, resets in 2:14".
+    let detail: String?
+
+    /// SF Symbol drawn as the widget icon.
+    let symbolName: String?
+
+    /// Accent color as `#RRGGBB`, normally the shown quota's status.
+    let tintHex: String?
+
+    /// The gauge, 0 to 100. We send quota remaining here.
+    let progress: Double?
+
+    init?(
+        title: String,
+        value: String? = nil,
+        unit: String? = nil,
+        detail: String? = nil,
+        symbolName: String? = nil,
+        tintHex: String? = nil,
+        progress: Double? = nil
+    ) {
+        guard let title = NotifyLimits.text(title, maximum: NotifyLimits.widgetTitleLength) else {
+            return nil
+        }
+        self.title = title
+        self.value = NotifyLimits.text(value, maximum: NotifyLimits.widgetValueLength)
+        self.unit = NotifyLimits.text(unit, maximum: NotifyLimits.widgetUnitLength)
+        self.detail = NotifyLimits.text(detail, maximum: NotifyLimits.widgetDetailLength)
+        self.symbolName = NotifyLimits.text(symbolName, maximum: NotifyLimits.symbolLength)
+        self.tintHex = NotifyLimits.tint(tintHex)
+        self.progress = NotifyLimits.progress(progress)
+    }
+}

--- a/Claude Usage/Shared/Notify/NotifyHTTPClient.swift
+++ b/Claude Usage/Shared/Notify/NotifyHTTPClient.swift
@@ -1,0 +1,23 @@
+//
+//  NotifyHTTPClient.swift
+//  Claude Usage
+//
+//  The one seam that lets the gateway client be tested without a network.
+//
+
+import Foundation
+
+/// Somewhere to send a request and get an answer back.
+///
+/// `URLSession` already does this; the protocol exists so a test can hand
+/// `NotifyGatewayClient` a stub and drive every status code the gateway can
+/// answer with, without a network and without a real device.
+protocol NotifyHTTPClient: Sendable {
+    func request(_ request: URLRequest) async throws -> (Data, URLResponse)
+}
+
+extension URLSession: NotifyHTTPClient {
+    func request(_ request: URLRequest) async throws -> (Data, URLResponse) {
+        try await data(for: request)
+    }
+}

--- a/Claude Usage/Shared/Notify/NotifyLimits.swift
+++ b/Claude Usage/Shared/Notify/NotifyLimits.swift
@@ -1,0 +1,66 @@
+//
+//  NotifyLimits.swift
+//  Claude Usage
+//
+//  The Notify! gateway's field limits, kept in one place.
+//
+
+import Foundation
+
+/// The Notify! gateway's field limits, kept in one place so every value type
+/// enforces the same rules at construction instead of hoping the caller did.
+///
+/// The gateway rejects an oversized string with a 400 naming the field, and
+/// clamps an out of range number rather than rejecting it. We do both here: a
+/// quota label that happens to be long should shorten, never fail to reach the
+/// phone.
+enum NotifyLimits {
+    // Live Activity tile
+    static let titleLength = 120
+    static let bodyLength = 300
+    static let symbolLength = 64
+    static let trailingLength = 40
+    static let metricCount = 6
+    static let metricLabelLength = 24
+    static let metricValueLength = 16
+    static let metricUnitLength = 8
+
+    // Lock Screen widget
+    static let widgetTitleLength = 120
+    static let widgetValueLength = 40
+    static let widgetUnitLength = 12
+    static let widgetDetailLength = 120
+
+    /// Trims whitespace, drops NUL (the gateway rejects it outright), shortens
+    /// to `maximum` characters, and reports an empty result as `nil` so an
+    /// absent field is never sent as `""`.
+    static func text(_ value: String?, maximum: Int) -> String? {
+        guard let value else { return nil }
+        let cleaned = value
+            .replacingOccurrences(of: "\0", with: "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !cleaned.isEmpty else { return nil }
+        guard cleaned.count > maximum else { return cleaned }
+        return String(cleaned.prefix(maximum))
+    }
+
+    /// Clamps a percentage into the 0 to 100 the gateway accepts. A quota can
+    /// legitimately report a negative remainder when the user is over the
+    /// limit, and that reads as an empty bar rather than an error.
+    static func progress(_ value: Double?) -> Double? {
+        guard let value, value.isFinite else { return nil }
+        return min(100, max(0, value))
+    }
+
+    /// Normalizes an accent color to the `#RRGGBB` (or `#AARRGGBB`) the gateway
+    /// accepts, returning nil for anything else so a bad color is dropped
+    /// rather than failing the whole publish.
+    static func tint(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        let digits = trimmed.hasPrefix("#") ? String(trimmed.dropFirst()) : trimmed
+        guard digits.count == 6 || digits.count == 8 else { return nil }
+        guard digits.allSatisfy({ $0.isHexDigit }) else { return nil }
+        return "#" + digits.uppercased()
+    }
+}

--- a/Claude Usage/Shared/Notify/NotifyPayload.swift
+++ b/Claude Usage/Shared/Notify/NotifyPayload.swift
@@ -1,0 +1,67 @@
+//
+//  NotifyPayload.swift
+//  Claude Usage
+//
+//  Everything the app wants standing on the phone right now.
+//
+
+import Foundation
+
+/// Which quota the Lock Screen widget gauge shows.
+///
+/// Both fields empty means "whichever quota needs attention most", which is the
+/// useful default for a glance and the only sane behavior before the user has
+/// chosen anything.
+struct NotifyGaugeSelection: Sendable, Equatable {
+    let providerId: String
+    let quotaKey: String
+
+    init(providerId: String = "", quotaKey: String = "") {
+        self.providerId = providerId
+        self.quotaKey = quotaKey
+    }
+
+    /// Whether the selection names a specific window.
+    var isAutomatic: Bool {
+        providerId.isEmpty || quotaKey.isEmpty
+    }
+
+    static let automatic = NotifyGaugeSelection()
+}
+
+/// Everything the app wants standing on the phone right now.
+///
+/// `Equatable` on purpose: the publish gate drops a payload identical to the
+/// last one, so an unchanged quota costs no HTTP at all. A nil surface means
+/// the user turned that surface off, and the driver leaves it alone rather
+/// than clearing it.
+struct NotifyPayload: Sendable, Equatable {
+    let tile: NotifyTile?
+    let gauge: NotifyGauge?
+
+    /// The Home Screen tile. Deliberately the same `NotifyTile` the Live
+    /// Activity carries, because the gateway derives both content sets from one
+    /// module: any body that starts a Live Activity is a valid screen widget
+    /// body. It is a separate property rather than a reuse of `tile` because
+    /// the two surfaces are switched on and off independently and published on
+    /// different clocks, so a payload has to be able to carry one without the
+    /// other.
+    let screenTile: NotifyTile?
+
+    init(
+        tile: NotifyTile? = nil,
+        gauge: NotifyGauge? = nil,
+        screenTile: NotifyTile? = nil
+    ) {
+        self.tile = tile
+        self.gauge = gauge
+        self.screenTile = screenTile
+    }
+
+    /// Nothing to say, so nothing to send.
+    var isEmpty: Bool {
+        tile == nil && gauge == nil && screenTile == nil
+    }
+
+    static let empty = NotifyPayload()
+}

--- a/Claude Usage/Shared/Notify/NotifyPayloadBuilder.swift
+++ b/Claude Usage/Shared/Notify/NotifyPayloadBuilder.swift
@@ -1,0 +1,222 @@
+//
+//  NotifyPayloadBuilder.swift
+//  Claude Usage
+//
+//  Turns quota readings into the tile and gauge published to Notify!.
+//
+
+import Foundation
+
+/// Turns quota readings into the tile and gauge published to Notify!.
+///
+/// This is the whole decision layer of the feature and it is deliberately pure:
+/// no clock of its own, no network, no settings lookups. What to show, in what
+/// order, in what words, and in what color is decided here so it can be tested
+/// as plain state assertions.
+///
+/// The rules:
+/// 1. The worst quota leads. Readings sort by status severity, then by how
+///    little is left, so the number that needs attention is the headline and
+///    the tile takes its color and progress bar from it.
+/// 2. The tile carries up to six windows as a metrics row, because six is the
+///    gateway's ceiling and more than six is unreadable on a Lock Screen.
+/// 3. Labels drop the provider name when every reading comes from the same
+///    provider, so a single provider tile reads "5h  7d" rather than
+///    "Claude 5h  Claude 7d".
+/// 4. Percentages are remaining, not used. Every surface in this app reads that
+///    way, and a full bar meaning a full quota is the only intuitive mapping
+///    for a gauge.
+struct NotifyPayloadBuilder: Sendable {
+    /// The tile and widget title. Both name the sending app rather than the
+    /// current quota: the gateway treats a title as an identity, and a widget
+    /// that renamed itself whenever the user switched provider would be
+    /// unrecognizable in the phone's widget picker.
+    static let defaultTitle = "Claude Usage"
+
+    private let title: String
+
+    init(title: String = NotifyPayloadBuilder.defaultTitle) {
+        self.title = title
+    }
+
+    func payload(
+        readings: [NotifyQuotaReading],
+        gaugeSelection: NotifyGaugeSelection = .automatic,
+        includesTile: Bool = true,
+        includesGauge: Bool = true,
+        includesScreenTile: Bool = true,
+        now: Date = Date()
+    ) -> NotifyPayload {
+        let ordered = Self.ordered(readings)
+        guard let headline = ordered.first else { return .empty }
+
+        // The Live Activity and the Home Screen tile are built once and shared.
+        // The gateway takes the same body on both routes, so building them twice
+        // could only produce two things that were supposed to be identical and
+        // one day were not.
+        let tile = (includesTile || includesScreenTile)
+            ? self.tile(ordered: ordered, headline: headline, now: now)
+            : nil
+
+        return NotifyPayload(
+            tile: includesTile ? tile : nil,
+            gauge: includesGauge
+                ? gauge(ordered: ordered, headline: headline, selection: gaugeSelection, now: now)
+                : nil,
+            screenTile: includesScreenTile ? tile : nil
+        )
+    }
+
+    // MARK: - Ordering
+
+    /// Worst first, and fully deterministic: two payloads built from the same
+    /// readings must compare equal, or the driver would republish forever.
+    static func ordered(_ readings: [NotifyQuotaReading]) -> [NotifyQuotaReading] {
+        readings.sorted { left, right in
+            let leftStatus = left.quota.status
+            let rightStatus = right.quota.status
+            if leftStatus != rightStatus { return leftStatus > rightStatus }
+            if left.quota.sortablePercentRemaining != right.quota.sortablePercentRemaining {
+                return left.quota.sortablePercentRemaining < right.quota.sortablePercentRemaining
+            }
+            if left.providerName != right.providerName { return left.providerName < right.providerName }
+            if left.quota.key != right.quota.key { return left.quota.key < right.quota.key }
+            // The last tie break, and the one that makes the comparator total.
+            // Display names are not unique, and Swift's sort is not stable, so
+            // without this two readings that tie on everything else could come
+            // back in either order. The payload would then differ between builds
+            // of the same state and the driver would republish for nothing.
+            return left.providerId < right.providerId
+        }
+    }
+
+    // MARK: - Tile
+
+    private func tile(
+        ordered: [NotifyQuotaReading],
+        headline: NotifyQuotaReading,
+        now: Date
+    ) -> NotifyTile? {
+        let omitsProviderName = Set(ordered.map { $0.providerId }).count == 1
+        let metrics = ordered
+            .prefix(NotifyLimits.metricCount)
+            .compactMap { reading in
+                NotifyMetric(
+                    label: Self.label(for: reading, omittingProviderName: omitsProviderName),
+                    value: Self.headlineValue(for: reading.quota),
+                    unit: Self.unit(for: reading.quota),
+                    tintHex: reading.quota.status.notifyTintHex
+                )
+            }
+
+        return NotifyTile(
+            title: title,
+            body: Self.summary(for: headline, now: now),
+            symbolName: NotifySymbol.quota,
+            tintHex: headline.quota.status.notifyTintHex,
+            progress: Self.progress(for: ordered),
+            trailing: headline.quota.compactResetTime(now: now),
+            metrics: metrics
+        )
+    }
+
+    // MARK: - Gauge
+
+    private func gauge(
+        ordered: [NotifyQuotaReading],
+        headline: NotifyQuotaReading,
+        selection: NotifyGaugeSelection,
+        now: Date
+    ) -> NotifyGauge? {
+        let shown = Self.selected(from: ordered, selection: selection) ?? headline
+
+        return NotifyGauge(
+            title: title,
+            value: Self.headlineValue(for: shown.quota),
+            unit: Self.unit(for: shown.quota),
+            detail: Self.gaugeDetail(for: shown, now: now),
+            symbolName: NotifySymbol.quota,
+            tintHex: shown.quota.status.notifyTintHex,
+            progress: shown.quota.percentRemaining
+        )
+    }
+
+    /// The reading the user asked the gauge to show, or nil when the selection
+    /// is automatic or names a window that is no longer reporting.
+    static func selected(
+        from readings: [NotifyQuotaReading],
+        selection: NotifyGaugeSelection
+    ) -> NotifyQuotaReading? {
+        guard !selection.isAutomatic else { return nil }
+        return readings.first {
+            $0.providerId == selection.providerId && $0.quota.key == selection.quotaKey
+        }
+    }
+
+    // MARK: - Words and numbers
+
+    /// "Claude 5h", or just "5h" when the tile only covers one provider.
+    static func label(for reading: NotifyQuotaReading, omittingProviderName: Bool) -> String {
+        guard !omittingProviderName else { return reading.quota.label }
+        return "\(reading.providerName) \(reading.quota.label)"
+    }
+
+    /// A percentage as a bare integer, or the formatted balance for a quota
+    /// measured in money rather than percent.
+    static func headlineValue(for quota: NotifyQuota) -> String {
+        if let balance = quota.formattedDollarRemaining { return balance }
+        return "\(Int((quota.percentRemaining ?? 0).rounded()))"
+    }
+
+    static func unit(for quota: NotifyQuota) -> String? {
+        quota.isDollarBased ? nil : "%"
+    }
+
+    /// "Claude 5h, 42% left, resets in 2:14". The tile's body line, which the
+    /// gateway shows only when there are no metrics to put in its place, so it
+    /// has to carry the number itself.
+    static func summary(for reading: NotifyQuotaReading, now: Date) -> String {
+        var parts = ["\(reading.providerName) \(reading.quota.label)"]
+
+        if let balance = reading.quota.formattedDollarRemaining {
+            parts.append("notify.summary.balance_left".localized(with: balance))
+        } else {
+            let percent = Int((reading.quota.percentRemaining ?? 0).rounded())
+            parts.append("notify.summary.percent_left".localized(with: percent))
+        }
+
+        if let resets = reading.quota.compactResetTime(now: now) {
+            parts.append(
+                resets == "soon"
+                    ? "notify.summary.resets_soon".localized
+                    : "notify.summary.resets_in".localized(with: resets)
+            )
+        }
+
+        return parts.joined(separator: ", ")
+    }
+
+    /// "Claude 5h, resets in 2:14". The widget's quieter line, which sits next
+    /// to a headline value that already shows the percentage, so repeating it
+    /// here would waste the one short line the widget has.
+    static func gaugeDetail(for reading: NotifyQuotaReading, now: Date) -> String {
+        var parts = ["\(reading.providerName) \(reading.quota.label)"]
+
+        if let resets = reading.quota.compactResetTime(now: now) {
+            parts.append(
+                resets == "soon"
+                    ? "notify.summary.resets_soon".localized
+                    : "notify.summary.resets_in".localized(with: resets)
+            )
+        }
+
+        return parts.joined(separator: ", ")
+    }
+
+    /// The bar on the tile. Money-based quotas have no percentage to draw, so
+    /// the bar falls through to the worst quota that does have one rather than
+    /// disappearing whenever a credit balance happens to be the headline.
+    static func progress(for ordered: [NotifyQuotaReading]) -> Double? {
+        ordered.first { $0.quota.percentRemaining != nil }?.quota.percentRemaining
+    }
+}

--- a/Claude Usage/Shared/Notify/NotifyPublishDriver.swift
+++ b/Claude Usage/Shared/Notify/NotifyPublishDriver.swift
@@ -1,0 +1,732 @@
+//
+//  NotifyPublishDriver.swift
+//  Claude Usage
+//
+//  Keeps a linked Notify! device in sync with the active profile's usage.
+//
+
+import Combine
+import Foundation
+
+/// Keeps a linked Notify! device in sync with the active profile's usage.
+///
+/// Mirrors `NotchHUDController`: a singleton the app delegate brings up and
+/// down with a setting, holding a Combine subscription on the state it renders
+/// and a timer for the changes that happen on a clock rather than on state.
+/// SwiftUI is not involved, because the surface being driven is on the user's
+/// phone and has no view here to invalidate.
+///
+/// Deliberately free of judgement. Everything about what to show and when to
+/// send it lives in `NotifyPayloadBuilder` and `NotifyPublishGate`, which are
+/// pure and tested; anything decided here would be decided untested. This
+/// driver only gathers state, asks those two, and performs the writes the
+/// answer implies.
+@MainActor
+final class NotifyPublishDriver {
+    static let shared = NotifyPublishDriver()
+
+    private let settings: NotifySettingsStore
+    private let publisher: NotifyPublishing
+    private let builder: NotifyPayloadBuilder
+    private let gate: NotifyPublishGate
+
+    private var cancellables: Set<AnyCancellable> = []
+    private var settingsObserver: NSObjectProtocol?
+
+    /// Offers the current payload to the gate on a clock. See `startTick` for
+    /// why state changes alone are not enough.
+    private var tickTimer: Timer?
+
+    /// Whether `start()` has run. Kept separately from the timer so a stop
+    /// followed by a start cannot leave half of the subscriptions live.
+    private var isRunning = false
+
+    /// The publish in flight. Exactly one at a time: two overlapping writes to
+    /// the same tile can land out of order, which leaves an older reading
+    /// standing on the Lock Screen with nothing to correct it.
+    ///
+    /// A publish already running is never cancelled to make room for a newer
+    /// one. Cancelling a start mid-flight is the one way this driver could
+    /// leave two tiles on a phone: the gateway may already have created the
+    /// tile, and losing the activity id it was about to return means the next
+    /// start opens a second one beside it. A skipped payload costs nothing,
+    /// because the tick re-offers it within the minute.
+    private var publishTask: Task<String?, Never>?
+
+    /// What the phone is believed to be showing, and when each surface last
+    /// received a write. The gate needs both to decide anything.
+    private var record: NotifyPublishRecord?
+
+    /// While set, tile writes are skipped: the gateway is in push to start
+    /// backoff and every attempt inside the wait lengthens it.
+    private var tileSuppressedUntil: Date?
+
+    /// While set, Home Screen tile writes are skipped: the gateway has that
+    /// surface switched off server side. Separate from the tile's wait because
+    /// the two mean opposite things. Backoff is the gateway asking us to stop
+    /// doing something; the kill switch is a feature Notify! has not started
+    /// serving yet, and nothing on this Mac shortens it.
+    private var screenTileSuppressedUntil: Date?
+
+    /// How often the payload is re-offered to the gate. A minute is the tile's
+    /// own minimum interval, so this is the finest cadence that can ever change
+    /// an answer.
+    private static let tickInterval: TimeInterval = 60
+
+    /// How long the Home Screen tile goes quiet after the gateway says it is
+    /// not serving that surface. Deliberately hours: the switch is thrown by
+    /// Notify! on Notify!'s own schedule, so asking again on the next tick is a
+    /// poll against a decision that will not have moved, once a minute forever.
+    private static let switchedOffSuppression: TimeInterval = 6 * 60 * 60
+
+    /// Everything this driver leans on, supplied explicitly.
+    ///
+    /// None of these are parameter defaults, which is deliberate. A default
+    /// argument expression is evaluated in a nonisolated context, and this
+    /// target builds with `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`, so every
+    /// one of these values is main-actor isolated and naming it as a default
+    /// warns at the declaration. The convenience initializer below supplies
+    /// them from a main-actor body instead, where reaching them is ordinary.
+    init(
+        settings: NotifySettingsStore,
+        publisher: NotifyPublishing,
+        builder: NotifyPayloadBuilder,
+        gate: NotifyPublishGate
+    ) {
+        self.settings = settings
+        self.publisher = publisher
+        self.builder = builder
+        self.gate = gate
+    }
+
+    /// The driver as the app runs it. `publisher` is the one seam a test needs,
+    /// and nil rather than a real default because nil is a literal and costs no
+    /// isolation to write down.
+    convenience init(publisher: NotifyPublishing? = nil) {
+        self.init(
+            settings: .shared,
+            publisher: publisher ?? NotifyGatewayClient(),
+            builder: NotifyPayloadBuilder(),
+            gate: NotifyPublishGate()
+        )
+    }
+
+    // MARK: - Lifecycle
+
+    /// Starts publishing. Idempotent, so the app delegate can call it from the
+    /// settings observer without checking whether it is already up.
+    func start() {
+        guard !isRunning else { return }
+        isRunning = true
+
+        LoggingService.shared.logInfo("Notify!: publishing on")
+
+        // Usage lands on the active profile, and `activeProfile` is republished
+        // every time a refresh saves one, so this fires on exactly the events
+        // that can change what the phone should show. Switching profile fires
+        // it too, which is right: the phone follows the profile the Mac is on.
+        ProfileManager.shared.$activeProfile
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                guard let self else { return }
+                self.schedule(payload: self.currentPayload())
+            }
+            .store(in: &cancellables)
+
+        // Credentials, the surface switches and the surface handles all live
+        // outside the profile, so a save in the pane changes nothing the
+        // subscription above can see. The pane posts instead.
+        if settingsObserver == nil {
+            settingsObserver = NotificationCenter.default.addObserver(
+                forName: .notifySettingsChanged, object: nil, queue: .main
+            ) { _ in
+                Task { @MainActor in
+                    _ = await NotifyPublishDriver.shared.publishNow()
+                }
+            }
+        }
+
+        startTick()
+        schedule(payload: currentPayload())
+    }
+
+    /// Stops publishing and releases everything held.
+    ///
+    /// Nothing is torn down on the device. Ending the tile and deleting the
+    /// widgets would need a network call at the exact moment the user said
+    /// stop, and would fail silently when they are offline; leaving the last
+    /// reading standing is the honest outcome of "stop sending", and the pane
+    /// offers an explicit way to remove it.
+    func stop() {
+        guard isRunning else { return }
+        isRunning = false
+
+        LoggingService.shared.logInfo("Notify!: publishing off, leaving the last published state on the device")
+
+        cancellables.removeAll()
+        stopTick()
+        publishTask?.cancel()
+        publishTask = nil
+
+        if let settingsObserver {
+            NotificationCenter.default.removeObserver(settingsObserver)
+            self.settingsObserver = nil
+        }
+    }
+
+    // MARK: - Forced publish
+
+    /// Publishes the current payload whether the gate would have allowed it or
+    /// not, for the moment the user saves new credentials or presses publish in
+    /// the pane. Waiting a quarter of an hour to find out whether a token works
+    /// is not an answer.
+    ///
+    /// This is the only forced path, and the settings pane goes through it
+    /// rather than opening a second one of its own. Two publishers writing the
+    /// same handles is exactly how a phone ends up with two Live Activities:
+    /// both read a nil activity id, both start a tile, and only one of the two
+    /// ids can be stored.
+    ///
+    /// - Returns: nil when everything the payload asked for was written, or a
+    ///   message fit to show the user when it was not.
+    @discardableResult
+    func publishNow() async -> String? {
+        guard settings.isEnabled() else {
+            return "notify.status.switched_off".localized
+        }
+
+        // Said before the payload is built, because an empty payload cannot
+        // tell these two apart afterwards: every surface switched off and no
+        // usage reported yet produce exactly the same nothing, and blaming the
+        // providers for a switch the user turned off themselves is the more
+        // annoying of the two wrong answers.
+        guard settings.isLiveActivityEnabled()
+            || settings.isWidgetEnabled()
+            || settings.isScreenWidgetEnabled() else {
+            return "notify.status.all_surfaces_off".localized
+        }
+
+        // Let any publish already running finish first, rather than cancelling
+        // it. A cancelled start may already have created a tile whose id is then
+        // lost, and the next start would put a second one beside it.
+        while let inFlight = publishTask {
+            _ = await inFlight.value
+        }
+
+        // Clearing the record is what forces the write: the gate holds a
+        // surface back on elapsed time since its last write, and with nothing
+        // recorded every surface the payload carries is due. The gateway's own
+        // backoff is left in place, since ignoring that earns a longer one.
+        record = nil
+
+        // The background tick stays quiet about a device that shows no surface,
+        // because saying so once a minute forever is noise. A forced publish is
+        // the opposite case: somebody asked for this one, now, and is owed the
+        // reason it cannot happen rather than a cheerful nil.
+        if let link = settings.deviceLink(), !link.kind.supportsAnySurface {
+            return link.kind.widgetUnsupportedReason ?? link.kind.liveActivityUnsupportedReason
+        }
+
+        let now = Date()
+        let payload = currentPayload(now: now)
+        guard !payload.isEmpty else {
+            return "notify.status.no_usage_yet".localized
+        }
+
+        let decision = withoutSuppressedSurfaces(gate.decide(payload: payload, since: nil, now: now), at: now)
+        guard !decision.publishesNothing else {
+            // Every surface the payload carried is inside a wait the gateway
+            // asked for, and the two waits are different news. A backoff is the
+            // app being told to slow down, which the user can sometimes clear
+            // from their phone; the kill switch is a surface Notify! has not
+            // started serving, where waiting is the only move either of us has.
+            // The backoff is named first because it is the one with a remedy.
+            if tileSuppressedUntil != nil {
+                return "notify.status.holding_off".localized
+            }
+            return "notify.status.home_screen_not_served".localized
+        }
+
+        return await startPublish(payload: payload, decision: decision, at: now).value
+    }
+
+    // MARK: - Building
+
+    /// Reads the active profile's usage and asks the builder for a payload.
+    ///
+    /// The active profile only, which is the whole multi-profile story: the
+    /// phone shows what the menu bar shows. Merging every profile into one tile
+    /// would need the six metric slots to cover several accounts, and a phone
+    /// that disagreed with the Mac is worse than one that shows less.
+    private func currentPayload(now: Date = Date()) -> NotifyPayload {
+        guard let profile = ProfileManager.shared.activeProfile,
+              let usage = profile.claudeUsage else {
+            return .empty
+        }
+
+        let readings = NotifyUsageReadings.readings(
+            from: usage,
+            provider: profile.provider,
+            now: now
+        )
+
+        return builder.payload(
+            readings: readings,
+            gaugeSelection: settings.gaugeSelection(),
+            includesTile: settings.isLiveActivityEnabled(),
+            includesGauge: settings.isWidgetEnabled(),
+            includesScreenTile: settings.isScreenWidgetEnabled(),
+            now: now
+        )
+    }
+
+    /// Asks the gate whether this payload is worth a request, and if so starts
+    /// one, unless a publish is already running.
+    ///
+    /// Synchronous on purpose: it is called from a Combine sink and from a
+    /// timer, neither of which can await, and the decision itself is pure.
+    private func schedule(payload: NotifyPayload) {
+        guard isRunning, !payload.isEmpty else { return }
+
+        let now = Date()
+        let decision = withoutSuppressedSurfaces(gate.decide(payload: payload, since: record, now: now), at: now)
+        guard !decision.publishesNothing else { return }
+        guard publishTask == nil else { return }
+
+        _ = startPublish(payload: payload, decision: decision, at: now)
+    }
+
+    /// Runs one publish as the single in-flight task, and hands the task back so
+    /// a caller that wants the outcome can await it.
+    private func startPublish(
+        payload: NotifyPayload,
+        decision: NotifyPublishDecision,
+        at now: Date
+    ) -> Task<String?, Never> {
+        let task = Task { @MainActor [weak self] in
+            let message = await self?.publish(payload: payload, decision: decision, at: now)
+            self?.publishTask = nil
+            return message ?? nil
+        }
+        publishTask = task
+        return task
+    }
+
+    // MARK: - Tick
+
+    /// Re-offers the payload to the gate on a clock.
+    ///
+    /// Both of the gate's time based rules are unreachable without this. A
+    /// change it suppressed for arriving inside a surface's minimum interval
+    /// has to be offered again once that interval has passed, and the tile has
+    /// to be re-sent every ninety minutes or the gateway's two hour abandonment
+    /// reaper ends it, on the grounds that a frozen percentage is worse than no
+    /// tile. Nothing in published state fires on the mere passage of time.
+    private func startTick() {
+        guard tickTimer == nil else { return }
+
+        let timer = Timer(timeInterval: Self.tickInterval, repeats: true) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                self.schedule(payload: self.currentPayload())
+            }
+        }
+        // `.common` rather than the default mode: while a menu tracking loop is
+        // up the default mode stops firing, and the popover being open is
+        // exactly when the user is watching their usage move.
+        RunLoop.main.add(timer, forMode: .common)
+        tickTimer = timer
+    }
+
+    private func stopTick() {
+        tickTimer?.invalidate()
+        tickTimer = nil
+    }
+
+    // MARK: - Narrowing
+
+    /// Drops the surfaces sitting inside a wait the gateway asked for, and
+    /// forgets each wait once it has passed.
+    ///
+    /// The two waits are held apart on purpose. The tile's is push to start
+    /// backoff, where every attempt inside it lengthens the wait; the Home
+    /// Screen tile's is a server side kill switch, where nothing is wrong and
+    /// there is simply nothing serving that route yet. Neither is evidence
+    /// about the other, so neither may silence the other, and the gauge is a
+    /// poll the gateway rations not at all.
+    private func withoutSuppressedSurfaces(
+        _ decision: NotifyPublishDecision,
+        at now: Date
+    ) -> NotifyPublishDecision {
+        if let tileSuppressedUntil, now >= tileSuppressedUntil {
+            self.tileSuppressedUntil = nil
+        }
+        if let screenTileSuppressedUntil, now >= screenTileSuppressedUntil {
+            self.screenTileSuppressedUntil = nil
+        }
+
+        return NotifyPublishDecision(
+            publishesTile: decision.publishesTile && tileSuppressedUntil == nil,
+            publishesGauge: decision.publishesGauge,
+            publishesScreenTile: decision.publishesScreenTile && screenTileSuppressedUntil == nil
+        )
+    }
+
+    /// Drops whichever surfaces the linked device could never show.
+    ///
+    /// A Notify! id says what it is, and the three surfaces answer to it
+    /// separately. A `GRP`, `MC` or `WB` id cannot show a Live Activity, so a
+    /// tile aimed at one is a 400 waiting to happen. Only a group can keep
+    /// neither widget, being a fan-out target rather than a device with a
+    /// widget list of its own. None of those requests is worth making.
+    ///
+    /// This is the one narrowing the gate cannot do for itself. The gate is
+    /// pure and the payload knows nothing about where it is going; the link is
+    /// the only thing that carries the destination, and the driver is the only
+    /// place holding one.
+    private func withoutUnsupportedSurfaces(
+        _ decision: NotifyPublishDecision,
+        for link: NotifyDeviceLink
+    ) -> NotifyPublishDecision {
+        NotifyPublishDecision(
+            publishesTile: decision.publishesTile && link.supportsLiveActivity,
+            publishesGauge: decision.publishesGauge && link.supportsWidget,
+            publishesScreenTile: decision.publishesScreenTile && link.supportsScreenWidget
+        )
+    }
+
+    // MARK: - Publishing
+
+    /// Which surface a write was for. Each is addressed by its own handle and
+    /// fails for its own reasons, so every reaction to a failure has to know
+    /// which one it is reacting to.
+    private enum Surface {
+        case tile
+        case gauge
+        case screenTile
+
+        var label: String {
+            switch self {
+            case .tile: return "tile"
+            case .gauge: return "Lock Screen widget"
+            case .screenTile: return "Home Screen widget"
+            }
+        }
+    }
+
+    /// - Returns: nil when every surface the decision named was written, or the
+    ///   first failure as a message fit to show the user.
+    private func publish(
+        payload: NotifyPayload,
+        decision: NotifyPublishDecision,
+        at now: Date
+    ) async -> String? {
+        guard let link = settings.deviceLink() else {
+            // No device linked is the state the feature ships in, not a failure,
+            // so it stays out of the file log.
+            LoggingService.shared.logDebug("Notify!: publish skipped, no device linked")
+            return NotifyPublishError.notLinked.errorDescription
+        }
+
+        // Now that there is a link, the decision can be narrowed to what this
+        // particular device can actually show.
+        let supported = withoutUnsupportedSurfaces(decision, for: link)
+        guard !supported.publishesNothing else {
+            // Debug only, and no message, for the same reason as the unlinked
+            // case above. A Mac, a browser or a group takes notifications and
+            // nothing else, which is a fact about the user's setup rather than
+            // anything going wrong, and the tick would otherwise write the same
+            // sentence into the log file every minute and hand the pane a
+            // failure to show. The place to explain a device's limits is where
+            // the user pastes the link, not once a minute forever.
+            LoggingService.shared.logDebug(
+                "Notify!: publish skipped, the linked \(link.kind.displayName) shows none of these surfaces"
+            )
+            return nil
+        }
+
+        // Each surface is written independently. A tile the device refuses to
+        // start must not cost the user their widgets, which poll happily on a
+        // device that cannot do Live Activities at all.
+        var sentTile = false
+        var sentGauge = false
+        var sentScreenTile = false
+        var failures: [String] = []
+
+        if supported.publishesTile, let tile = payload.tile {
+            if let failure = await sendTile(tile, link: link) {
+                failures.append(failure)
+            } else {
+                sentTile = true
+            }
+        }
+        if supported.publishesGauge, let gauge = payload.gauge {
+            if let failure = await sendGauge(gauge, link: link) {
+                failures.append(failure)
+            } else {
+                sentGauge = true
+            }
+        }
+        // Last, and with the same content the Live Activity just carried. The
+        // Home Screen route takes the tile body unchanged, which is why the
+        // builder hands out one value for both rather than two that agree.
+        if supported.publishesScreenTile, let screenTile = payload.screenTile {
+            if let failure = await sendScreenTile(screenTile, link: link) {
+                failures.append(failure)
+            } else {
+                sentScreenTile = true
+            }
+        }
+
+        remember(
+            payload: payload,
+            sentTile: sentTile,
+            sentGauge: sentGauge,
+            sentScreenTile: sentScreenTile,
+            at: now
+        )
+        return failures.first
+    }
+
+    /// - Returns: nil when the tile was written, or the failure as a message.
+    private func sendTile(_ tile: NotifyTile, link: NotifyDeviceLink) async -> String? {
+        do {
+            let activityId = try await publisher.publishTile(
+                tile,
+                link: link,
+                activityId: settings.activityId()
+            )
+            store(activityId: activityId, for: link)
+            return nil
+        } catch NotifyPublishError.tileGone {
+            // The handle names a tile the user dismissed, which can never be
+            // updated again. Forget it and start one fresh, exactly once: a
+            // retry loop here is a retry loop against the gateway.
+            LoggingService.shared.logInfo("Notify!: the tile was dismissed on the device, starting a new one")
+            settings.setActivityId(nil)
+            return await restartTile(tile, link: link)
+        } catch {
+            report(error, surface: .tile)
+            return message(for: error)
+        }
+    }
+
+    private func restartTile(_ tile: NotifyTile, link: NotifyDeviceLink) async -> String? {
+        do {
+            let activityId = try await publisher.publishTile(tile, link: link, activityId: nil)
+            store(activityId: activityId, for: link)
+            return nil
+        } catch {
+            report(error, surface: .tile)
+            return message(for: error)
+        }
+    }
+
+    /// - Returns: nil when the Lock Screen widget was written, or the failure.
+    private func sendGauge(_ gauge: NotifyGauge, link: NotifyDeviceLink) async -> String? {
+        do {
+            let widgetId = try await publisher.publishGauge(
+                gauge,
+                link: link,
+                widgetId: settings.widgetId()
+            )
+            store(widgetId: widgetId, for: link)
+            return nil
+        } catch {
+            report(error, surface: .gauge)
+            return message(for: error)
+        }
+    }
+
+    /// - Returns: nil when the Home Screen widget was written, or the failure.
+    private func sendScreenTile(_ tile: NotifyTile, link: NotifyDeviceLink) async -> String? {
+        do {
+            let screenWidgetId = try await publisher.publishScreenTile(
+                tile,
+                link: link,
+                screenWidgetId: settings.screenWidgetId()
+            )
+            store(screenWidgetId: screenWidgetId, for: link)
+            return nil
+        } catch {
+            report(error, surface: .screenTile)
+            return message(for: error)
+        }
+    }
+
+    // MARK: - Handles
+
+    /// Stores a handle only while it still belongs to the saved link.
+    ///
+    /// A publish holds the link it started with, and a request can be in flight
+    /// for as long as the timeout allows. The user can remove or replace the
+    /// link in that window, and the reply, when it lands, carries a handle for a
+    /// device that is no longer the one on file. Writing it would leave the next
+    /// link inheriting a stranger's tile id, which costs a wasted request and a
+    /// 403 before it heals. Comparing first is cheaper than healing.
+    private func store(activityId: String, for link: NotifyDeviceLink) {
+        guard settings.deviceLink() == link else {
+            LoggingService.shared.logInfo("Notify!: the link changed while publishing, discarding the tile handle it returned")
+            return
+        }
+        settings.setActivityId(activityId)
+    }
+
+    private func store(widgetId: String, for link: NotifyDeviceLink) {
+        guard settings.deviceLink() == link else {
+            LoggingService.shared.logInfo("Notify!: the link changed while publishing, discarding the widget handle it returned")
+            return
+        }
+        settings.setWidgetId(widgetId)
+    }
+
+    private func store(screenWidgetId: String, for link: NotifyDeviceLink) {
+        guard settings.deviceLink() == link else {
+            LoggingService.shared.logInfo(
+                "Notify!: the link changed while publishing, discarding the Home Screen widget handle it returned"
+            )
+            return
+        }
+        settings.setScreenWidgetId(screenWidgetId)
+    }
+
+    /// Drops the stored handle for one surface, so the next publish creates its
+    /// own replacement rather than writing to something that is gone.
+    private func forget(_ surface: Surface) {
+        switch surface {
+        case .tile: settings.setActivityId(nil)
+        case .gauge: settings.setWidgetId(nil)
+        case .screenTile: settings.setScreenWidgetId(nil)
+        }
+    }
+
+    // MARK: - Bookkeeping
+
+    /// Every `NotifyPublishError` already carries a sentence written for a
+    /// person, which is the whole reason it is its own error type.
+    private func message(for error: Error) -> String {
+        (error as? NotifyPublishError)?.errorDescription ?? error.localizedDescription
+    }
+
+    /// Records what the phone now shows, per surface.
+    ///
+    /// What was actually sent, not what was decided: a surface that failed must
+    /// not be filed as delivered. `NotifyPublishRecord.updated` does the per
+    /// surface merge itself, so a surface that was held back or that failed
+    /// keeps the content it is really showing.
+    private func remember(
+        payload: NotifyPayload,
+        sentTile: Bool,
+        sentGauge: Bool,
+        sentScreenTile: Bool,
+        at now: Date
+    ) {
+        guard sentTile || sentGauge || sentScreenTile else { return }
+
+        let sent = NotifyPublishDecision(
+            publishesTile: sentTile,
+            publishesGauge: sentGauge,
+            publishesScreenTile: sentScreenTile
+        )
+        record = (record ?? NotifyPublishRecord(payload: .empty))
+            .updated(with: payload, decision: sent, at: now)
+    }
+
+    /// Turns a failed write into whatever state change it implies, and one log
+    /// line. Never a device id and never a token: both are secrets, and the
+    /// gateway answers a bad token and an unknown device identically anyway, so
+    /// naming the id would not help anyone read the log.
+    ///
+    /// Every reaction is scoped to the surface that actually failed. The gateway
+    /// answers a missing token, a wrong token, an unknown id and somebody else's
+    /// id with one identical 403, so a 403 is not evidence the credentials are
+    /// bad. The likeliest cause by far is the ordinary one: the user deleted
+    /// that one tile or that one widget in the Notify! app, and the handle now
+    /// names something that is gone.
+    private func report(_ error: Error, surface: Surface) {
+        guard let error = error as? NotifyPublishError else {
+            // An error from outside this feature's own vocabulary, so its text
+            // is not known to be free of a URL, and every URL here carries the
+            // device token. The type is enough to find the cause and cannot
+            // quote anything.
+            LoggingService.shared.logError("Notify!: \(surface.label) publish failed: \(type(of: error))")
+            return
+        }
+
+        switch error {
+        case .rejectedCredentials:
+            // Forget only the handle that was refused, and let the next publish
+            // create a replacement for it. Clearing the other surfaces' handles
+            // as well would abandon a tile or widget that is alive and being
+            // written to perfectly happily, and the next write, having no handle
+            // for it, would create a second one beside it.
+            forget(surface)
+            LoggingService.shared.logError(
+                "Notify!: refused the stored \(surface.label), forgetting its handle so the next publish creates a new one"
+            )
+
+        case .backoff(let retryAfter, let openingTheAppMayHelp):
+            // Push to start backoff is a Live Activity rule. Both widgets are
+            // polls the gateway does not ration, so a tile's wait must never
+            // silence either of them.
+            guard surface == .tile else {
+                LoggingService.shared.logWarning(
+                    "Notify!: the \(surface.label) publish was rate limited, retrying on a later tick"
+                )
+                return
+            }
+            tileSuppressedUntil = Date().addingTimeInterval(retryAfter)
+            let hint = openingTheAppMayHelp ? ", opening the Notify! app on the device may clear it sooner" : ""
+            LoggingService.shared.logWarning(
+                "Notify!: holding off Live Activity starts for \(Int(retryAfter.rounded()))s\(hint)"
+            )
+
+        case .surfaceSwitchedOff:
+            // Not a failure, which is why it is the only branch here that logs
+            // at info. Home Screen widgets ship behind a server side kill
+            // switch, so a build that can write them meets a gateway that is not
+            // serving them yet, and the remedy is entirely Notify!'s. Backing
+            // off for hours rather than retrying every tick, because nothing
+            // this app does moves that switch and asking once a minute forever
+            // would fill the log with a fact that has not changed.
+            guard surface == .screenTile else {
+                // The 503 belongs to the Home Screen route. Reaching here means
+                // the gateway switched off a surface this code did not expect to
+                // be switchable, so that write is skipped and offered again on a
+                // later tick, and the Home Screen tile's own pause is left alone.
+                LoggingService.shared.logInfo(
+                    "Notify!: the \(surface.label) is switched off at the moment, retrying on a later tick"
+                )
+                return
+            }
+            screenTileSuppressedUntil = Date().addingTimeInterval(Self.switchedOffSuppression)
+            LoggingService.shared.logInfo(
+                "Notify!: Home Screen widgets are not being served yet, pausing that surface for six hours"
+            )
+
+        case .deliveryUnconfirmed(let activityId):
+            // Apple never answered, so a tile may already exist. Keeping the id
+            // the gateway did hand back means the next update addresses that
+            // tile instead of starting a second one beside it.
+            if let activityId, !activityId.isEmpty {
+                settings.setActivityId(activityId)
+            }
+            LoggingService.shared.logWarning(
+                "Notify!: could not confirm the tile started, updating it on the next tick"
+            )
+
+        case .transportFailed:
+            // The one error whose text is not ours. It carries a URLError's
+            // localized description, which is free to quote the URL it failed
+            // on, and every URL in this feature has the device token in its
+            // query string. The client already refuses to write that down;
+            // logging it here through the error's description would put it in
+            // the same file by the back door. The pane still shows it, which is
+            // not written down.
+            LoggingService.shared.logError("Notify!: the \(surface.label) publish could not reach the gateway")
+
+        default:
+            LoggingService.shared.logError("Notify!: the \(surface.label) publish failed: \(error.localizedDescription)")
+        }
+    }
+}

--- a/Claude Usage/Shared/Notify/NotifyPublishError.swift
+++ b/Claude Usage/Shared/Notify/NotifyPublishError.swift
@@ -1,0 +1,121 @@
+//
+//  NotifyPublishError.swift
+//  Claude Usage
+//
+//  Why a publish to Notify! did not land, and the remedy each failure implies.
+//
+
+import Foundation
+
+/// Why a publish to Notify! did not land.
+///
+/// A dedicated type rather than an `AppError` case: every message here is shown
+/// in the Notify! pane, and half of them name an action only the user can take
+/// on their phone. `AppError` speaks about fetching usage from a provider,
+/// which is the opposite direction of travel.
+///
+/// The gateway answers a missing token, a wrong token, an unknown device and
+/// somebody else's device with one identical 403 so that it never confirms an
+/// id exists, so `rejectedCredentials` deliberately covers all four.
+enum NotifyPublishError: Error, Sendable, Equatable, LocalizedError {
+    /// No device id and token saved yet.
+    case notLinked
+
+    /// The gateway refused the credentials, or the device is not ours.
+    case rejectedCredentials
+
+    /// The device cannot show a Live Activity yet. Carries the gateway's own
+    /// explanation, which distinguishes "the app has never been opened" from
+    /// "Live Activities are switched off" from "several tiles are live".
+    case liveActivityUnavailable(String)
+
+    /// The tile was dismissed by the user or has already ended, so it can never
+    /// be updated again. The driver forgets the handle and starts a fresh tile.
+    case tileGone
+
+    /// Push to start backoff after tiles that Apple accepted but never
+    /// delivered. The ladder is 30 minutes after 2, 3 hours after 4, 6 hours
+    /// after 6, and it resets the moment a tile appears.
+    case backoff(retryAfter: TimeInterval, openingTheAppMayHelp: Bool)
+
+    /// The gateway named a field it would not accept, or a per device ceiling
+    /// was reached (5 live tiles, 10 widgets).
+    case invalidPayload(String)
+
+    /// A start where Apple never answered. A tile may exist, so the handle is
+    /// kept and polled rather than started again, which could leave two tiles.
+    case deliveryUnconfirmed(activityId: String?)
+
+    /// The request never completed.
+    case transportFailed(String)
+
+    /// The gateway has this surface switched off server side. Home Screen
+    /// widgets ship behind a kill switch, so a build that supports them can meet
+    /// a service that is not serving them yet. Reads and deletes stay open, only
+    /// creates and updates are refused, and the remedy is to wait rather than to
+    /// change anything.
+    case surfaceSwitchedOff(String)
+
+    case unexpectedStatus(Int)
+
+    case malformedResponse
+
+    var errorDescription: String? {
+        switch self {
+        case .notLinked:
+            return "notify.error.not_linked".localized
+        case .rejectedCredentials:
+            return "notify.error.rejected_credentials".localized
+        case .liveActivityUnavailable(let reason):
+            return reason.isEmpty ? "notify.error.live_activity_unavailable".localized : reason
+        case .tileGone:
+            return "notify.error.tile_gone".localized
+        case .backoff(let retryAfter, let openingTheAppMayHelp):
+            let wait = Self.minutes(retryAfter)
+            return openingTheAppMayHelp
+                ? "notify.error.backoff_open_app".localized(with: wait)
+                : "notify.error.backoff".localized(with: wait)
+        case .invalidPayload(let message):
+            return message.isEmpty ? "notify.error.invalid_payload".localized : message
+        case .deliveryUnconfirmed:
+            return "notify.error.delivery_unconfirmed".localized
+        case .transportFailed(let message):
+            return "notify.error.transport_failed".localized(with: message)
+        case .surfaceSwitchedOff(let message):
+            return message.isEmpty ? "notify.error.surface_switched_off".localized : message
+        case .unexpectedStatus(let code):
+            return "notify.error.unexpected_status".localized(with: code)
+        case .malformedResponse:
+            return "notify.error.malformed_response".localized
+        }
+    }
+
+    /// How long to wait before trying again, when waiting is the remedy.
+    var retryAfter: TimeInterval? {
+        switch self {
+        case .backoff(let retryAfter, _): return retryAfter
+        default: return nil
+        }
+    }
+
+    /// Whether retrying the same request unchanged could ever succeed. Used to
+    /// decide between backing off and giving up until something changes.
+    var isRetryable: Bool {
+        switch self {
+        case .transportFailed, .backoff, .deliveryUnconfirmed, .unexpectedStatus, .surfaceSwitchedOff:
+            return true
+        case .notLinked, .rejectedCredentials, .liveActivityUnavailable, .tileGone,
+             .invalidPayload, .malformedResponse:
+            return false
+        }
+    }
+
+    /// A wait as a phrase a person reads, for example "30 minutes" or "an hour".
+    static func minutes(_ interval: TimeInterval) -> String {
+        let minutes = Int((interval / 60).rounded(.up))
+        if minutes <= 1 { return "notify.wait.a_minute".localized }
+        if minutes < 60 { return "notify.wait.minutes".localized(with: minutes) }
+        let hours = Int((Double(minutes) / 60).rounded())
+        return hours == 1 ? "notify.wait.an_hour".localized : "notify.wait.hours".localized(with: hours)
+    }
+}

--- a/Claude Usage/Shared/Notify/NotifyPublishGate.swift
+++ b/Claude Usage/Shared/Notify/NotifyPublishGate.swift
@@ -1,0 +1,170 @@
+//
+//  NotifyPublishGate.swift
+//  Claude Usage
+//
+//  Decides when a payload is worth a request.
+//
+
+import Foundation
+
+/// What the last publish sent, and when each surface was last written.
+struct NotifyPublishRecord: Sendable, Equatable {
+    let payload: NotifyPayload
+    let tileAt: Date?
+    let gaugeAt: Date?
+    let screenTileAt: Date?
+
+    init(
+        payload: NotifyPayload,
+        tileAt: Date? = nil,
+        gaugeAt: Date? = nil,
+        screenTileAt: Date? = nil
+    ) {
+        self.payload = payload
+        self.tileAt = tileAt
+        self.gaugeAt = gaugeAt
+        self.screenTileAt = screenTileAt
+    }
+
+    /// The record after a publish, carrying forward both the timestamp and the
+    /// content of whichever surface was not written this time.
+    ///
+    /// Merging per surface rather than storing the payload wholesale is what
+    /// keeps a held back change from being lost. A tile-only publish that
+    /// recorded the whole payload would file the new gauge as already sent, and
+    /// the gate would then see no change when the gauge's own interval finally
+    /// came round, leaving a stale value on the phone until something else
+    /// happened to move it. The record has to remember what each surface is
+    /// actually showing, which is not the same as the last payload built.
+    func updated(with payload: NotifyPayload, decision: NotifyPublishDecision, at now: Date) -> NotifyPublishRecord {
+        NotifyPublishRecord(
+            payload: NotifyPayload(
+                tile: decision.publishesTile ? payload.tile : self.payload.tile,
+                gauge: decision.publishesGauge ? payload.gauge : self.payload.gauge,
+                screenTile: decision.publishesScreenTile ? payload.screenTile : self.payload.screenTile
+            ),
+            tileAt: decision.publishesTile ? now : tileAt,
+            gaugeAt: decision.publishesGauge ? now : gaugeAt,
+            screenTileAt: decision.publishesScreenTile ? now : screenTileAt
+        )
+    }
+}
+
+/// Which surfaces a publish should actually write.
+struct NotifyPublishDecision: Sendable, Equatable {
+    let publishesTile: Bool
+    let publishesGauge: Bool
+    let publishesScreenTile: Bool
+
+    init(
+        publishesTile: Bool,
+        publishesGauge: Bool,
+        publishesScreenTile: Bool = false
+    ) {
+        self.publishesTile = publishesTile
+        self.publishesGauge = publishesGauge
+        self.publishesScreenTile = publishesScreenTile
+    }
+
+    var publishesNothing: Bool {
+        !publishesTile && !publishesGauge && !publishesScreenTile
+    }
+
+    static let nothing = NotifyPublishDecision(
+        publishesTile: false,
+        publishesGauge: false,
+        publishesScreenTile: false
+    )
+}
+
+/// Decides when a payload is worth a request.
+///
+/// Quota numbers move on every refresh, and the reset countdown in the detail
+/// line moves every minute, so "publish whenever the payload differs" would
+/// mean a request per refresh forever. The gate adds two rules on top of that
+/// difference:
+///
+/// - a minimum gap per surface, because iOS redraws a widget roughly every
+///   fifteen minutes no matter how often the value is pushed, so pushing faster
+///   buys nothing;
+/// - a keep alive for the tile, because the gateway ends a progress-only Live
+///   Activity that has gone two hours without an update, on the grounds that a
+///   frozen percentage is worse than no tile at all. Republishing every ninety
+///   minutes keeps it alive with room to spare.
+///
+/// Pure and clock free: `now` is a parameter, so every rule is directly testable.
+struct NotifyPublishGate: Sendable {
+    /// The tile is a push, so it can afford to be prompt.
+    static let defaultTileInterval: TimeInterval = 60
+
+    /// The widget is a poll. iOS decides when it redraws, roughly every quarter
+    /// hour, so there is nothing to gain from writing it more often.
+    static let defaultGaugeInterval: TimeInterval = 15 * 60
+
+    /// The Home Screen tile is a poll like the gauge, on the same quarter hour.
+    static let defaultScreenTileInterval: TimeInterval = 15 * 60
+
+    /// Comfortably inside both deadlines it has to beat: the gateway ends a
+    /// progress-only Live Activity after two hours without an update, and a
+    /// screen widget's `staleAt` falls two hours after its last write, past
+    /// which the phone dims the tile and says how long ago it was current.
+    static let defaultKeepAliveInterval: TimeInterval = 90 * 60
+
+    private let tileInterval: TimeInterval
+    private let gaugeInterval: TimeInterval
+    private let screenTileInterval: TimeInterval
+    private let keepAliveInterval: TimeInterval
+
+    init(
+        tileInterval: TimeInterval = NotifyPublishGate.defaultTileInterval,
+        gaugeInterval: TimeInterval = NotifyPublishGate.defaultGaugeInterval,
+        screenTileInterval: TimeInterval = NotifyPublishGate.defaultScreenTileInterval,
+        keepAliveInterval: TimeInterval = NotifyPublishGate.defaultKeepAliveInterval
+    ) {
+        self.tileInterval = tileInterval
+        self.gaugeInterval = gaugeInterval
+        self.screenTileInterval = screenTileInterval
+        self.keepAliveInterval = keepAliveInterval
+    }
+
+    func decide(
+        payload: NotifyPayload,
+        since record: NotifyPublishRecord?,
+        now: Date
+    ) -> NotifyPublishDecision {
+        NotifyPublishDecision(
+            publishesTile: publishesTile(payload: payload, record: record, now: now),
+            publishesGauge: publishesGauge(payload: payload, record: record, now: now),
+            publishesScreenTile: publishesScreenTile(payload: payload, record: record, now: now)
+        )
+    }
+
+    private func publishesTile(payload: NotifyPayload, record: NotifyPublishRecord?, now: Date) -> Bool {
+        guard let tile = payload.tile else { return false }
+        guard let record, let lastAt = record.tileAt else { return true }
+
+        let elapsed = now.timeIntervalSince(lastAt)
+        if elapsed >= keepAliveInterval { return true }
+        return tile != record.payload.tile && elapsed >= tileInterval
+    }
+
+    /// The Home Screen tile takes the keep alive as well as its interval,
+    /// because its freshness deadline is a real one: two hours after the last
+    /// write the phone stops presenting the content as current and dims it.
+    private func publishesScreenTile(payload: NotifyPayload, record: NotifyPublishRecord?, now: Date) -> Bool {
+        guard let screenTile = payload.screenTile else { return false }
+        guard let record, let lastAt = record.screenTileAt else { return true }
+
+        let elapsed = now.timeIntervalSince(lastAt)
+        if elapsed >= keepAliveInterval { return true }
+        return screenTile != record.payload.screenTile && elapsed >= screenTileInterval
+    }
+
+    private func publishesGauge(payload: NotifyPayload, record: NotifyPublishRecord?, now: Date) -> Bool {
+        guard let gauge = payload.gauge else { return false }
+        guard let record, let lastAt = record.gaugeAt else { return true }
+
+        let elapsed = now.timeIntervalSince(lastAt)
+        return gauge != record.payload.gauge && elapsed >= gaugeInterval
+    }
+}

--- a/Claude Usage/Shared/Notify/NotifyPublishing.swift
+++ b/Claude Usage/Shared/Notify/NotifyPublishing.swift
@@ -1,0 +1,59 @@
+//
+//  NotifyPublishing.swift
+//  Claude Usage
+//
+//  What the app can ask of Notify!, in value types, with no idea HTTP exists.
+//
+
+import Foundation
+
+/// Publishing quota state to a linked Notify! device.
+///
+/// The abstract side of the feature: what the app can ask for, in plain value
+/// types. `NotifyGatewayClient` is the implementation, and it is the only file
+/// that knows about URLs. A protocol so tests can drive the driver with a stub
+/// and no network.
+///
+/// All three write methods take the handle of the thing they last wrote and
+/// return the handle to store next time. That is what keeps the app from
+/// touching a tile or widget the user created for something else: a nil handle
+/// means "create your own", and every later write addresses that one by id.
+protocol NotifyPublishing: Sendable {
+    /// Starts a Live Activity, or updates the one `activityId` names.
+    /// - Returns: the activity id to store for the next update.
+    func publishTile(
+        _ tile: NotifyTile,
+        link: NotifyDeviceLink,
+        activityId: String?
+    ) async throws -> String
+
+    /// Creates the Lock Screen widget, or updates the one `widgetId` names.
+    /// - Returns: the widget id to store for the next update.
+    func publishGauge(
+        _ gauge: NotifyGauge,
+        link: NotifyDeviceLink,
+        widgetId: String?
+    ) async throws -> String
+
+    /// Creates the Home Screen widget, or updates the one `screenWidgetId`
+    /// names.
+    ///
+    /// Takes a `NotifyTile` rather than a shape of its own: the gateway derives
+    /// this route's content contract from the Live Activity module, so the two
+    /// surfaces genuinely accept one body.
+    /// - Returns: the screen widget id to store for the next update.
+    func publishScreenTile(
+        _ tile: NotifyTile,
+        link: NotifyDeviceLink,
+        screenWidgetId: String?
+    ) async throws -> String
+
+    /// Ends the Live Activity, optionally leaving it on the Lock Screen for a
+    /// while so the final state can be read.
+    func endTile(link: NotifyDeviceLink, activityId: String, keepFor: TimeInterval) async throws
+
+    /// Checks a device id and token pair and describes the device it names.
+    /// The only user-triggered call, and rate limited to five a minute by the
+    /// gateway, so it belongs behind an explicit button and nothing else.
+    func deviceInfo(link: NotifyDeviceLink) async throws -> NotifyDeviceInfo
+}

--- a/Claude Usage/Shared/Notify/NotifyQuota.swift
+++ b/Claude Usage/Shared/Notify/NotifyQuota.swift
@@ -1,0 +1,172 @@
+//
+//  NotifyQuota.swift
+//  Claude Usage
+//
+//  One quota window, flattened into the shape the payload builder needs.
+//
+
+import Foundation
+
+/// How much attention a quota window needs.
+///
+/// Four levels rather than the app's three, because a depleted window deserves
+/// its own color on a Lock Screen: "you have run out" and "you are nearly out"
+/// are different messages, and on a ring a quarter of a degree apart they are
+/// otherwise indistinguishable. The first three thresholds are the same ones
+/// `UsageStatusCalculator` uses in remaining mode, so a window that reads
+/// critical in the menu bar reads critical on the phone.
+enum NotifyQuotaStatus: Int, Sendable, Comparable, CaseIterable {
+    case healthy = 0
+    case warning = 1
+    case critical = 2
+    case depleted = 3
+
+    static func < (lhs: NotifyQuotaStatus, rhs: NotifyQuotaStatus) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+
+    /// The status for a percentage of quota remaining.
+    static func forRemaining(_ percentRemaining: Double) -> NotifyQuotaStatus {
+        if percentRemaining <= 0 { return .depleted }
+        if percentRemaining < 10 { return .critical }
+        if percentRemaining < 30 { return .warning }
+        return .healthy
+    }
+}
+
+/// One quota window the app is currently reporting.
+///
+/// Deliberately a flat value rather than a view onto `ClaudeUsage`: the payload
+/// builder is pure and testable only if what it takes carries no behavior of
+/// its own. `NotifyUsageReadings` is the one place that knows how to turn a
+/// `ClaudeUsage` into these.
+///
+/// Percentages here are always **remaining**, not used. Every surface in this
+/// app reads that way, and a full bar meaning a full quota is the only
+/// intuitive mapping a gauge has.
+struct NotifyQuota: Sendable, Equatable {
+    /// Stable key for this window, used by the gauge selection so a user's
+    /// choice survives a restart. Never localized and never renamed.
+    let key: String
+
+    /// Short label for the window, for example "5h" or "Opus 7d".
+    let label: String
+
+    /// Percent of the window still available, 0 to 100. Nil for a quota
+    /// measured in money with no limit to divide by.
+    let percentRemaining: Double?
+
+    /// Money still available, for a credit balance or a spend allowance.
+    let dollarRemaining: Double?
+
+    /// ISO code for `dollarRemaining`, for example "USD".
+    let currencyCode: String?
+
+    /// When the window rolls over, when it rolls over at all. A credit balance
+    /// normally has no reset.
+    let resetsAt: Date?
+
+    init(
+        key: String,
+        label: String,
+        percentRemaining: Double? = nil,
+        dollarRemaining: Double? = nil,
+        currencyCode: String? = nil,
+        resetsAt: Date? = nil
+    ) {
+        self.key = key
+        self.label = label
+        self.percentRemaining = percentRemaining
+        self.dollarRemaining = dollarRemaining
+        self.currencyCode = currencyCode
+        self.resetsAt = resetsAt
+    }
+
+    /// Whether this window is measured in money rather than in percent. A
+    /// dollar quota has no ring to draw, which is why the tile's bar falls
+    /// through to the worst window that does have one.
+    var isDollarBased: Bool {
+        percentRemaining == nil && dollarRemaining != nil
+    }
+
+    /// How much attention this window needs.
+    ///
+    /// A money quota with no percentage has only one thing to go on: whether
+    /// there is anything left at all.
+    var status: NotifyQuotaStatus {
+        if let percentRemaining {
+            return .forRemaining(percentRemaining)
+        }
+        if let dollarRemaining {
+            return dollarRemaining > 0 ? .healthy : .depleted
+        }
+        return .healthy
+    }
+
+    /// Percent remaining for ordering, treating a money quota as full so a
+    /// healthy credit balance never sorts above a window that is actually low.
+    var sortablePercentRemaining: Double {
+        percentRemaining ?? 100
+    }
+
+    /// The formatted balance for a money quota, or nil when this window is
+    /// measured in percent.
+    var formattedDollarRemaining: String? {
+        guard let dollarRemaining, percentRemaining == nil else { return nil }
+        return Self.formatCurrency(dollarRemaining, code: currencyCode)
+    }
+
+    /// A compact countdown to the reset: "3d", "4:40", "12m", or "soon".
+    ///
+    /// Takes `now` rather than reading the clock so the payload it ends up in
+    /// is a pure function of its inputs, which is what makes the builder
+    /// testable and the publish gate's dedupe meaningful.
+    func compactResetTime(now: Date = Date()) -> String? {
+        guard let resetsAt else { return nil }
+        let seconds = Int(resetsAt.timeIntervalSince(now))
+        guard seconds > 0 else { return "soon" }
+        if seconds >= 86400 { return "\(seconds / 86400)d" }
+        if seconds >= 3600 { return String(format: "%d:%02d", seconds / 3600, (seconds % 3600) / 60) }
+        if seconds >= 60 { return "\(seconds / 60)m" }
+        return "soon"
+    }
+
+    /// Money as the widget wants it: short, and never more precise than it
+    /// needs to be. A whole balance drops its cents, because the widget has
+    /// forty characters and "$120" reads faster than "$120.00".
+    ///
+    /// Formatted in the user's own locale rather than a fixed one. The phone
+    /// only renders the string it is handed, so this Mac is the only place that
+    /// knows how the person reading it expects money to look.
+    static func formatCurrency(
+        _ amount: Double,
+        code: String?,
+        locale: Locale = .current
+    ) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.locale = locale
+        formatter.currencyCode = code ?? "USD"
+        let isWhole = amount == amount.rounded()
+        formatter.maximumFractionDigits = isWhole ? 0 : 2
+        formatter.minimumFractionDigits = isWhole ? 0 : 2
+        return formatter.string(from: NSNumber(value: amount)) ?? String(format: "%.2f", amount)
+    }
+}
+
+/// One provider's quota window, paired with the provider's display name.
+///
+/// The driver reads these off the active profile's usage; the payload builder
+/// needs the name for a metric label and must not reach back into the app's
+/// models to find one.
+struct NotifyQuotaReading: Sendable, Equatable {
+    let providerId: String
+    let providerName: String
+    let quota: NotifyQuota
+
+    init(providerId: String, providerName: String, quota: NotifyQuota) {
+        self.providerId = providerId
+        self.providerName = providerName
+        self.quota = quota
+    }
+}

--- a/Claude Usage/Shared/Notify/NotifySettingsStore.swift
+++ b/Claude Usage/Shared/Notify/NotifySettingsStore.swift
@@ -1,0 +1,289 @@
+//
+//  NotifySettingsStore.swift
+//  Claude Usage
+//
+//  Where the Notify! link, the surface switches and the surface handles live.
+//
+
+import Foundation
+
+/// Defaults for the Notify! integration.
+enum NotifyConstants {
+    /// Off until the user links a device. The feature sends data to a third
+    /// party service, so it can never be on by default.
+    static let defaultEnabled = false
+
+    /// Every surface is on once the feature itself is on: a user who linked a
+    /// device wants to see their quota, and each can be switched off alone.
+    static let defaultLiveActivityEnabled = true
+    static let defaultWidgetEnabled = true
+
+    /// The Home Screen widget ships behind a server side kill switch, so a
+    /// build that supports it can meet a gateway that is not serving it yet.
+    /// On by default anyway: a 503 is handled as "not yet" rather than as an
+    /// error, and leaving it off would mean nobody sees the surface on the day
+    /// it is switched on.
+    static let defaultScreenWidgetEnabled = true
+}
+
+/// Settings for publishing usage to a Notify! device.
+///
+/// Its own store rather than a corner of `SharedDataStore`, because Notify! is
+/// not somewhere the app reads usage from, it is somewhere the app writes to,
+/// and none of the provider vocabulary applies. The switches and the surface
+/// handles live in UserDefaults; the device token is a secret and goes to the
+/// Keychain.
+final class NotifySettingsStore {
+    static let shared = NotifySettingsStore()
+
+    private let defaults: UserDefaults
+    private let keychain: KeychainService
+
+    /// Every key this feature owns, all under a `notify.` prefix so they are
+    /// obvious in a defaults dump and easy to remove wholesale.
+    private enum Keys {
+        static let enabled = "notify.enabled"
+        static let deviceId = "notify.deviceId"
+        static let liveActivityEnabled = "notify.liveActivityEnabled"
+        static let widgetEnabled = "notify.widgetEnabled"
+        static let screenWidgetEnabled = "notify.screenWidgetEnabled"
+        static let gaugeProviderId = "notify.gauge.providerId"
+        static let gaugeQuotaKey = "notify.gauge.quotaKey"
+        static let activityId = "notify.activityId"
+        static let widgetId = "notify.widgetId"
+        static let screenWidgetId = "notify.screenWidgetId"
+
+        /// Written by one pre-release build that kept the token here when the
+        /// Keychain was unreachable. Only referenced by `purgeLegacyToken()`,
+        /// which deletes it; nothing ever reads it.
+        static let legacyFallbackToken = "notify.deviceToken.fallback"
+    }
+
+    init(defaults: UserDefaults = .standard, keychain: KeychainService = .shared) {
+        self.defaults = defaults
+        self.keychain = keychain
+        purgeLegacyToken()
+    }
+
+    /// Deletes a token left in UserDefaults by one pre-release build.
+    ///
+    /// That build stored the token here when no Keychain was reachable, which
+    /// contradicts the promise the README makes for every other credential in
+    /// this app: never in cleartext on disk. The key is gone now, and so is
+    /// anything a copy of that build wrote to it.
+    private func purgeLegacyToken() {
+        guard defaults.object(forKey: Keys.legacyFallbackToken) != nil else { return }
+        defaults.removeObject(forKey: Keys.legacyFallbackToken)
+        LoggingService.shared.logInfo("Notify!: removed a device token left in app settings by an earlier build")
+    }
+
+    // MARK: - Master switch
+
+    func isEnabled() -> Bool {
+        guard defaults.object(forKey: Keys.enabled) != nil else {
+            return NotifyConstants.defaultEnabled
+        }
+        return defaults.bool(forKey: Keys.enabled)
+    }
+
+    func setEnabled(_ enabled: Bool) {
+        defaults.set(enabled, forKey: Keys.enabled)
+    }
+
+    // MARK: - Credentials
+
+    func deviceId() -> String {
+        defaults.string(forKey: Keys.deviceId) ?? ""
+    }
+
+    func setDeviceId(_ deviceId: String) {
+        defaults.set(deviceId, forKey: Keys.deviceId)
+    }
+
+    /// The token, from the Keychain. There is nowhere else it can be.
+    func deviceToken() -> String? {
+        keychain.notifyDeviceToken()
+    }
+
+    /// Saves the token to the Keychain, and says whether it actually landed.
+    ///
+    /// The Keychain or nothing. The README promises every credential in this
+    /// app is kept there and never in cleartext on disk
+    /// (GHSA-mfxh-xpwm-23c7), and a push token for the user's phone is not the
+    /// place to make an exception.
+    ///
+    /// So a build with no reachable Keychain cannot link, and says so. That is
+    /// every ad-hoc signed build: the data-protection keychain wants an
+    /// application-identifier entitlement such a build has no way to carry, and
+    /// the file-based login keychain is deliberately gated off for ad-hoc
+    /// identities because their designated requirement changes on every rebuild
+    /// and the next launch would throw an ACL password prompt (#292). Signing
+    /// the app with a development team fixes it; there is no second store to
+    /// fall back to and there should not be one.
+    ///
+    /// - Returns: false when the Keychain would not take it, in which case
+    ///   nothing was stored anywhere.
+    @discardableResult
+    func saveDeviceToken(_ token: String) -> Bool {
+        guard keychain.saveNotifyDeviceToken(token) else {
+            LoggingService.shared.logWarning(
+                "Notify!: no reachable Keychain store in this build, so the device token was not saved"
+            )
+            return false
+        }
+        return true
+    }
+
+    @discardableResult
+    func deleteDeviceToken() -> Bool {
+        keychain.deleteNotifyDeviceToken()
+    }
+
+    func hasDeviceToken() -> Bool {
+        deviceToken() != nil
+    }
+
+    /// The saved credentials as one value, or nil when either half is missing
+    /// or malformed. The single place the rest of the app asks "are we linked".
+    func deviceLink() -> NotifyDeviceLink? {
+        guard let token = deviceToken() else { return nil }
+        return NotifyDeviceLink(deviceId: deviceId(), token: token)
+    }
+
+    /// Stores a link, keeping the surface handles when it names the same device.
+    ///
+    /// The handles are owned by a device, not by a credential. Pressing Save
+    /// twice, or re-saving after rotating a token, names the same phone, and
+    /// the tile and the two widgets already standing on it are still ours:
+    /// clearing their handles would orphan them and make the next publish
+    /// create a second set beside them, which on a Home Screen is a duplicate
+    /// the user has to go and remove by hand. Only a different device id
+    /// invalidates them, and then they must go, because they name surfaces on a
+    /// phone this link can no longer write to.
+    /// - Returns: false when the token could not be stored anywhere, in which
+    ///   case nothing is linked and the caller must not claim otherwise.
+    @discardableResult
+    func saveDeviceLink(_ link: NotifyDeviceLink) -> Bool {
+        if deviceId() != link.deviceId {
+            setActivityId(nil)
+            setWidgetId(nil)
+            setScreenWidgetId(nil)
+        }
+        setDeviceId(link.deviceId)
+        return saveDeviceToken(link.token)
+    }
+
+    /// Forgets the link and everything standing on it. The surfaces already on
+    /// the phone are left alone: removing them needs a network call at the exact
+    /// moment the user said stop, and would fail silently when they are offline.
+    func clearDeviceLink() {
+        setDeviceId("")
+        deleteDeviceToken()
+        setActivityId(nil)
+        setWidgetId(nil)
+        setScreenWidgetId(nil)
+    }
+
+    // MARK: - Surfaces
+
+    func isLiveActivityEnabled() -> Bool {
+        guard defaults.object(forKey: Keys.liveActivityEnabled) != nil else {
+            return NotifyConstants.defaultLiveActivityEnabled
+        }
+        return defaults.bool(forKey: Keys.liveActivityEnabled)
+    }
+
+    func setLiveActivityEnabled(_ enabled: Bool) {
+        defaults.set(enabled, forKey: Keys.liveActivityEnabled)
+    }
+
+    func isWidgetEnabled() -> Bool {
+        guard defaults.object(forKey: Keys.widgetEnabled) != nil else {
+            return NotifyConstants.defaultWidgetEnabled
+        }
+        return defaults.bool(forKey: Keys.widgetEnabled)
+    }
+
+    func setWidgetEnabled(_ enabled: Bool) {
+        defaults.set(enabled, forKey: Keys.widgetEnabled)
+    }
+
+    func isScreenWidgetEnabled() -> Bool {
+        guard defaults.object(forKey: Keys.screenWidgetEnabled) != nil else {
+            return NotifyConstants.defaultScreenWidgetEnabled
+        }
+        return defaults.bool(forKey: Keys.screenWidgetEnabled)
+    }
+
+    func setScreenWidgetEnabled(_ enabled: Bool) {
+        defaults.set(enabled, forKey: Keys.screenWidgetEnabled)
+    }
+
+    // MARK: - Gauge selection
+
+    func gaugeProviderId() -> String {
+        defaults.string(forKey: Keys.gaugeProviderId) ?? ""
+    }
+
+    func setGaugeProviderId(_ providerId: String) {
+        defaults.set(providerId, forKey: Keys.gaugeProviderId)
+    }
+
+    func gaugeQuotaKey() -> String {
+        defaults.string(forKey: Keys.gaugeQuotaKey) ?? ""
+    }
+
+    func setGaugeQuotaKey(_ quotaKey: String) {
+        defaults.set(quotaKey, forKey: Keys.gaugeQuotaKey)
+    }
+
+    /// Which quota window the gauge should show.
+    func gaugeSelection() -> NotifyGaugeSelection {
+        NotifyGaugeSelection(providerId: gaugeProviderId(), quotaKey: gaugeQuotaKey())
+    }
+
+    // MARK: - Surface handles
+
+    /// The handle of the Live Activity we started, so later updates address
+    /// that exact tile and never one the user started elsewhere.
+    func activityId() -> String? {
+        nonEmpty(defaults.string(forKey: Keys.activityId))
+    }
+
+    func setActivityId(_ activityId: String?) {
+        set(activityId, forKey: Keys.activityId)
+    }
+
+    /// The handle of the Lock Screen widget we created, for the same reason.
+    func widgetId() -> String? {
+        nonEmpty(defaults.string(forKey: Keys.widgetId))
+    }
+
+    func setWidgetId(_ widgetId: String?) {
+        set(widgetId, forKey: Keys.widgetId)
+    }
+
+    /// The handle of the Home Screen widget we created.
+    func screenWidgetId() -> String? {
+        nonEmpty(defaults.string(forKey: Keys.screenWidgetId))
+    }
+
+    func setScreenWidgetId(_ screenWidgetId: String?) {
+        set(screenWidgetId, forKey: Keys.screenWidgetId)
+    }
+
+    // MARK: - Helpers
+
+    private func nonEmpty(_ value: String?) -> String? {
+        guard let value, !value.isEmpty else { return nil }
+        return value
+    }
+
+    private func set(_ value: String?, forKey key: String) {
+        if let value, !value.isEmpty {
+            defaults.set(value, forKey: key)
+        } else {
+            defaults.removeObject(forKey: key)
+        }
+    }
+}

--- a/Claude Usage/Shared/Notify/NotifyTile.swift
+++ b/Claude Usage/Shared/Notify/NotifyTile.swift
@@ -1,0 +1,91 @@
+//
+//  NotifyTile.swift
+//  Claude Usage
+//
+//  The content of the Live Activity tile published to Notify!.
+//
+
+import Foundation
+
+/// One cell of a Live Activity metrics row, for example "5h 42%".
+///
+/// The gateway renders up to six of these side by side where the tile's body
+/// line would otherwise go, which is what makes a metrics tile the right shape
+/// for several quota windows at once.
+struct NotifyMetric: Sendable, Equatable, Hashable {
+    let label: String
+    let value: String
+    let unit: String?
+    let tintHex: String?
+
+    /// Fails only when the label or value is empty after cleaning, because the
+    /// gateway requires both. Everything else shortens or drops.
+    init?(label: String, value: String, unit: String? = nil, tintHex: String? = nil) {
+        guard let label = NotifyLimits.text(label, maximum: NotifyLimits.metricLabelLength),
+              let value = NotifyLimits.text(value, maximum: NotifyLimits.metricValueLength) else {
+            return nil
+        }
+        self.label = label
+        self.value = value
+        self.unit = NotifyLimits.text(unit, maximum: NotifyLimits.metricUnitLength)
+        self.tintHex = NotifyLimits.tint(tintHex)
+    }
+}
+
+/// The content of the Live Activity tile the app keeps on the Lock Screen.
+///
+/// The gateway has no notion of a tile type: the fields present decide how the
+/// tile draws, so a title plus a progress bar plus a metrics row IS the metrics
+/// layout. Every field is normalized on the way in, so a tile that exists is a
+/// tile the gateway will accept.
+///
+/// The Home Screen widget carries this same value. The gateway derives that
+/// route's content contract from the Live Activity's, field for field and cap
+/// for cap, so building a second shape for it could only produce two pictures
+/// of one quota that were meant to be identical.
+struct NotifyTile: Sendable, Equatable {
+    /// The tile's identity, and the one field a start cannot omit.
+    let title: String
+
+    /// Second line, shown only when there are no metrics to put there.
+    let body: String?
+
+    /// SF Symbol drawn as the tile icon.
+    let symbolName: String?
+
+    /// Accent color as `#RRGGBB`, normally the worst quota status on show.
+    let tintHex: String?
+
+    /// The progress bar, 0 to 100. We send quota remaining here, so a full bar
+    /// means a full quota.
+    let progress: Double?
+
+    /// Static text where a timer would sit, normally the headline window's
+    /// compact reset countdown.
+    let trailing: String?
+
+    /// Up to six values rendered side by side. Longer input is truncated to the
+    /// first six rather than rejected.
+    let metrics: [NotifyMetric]
+
+    init?(
+        title: String,
+        body: String? = nil,
+        symbolName: String? = nil,
+        tintHex: String? = nil,
+        progress: Double? = nil,
+        trailing: String? = nil,
+        metrics: [NotifyMetric] = []
+    ) {
+        guard let title = NotifyLimits.text(title, maximum: NotifyLimits.titleLength) else {
+            return nil
+        }
+        self.title = title
+        self.body = NotifyLimits.text(body, maximum: NotifyLimits.bodyLength)
+        self.symbolName = NotifyLimits.text(symbolName, maximum: NotifyLimits.symbolLength)
+        self.tintHex = NotifyLimits.tint(tintHex)
+        self.progress = NotifyLimits.progress(progress)
+        self.trailing = NotifyLimits.text(trailing, maximum: NotifyLimits.trailingLength)
+        self.metrics = Array(metrics.prefix(NotifyLimits.metricCount))
+    }
+}

--- a/Claude Usage/Shared/Notify/NotifyTint.swift
+++ b/Claude Usage/Shared/Notify/NotifyTint.swift
@@ -1,0 +1,33 @@
+//
+//  NotifyTint.swift
+//  Claude Usage
+//
+//  The colors and symbols sent to Notify!.
+//
+
+import Foundation
+
+extension NotifyQuotaStatus {
+    /// The accent color sent to Notify! for this status.
+    ///
+    /// These are the system colors the menu bar icon already uses, written as
+    /// hex because the gateway wants `#RRGGBB` and Foundation has no view layer
+    /// here. Keeping them in step means a quota that looks critical in the menu
+    /// bar looks critical on the Lock Screen.
+    var notifyTintHex: String {
+        switch self {
+        case .healthy: return "#34C759"   // systemGreen
+        case .warning: return "#FF9500"   // systemOrange
+        case .critical: return "#FF3B30"  // systemRed
+        case .depleted: return "#D70015"  // a darker red, for a window with nothing left
+        }
+    }
+}
+
+/// SF Symbols we ask Notify! to draw. Named here rather than inline so the tile
+/// and the widget cannot drift apart.
+enum NotifySymbol {
+    /// The tile and widget icon. A gauge reads correctly at both sizes and does
+    /// not imply a direction of travel the way an arrow would.
+    static let quota = "gauge.with.needle"
+}

--- a/Claude Usage/Shared/Notify/NotifyUsageReadings.swift
+++ b/Claude Usage/Shared/Notify/NotifyUsageReadings.swift
@@ -1,0 +1,205 @@
+//
+//  NotifyUsageReadings.swift
+//  Claude Usage
+//
+//  Flattens a profile's usage into the readings the payload builder takes.
+//
+
+import Foundation
+
+/// Turns the active profile's `ClaudeUsage` into the flat readings the payload
+/// builder works on.
+///
+/// This is the seam between the app's model and the Notify! feature. `ClaudeUsage`
+/// is a wide struct of named windows, some of which a given provider never
+/// fills in; `NotifyQuotaReading` is a flat list of windows that are actually
+/// reporting something. Keeping the translation in one pure function means the
+/// builder never has to know which provider it is looking at, and the whole
+/// mapping is testable without a network or a profile.
+///
+/// Only windows the provider genuinely reports are included. A per-model
+/// weekly window that a provider never fills in would otherwise sort as a
+/// healthy 100% and take one of the tile's six slots away from a number that
+/// matters.
+enum NotifyUsageReadings {
+
+    /// Every quota window worth publishing for one profile's usage.
+    ///
+    /// - Parameters:
+    ///   - usage: the profile's most recent usage.
+    ///   - provider: which provider produced it, for the label and capabilities.
+    ///   - now: the moment to measure expiry against, injected for tests.
+    static func readings(
+        from usage: ClaudeUsage,
+        provider: Provider,
+        now: Date = Date()
+    ) -> [NotifyQuotaReading] {
+        let descriptor = provider.descriptor
+        let providerId = provider.rawValue
+        let providerName = descriptor.displayName
+        var quotas: [NotifyQuota] = []
+
+        // The rolling session window. `effectiveSessionPercentage` already
+        // reports an expired window as 0% used, which is the right answer: a
+        // window that rolled over while the Mac was asleep is full again, and
+        // publishing the stale percentage would put a red ring on a phone for a
+        // limit that no longer applies.
+        let sessionUsed = usage.sessionResetTime < now ? 0 : usage.sessionPercentage
+        quotas.append(
+            NotifyQuota(
+                key: QuotaKey.session,
+                label: "notify.window.session".localized,
+                percentRemaining: remaining(from: sessionUsed),
+                resetsAt: usage.sessionResetTime > now ? usage.sessionResetTime : nil
+            )
+        )
+
+        // The weekly window across all models.
+        quotas.append(
+            NotifyQuota(
+                key: QuotaKey.weekly,
+                label: "notify.window.weekly".localized,
+                percentRemaining: remaining(from: usage.weeklyPercentage),
+                resetsAt: usage.weeklyResetTime > now ? usage.weeklyResetTime : nil
+            )
+        )
+
+        // Per-model weekly windows, for the providers that report them. Each is
+        // included only when it is actually reporting: a model the account has
+        // never used has no window, and a placeholder 100% would take a slot on
+        // the tile away from a number the user needs.
+        if descriptor.capabilities.perModelBreakdown {
+            let weeklyReset = usage.weeklyResetTime > now ? usage.weeklyResetTime : nil
+
+            appendModelWindow(
+                to: &quotas,
+                key: QuotaKey.opusWeekly,
+                labelKey: "notify.window.opus",
+                usedPercentage: usage.opusWeeklyPercentage,
+                resetsAt: weeklyReset,
+                now: now
+            )
+            appendModelWindow(
+                to: &quotas,
+                key: QuotaKey.sonnetWeekly,
+                labelKey: "notify.window.sonnet",
+                usedPercentage: usage.sonnetWeeklyPercentage,
+                resetsAt: usage.sonnetWeeklyResetTime ?? weeklyReset,
+                now: now
+            )
+            appendModelWindow(
+                to: &quotas,
+                key: QuotaKey.designWeekly,
+                labelKey: "notify.window.design",
+                usedPercentage: usage.designWeeklyPercentage,
+                resetsAt: usage.designWeeklyResetTime ?? weeklyReset,
+                now: now
+            )
+            appendModelWindow(
+                to: &quotas,
+                key: QuotaKey.fableWeekly,
+                labelKey: "notify.window.fable",
+                usedPercentage: usage.fableWeeklyPercentage,
+                resetsAt: usage.fableWeeklyResetTime ?? weeklyReset,
+                now: now
+            )
+        }
+
+        // A spend allowance with a ceiling is a percentage like any other
+        // window, so it draws a bar. Without a ceiling there is nothing to
+        // divide by and it is not published at all: a bare "spent so far" number
+        // answers no question the user is asking a Lock Screen.
+        if let costUsed = usage.costUsed, let costLimit = usage.costLimit, costLimit > 0 {
+            quotas.append(
+                NotifyQuota(
+                    key: QuotaKey.cost,
+                    label: "notify.window.spend".localized,
+                    percentRemaining: remaining(from: (costUsed / costLimit) * 100),
+                    currencyCode: usage.costCurrency,
+                    resetsAt: usage.weeklyResetTime > now ? usage.weeklyResetTime : nil
+                )
+            )
+        }
+
+        // Money with no ceiling: an overage grant and a prepaid credits balance
+        // both publish their formatted balance and no ring, because there is no
+        // percentage to draw one from.
+        if let overage = usage.overageBalance {
+            quotas.append(
+                NotifyQuota(
+                    key: QuotaKey.overage,
+                    label: "notify.window.extra_usage".localized,
+                    dollarRemaining: overage,
+                    currencyCode: usage.overageBalanceCurrency
+                )
+            )
+        }
+
+        // An unlimited plan has no balance to report, and "unlimited" on a ring
+        // is not a number, so the window is left out entirely.
+        if descriptor.capabilities.credits,
+           usage.creditsUnlimited != true,
+           let credits = usage.creditsBalance {
+            quotas.append(
+                NotifyQuota(
+                    key: QuotaKey.credits,
+                    label: "notify.window.credits".localized,
+                    dollarRemaining: credits,
+                    currencyCode: "USD"
+                )
+            )
+        }
+
+        return quotas.map {
+            NotifyQuotaReading(providerId: providerId, providerName: providerName, quota: $0)
+        }
+    }
+
+    /// Stable keys for the gauge selection. Persisted in UserDefaults, so a
+    /// value here must never be renamed: a user who picked "Opus 7d" for their
+    /// Lock Screen would silently fall back to automatic if it were.
+    enum QuotaKey {
+        static let session = "session"
+        static let weekly = "weekly"
+        static let opusWeekly = "opus_weekly"
+        static let sonnetWeekly = "sonnet_weekly"
+        static let designWeekly = "design_weekly"
+        static let fableWeekly = "fable_weekly"
+        static let cost = "cost"
+        static let overage = "overage"
+        static let credits = "credits"
+    }
+
+    // MARK: - Helpers
+
+    /// A per-model window, included only when the provider is reporting one.
+    ///
+    /// "Reporting" means either some of it has been used, or it carries a reset
+    /// time of its own. A model with neither has no window on this account.
+    private static func appendModelWindow(
+        to quotas: inout [NotifyQuota],
+        key: String,
+        labelKey: String,
+        usedPercentage: Double,
+        resetsAt: Date?,
+        now: Date
+    ) {
+        guard usedPercentage > 0 else { return }
+        quotas.append(
+            NotifyQuota(
+                key: key,
+                label: labelKey.localized,
+                percentRemaining: remaining(from: usedPercentage),
+                resetsAt: resetsAt.flatMap { $0 > now ? $0 : nil }
+            )
+        )
+    }
+
+    /// Used percent to remaining percent, clamped, because a provider that
+    /// reports more than 100% used should read as an empty window rather than
+    /// as a negative one.
+    private static func remaining(from usedPercentage: Double) -> Double {
+        guard usedPercentage.isFinite else { return 100 }
+        return min(100, max(0, 100 - usedPercentage))
+    }
+}

--- a/Claude Usage/Shared/Services/KeychainService.swift
+++ b/Claude Usage/Shared/Services/KeychainService.swift
@@ -257,6 +257,53 @@ class KeychainService {
         return onDisk == expected
     }
 
+    // MARK: - Notify! Device Token
+
+    /// The linked Notify! device's per-device secret.
+    ///
+    /// Deliberately on the same `saveItem`/`loadItem` helpers the per-profile
+    /// secrets use, rather than the older `save(_:for:)` API above. That one
+    /// attaches a `kSecAttrAccessControl`, which routes the item to the
+    /// data-protection keychain with no fallback, so on any build without the
+    /// application-identifier entitlement it fails outright — and a token that
+    /// silently fails to save reads to the user as "linked" while every publish
+    /// answers "not linked".
+    private static let notifyService = "com.claudeusagetracker.notify"
+    private static let notifyTokenAccount = "device-token"
+
+    /// Saves the token and confirms it can be read back again.
+    ///
+    /// The read-back is the point. `saveItem` can report success against a
+    /// store a later read cannot reach, and the caller needs to know whether
+    /// the token is really there before it tells anyone they are linked.
+    ///
+    /// - Returns: false when this build has no reachable keychain store, which
+    ///   is the ordinary case for an ad-hoc signed local build.
+    @discardableResult
+    func saveNotifyDeviceToken(_ token: String) -> Bool {
+        do {
+            try saveItem(token, service: Self.notifyService, account: Self.notifyTokenAccount)
+        } catch {
+            LoggingService.shared.log("Keychain: no reachable store for the Notify! device token in this build")
+            return false
+        }
+        return notifyDeviceToken() == token
+    }
+
+    /// The stored token, or nil when absent or unreadable.
+    func notifyDeviceToken() -> String? {
+        guard let token = try? loadItem(service: Self.notifyService, account: Self.notifyTokenAccount),
+              !token.isEmpty else {
+            return nil
+        }
+        return token
+    }
+
+    @discardableResult
+    func deleteNotifyDeviceToken() -> Bool {
+        deleteItem(service: Self.notifyService, account: Self.notifyTokenAccount)
+    }
+
     /// Removes all Keychain secrets belonging to a profile (call on profile deletion).
     func deleteAllProfileSecrets(profileId: UUID) {
         for field in ProfileSecretField.allCases {

--- a/Claude Usage/Views/Settings/App/NotifySettingsView.swift
+++ b/Claude Usage/Views/Settings/App/NotifySettingsView.swift
@@ -1,0 +1,469 @@
+//
+//  NotifySettingsView.swift
+//  Claude Usage
+//
+//  Where the Notify! device is linked, the three surfaces are switched, the
+//  Lock Screen gauge's window is chosen, and a publish can be forced.
+//
+
+import SwiftUI
+
+struct NotifySettingsView: View {
+    private let store = NotifySettingsStore.shared
+
+    // Everything below is filled in by `loadFromStore()` on appear rather than
+    // in a property default. A default expression runs on every construction of
+    // the view, and one of these reads the Keychain, which is not something to
+    // do on every SwiftUI re-init of a settings pane.
+    @State private var enabled = false
+    @State private var deviceId = ""
+    @State private var token = ""
+
+    @State private var liveActivityEnabled = true
+    @State private var widgetEnabled = true
+    @State private var screenWidgetEnabled = true
+
+    @State private var gaugeSelectionId = ""
+
+    /// Whether a link is actually saved, as opposed to merely typed into the
+    /// two fields. Held in state rather than asked of the store on every body
+    /// pass, because answering it means a Keychain lookup.
+    @State private var isLinked = false
+
+
+    @State private var isVerifying = false
+    @State private var isPublishing = false
+    @State private var statusMessage: String?
+    @State private var statusIsError = false
+
+    @StateObject private var profileManager = ProfileManager.shared
+
+    /// The link the two fields currently describe, or nil when they do not yet
+    /// make one. Everything that needs a device to talk to reads this, so the
+    /// pane never has to ask twice whether it is linked.
+    private var draftLink: NotifyDeviceLink? {
+        NotifyDeviceLink(deviceId: deviceId, token: token)
+    }
+
+    /// A switch that writes through to the store as the user flips it.
+    ///
+    /// A write-through binding rather than `onChange`, because `onChange` fires
+    /// for any change including the one `loadFromStore` makes on appear, and
+    /// telling those two apart needs a flag that is easy to get wrong. A
+    /// binding's setter runs only when somebody actually flips the switch.
+    private func writeThrough(
+        _ value: Binding<Bool>,
+        to save: @escaping (Bool) -> Void
+    ) -> Binding<Bool> {
+        Binding(
+            get: { value.wrappedValue },
+            set: { newValue in
+                value.wrappedValue = newValue
+                save(newValue)
+                postSettingsChanged()
+            }
+        )
+    }
+
+    /// The gauge picker's selection, in the "provider|window" spelling the
+    /// store persists. Empty means automatic.
+    private var gaugeBinding: Binding<String> {
+        Binding(
+            get: { gaugeSelectionId },
+            set: { newValue in
+                gaugeSelectionId = newValue
+                saveGaugeSelection(newValue)
+                postSettingsChanged()
+            }
+        )
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: DesignTokens.Spacing.section) {
+                SettingsPageHeader(
+                    title: "notify.title".localized,
+                    subtitle: "notify.subtitle".localized
+                )
+
+                enableCard
+                linkCard
+
+                if enabled {
+                    surfacesCard
+                    gaugeCard
+                    publishCard
+                }
+
+                privacyCard
+            }
+            .padding()
+        }
+        .onAppear(perform: loadFromStore)
+    }
+
+    // MARK: - Enable
+
+    private var enableCard: some View {
+        SettingsSectionCard(
+            title: "notify.section.publishing".localized,
+            subtitle: "notify.section.publishing_desc".localized
+        ) {
+            SettingToggle(
+                title: "notify.enable".localized,
+                description: "notify.enable_desc".localized,
+                badge: .beta,
+                isOn: writeThrough($enabled, to: store.setEnabled)
+            )
+            .disabled(!isLinked && !enabled)
+            .opacity(!isLinked && !enabled ? 0.5 : 1.0)
+        }
+    }
+
+    // MARK: - Link
+
+    private var linkCard: some View {
+        SettingsSectionCard(
+            title: "notify.section.device".localized,
+            subtitle: "notify.section.device_desc".localized
+        ) {
+            VStack(alignment: .leading, spacing: DesignTokens.Spacing.cardPadding) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("notify.device_id".localized)
+                        .font(DesignTokens.Typography.bodyMedium)
+                    TextField("notify.device_id.placeholder".localized, text: $deviceId)
+                        .textFieldStyle(.roundedBorder)
+                        .onChange(of: deviceId) { _, newValue in
+                            // The Notify! app also offers a ready-made
+                            // notification URL with both halves in it, so a
+                            // paste into either field is unpicked rather than
+                            // rejected as a malformed ID.
+                            adoptPastedText(newValue)
+                        }
+                }
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("notify.device_token".localized)
+                        .font(DesignTokens.Typography.bodyMedium)
+                    SecureField("notify.device_token.placeholder".localized, text: $token)
+                        .textFieldStyle(.roundedBorder)
+                }
+
+                if let kind = draftLink?.kind {
+                    deviceKindNotes(kind)
+                }
+
+                HStack(spacing: DesignTokens.Spacing.medium) {
+                    SettingsButton(
+                        title: isVerifying
+                            ? "notify.verifying".localized
+                            : "notify.verify".localized,
+                        icon: "checkmark.shield",
+                        style: .secondary
+                    ) {
+                        verifyDevice()
+                    }
+                    .disabled(draftLink == nil || isVerifying)
+
+                    SettingsButton(
+                        title: "notify.save_link".localized,
+                        icon: "link",
+                        style: .primary
+                    ) {
+                        saveLink()
+                    }
+                    .disabled(draftLink == nil)
+
+                    if isLinked {
+                        SettingsButton(
+                            title: "notify.unlink".localized,
+                            icon: "trash",
+                            style: .destructive
+                        ) {
+                            unlink()
+                        }
+                    }
+                }
+
+                if let statusMessage {
+                    Text(statusMessage)
+                        .font(DesignTokens.Typography.body)
+                        .foregroundColor(statusIsError ? SettingsColors.error : SettingsColors.success)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+        }
+    }
+
+    /// The sentences that explain what this particular ID can and cannot carry.
+    ///
+    /// Shown per surface rather than as one verdict, because the three are
+    /// gated differently: a Mac can keep both widgets and cannot show a Live
+    /// Activity, and a user who reads only "unsupported" would switch the whole
+    /// feature off over a limit that costs them one surface.
+    @ViewBuilder
+    private func deviceKindNotes(_ kind: NotifyDeviceKind) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            if let reason = kind.liveActivityUnsupportedReason {
+                noteRow(reason)
+            }
+            if let reason = kind.widgetUnsupportedReason {
+                noteRow(reason)
+            }
+        }
+    }
+
+    private func noteRow(_ text: String) -> some View {
+        HStack(alignment: .top, spacing: 6) {
+            Image(systemName: "info.circle")
+                .foregroundColor(SettingsColors.warning)
+            Text(text)
+                .font(DesignTokens.Typography.body)
+                .foregroundColor(SettingsColors.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    // MARK: - Surfaces
+
+    private var surfacesCard: some View {
+        SettingsSectionCard(
+            title: "notify.section.surfaces".localized,
+            subtitle: "notify.section.surfaces_desc".localized
+        ) {
+            VStack(alignment: .leading, spacing: DesignTokens.Spacing.cardPadding) {
+                SettingToggle(
+                    title: "notify.surface.live_activity".localized,
+                    description: "notify.surface.live_activity_desc".localized,
+                    badge: nil,
+                    isOn: writeThrough($liveActivityEnabled, to: store.setLiveActivityEnabled)
+                )
+                .disabled(draftLink?.supportsLiveActivity == false)
+                .opacity(draftLink?.supportsLiveActivity == false ? 0.5 : 1.0)
+
+                SettingToggle(
+                    title: "notify.surface.lock_screen".localized,
+                    description: "notify.surface.lock_screen_desc".localized,
+                    badge: nil,
+                    isOn: writeThrough($widgetEnabled, to: store.setWidgetEnabled)
+                )
+                .disabled(draftLink?.supportsWidget == false)
+                .opacity(draftLink?.supportsWidget == false ? 0.5 : 1.0)
+
+                SettingToggle(
+                    title: "notify.surface.home_screen".localized,
+                    description: "notify.surface.home_screen_desc".localized,
+                    badge: nil,
+                    isOn: writeThrough($screenWidgetEnabled, to: store.setScreenWidgetEnabled)
+                )
+                .disabled(draftLink?.supportsScreenWidget == false)
+                .opacity(draftLink?.supportsScreenWidget == false ? 0.5 : 1.0)
+            }
+        }
+    }
+
+    // MARK: - Gauge
+
+    private var gaugeCard: some View {
+        SettingsSectionCard(
+            title: "notify.section.gauge".localized,
+            subtitle: "notify.section.gauge_desc".localized
+        ) {
+            Picker("notify.gauge.window".localized, selection: gaugeBinding) {
+                Text("notify.gauge.automatic".localized).tag("")
+                ForEach(availableWindows) { window in
+                    Text(window.label).tag(window.id)
+                }
+            }
+            .pickerStyle(.menu)
+        }
+    }
+
+    /// The windows the active profile is currently reporting, as picker rows.
+    ///
+    /// Built from the same function the driver publishes through, so a window
+    /// that can be chosen here is a window that will actually reach the phone.
+    private var availableWindows: [GaugeWindow] {
+        guard let profile = profileManager.activeProfile,
+              let usage = profile.claudeUsage else {
+            return []
+        }
+        return NotifyUsageReadings.readings(from: usage, provider: profile.provider)
+            .map { reading in
+                GaugeWindow(
+                    id: "\(reading.providerId)|\(reading.quota.key)",
+                    label: "\(reading.providerName) \(reading.quota.label)"
+                )
+            }
+    }
+
+    /// One row of the gauge picker. The `id` is the same "provider|window"
+    /// string the store persists, so the picker's selection needs no
+    /// translation on the way in or out.
+    private struct GaugeWindow: Identifiable {
+        let id: String
+        let label: String
+    }
+
+    // MARK: - Publish
+
+    private var publishCard: some View {
+        SettingsSectionCard(
+            title: "notify.section.publish".localized,
+            subtitle: "notify.section.publish_desc".localized
+        ) {
+            SettingsButton(
+                title: isPublishing
+                    ? "notify.publishing".localized
+                    : "notify.publish_now".localized,
+                icon: "paperplane.fill",
+                style: .primary
+            ) {
+                publishNow()
+            }
+            .disabled(isPublishing || !isLinked)
+        }
+    }
+
+    // MARK: - Privacy
+
+    private var privacyCard: some View {
+        SettingsSectionCard(
+            title: "notify.section.privacy".localized,
+            subtitle: nil
+        ) {
+            VStack(alignment: .leading, spacing: 6) {
+                BulletPoint("notify.privacy.what_leaves".localized)
+                BulletPoint("notify.privacy.where_it_goes".localized)
+                BulletPoint("notify.privacy.off_by_default".localized)
+                BulletPoint("notify.privacy.token_secret".localized)
+            }
+        }
+    }
+
+    // MARK: - Actions
+
+    /// Unpicks a pasted notification URL, or an "id token" pair, into the two
+    /// fields. Silent when the text is neither, because that is simply somebody
+    /// typing an ID one character at a time.
+    private func adoptPastedText(_ text: String) {
+        guard text.count > 32 || text.contains("/") || text.contains(" ") else { return }
+        if let link = NotifyDeviceLink(pastedText: text) {
+            deviceId = link.deviceId
+            token = link.token
+        } else if let identifier = NotifyDeviceLink.deviceId(inPastedText: text) {
+            deviceId = identifier
+        }
+    }
+
+    private func saveLink() {
+        guard let link = draftLink else { return }
+
+        // The store reports whether the token actually landed. Claiming a link
+        // that did not save is how a user ends up pressing Send Now and being
+        // told to add the ID and token they can see in front of them.
+        guard store.saveDeviceLink(link) else {
+            isLinked = false
+            show("notify.status.link_save_failed".localized, isError: true)
+            return
+        }
+
+        isLinked = true
+        show("notify.status.link_saved".localized, isError: false)
+        postSettingsChanged()
+    }
+
+    private func unlink() {
+        store.clearDeviceLink()
+        isLinked = false
+        deviceId = ""
+        token = ""
+        enabled = false
+        store.setEnabled(false)
+        show("notify.status.unlinked".localized, isError: false)
+        postSettingsChanged()
+    }
+
+    /// Checks the credentials against the gateway and names the device they
+    /// point at.
+    ///
+    /// Behind a button and nothing else: the gateway rate limits this route to
+    /// five calls a minute per IP, so nothing on a timer may reach it.
+    private func verifyDevice() {
+        guard let link = draftLink else { return }
+        isVerifying = true
+        statusMessage = nil
+
+        Task { @MainActor in
+            defer { isVerifying = false }
+            do {
+                let info = try await NotifyGatewayClient().deviceInfo(link: link)
+                show("notify.status.verified".localized(with: info.displayDescription), isError: false)
+            } catch {
+                let message = (error as? NotifyPublishError)?.errorDescription ?? error.localizedDescription
+                show(message, isError: true)
+            }
+        }
+    }
+
+    /// Forces a publish through the driver rather than writing to the gateway
+    /// here. The driver holds the stored handles and the single in-flight
+    /// publish, and two publishers racing over one nil activity id is exactly
+    /// how a phone ends up with two Live Activities.
+    private func publishNow() {
+        isPublishing = true
+        statusMessage = nil
+
+        Task { @MainActor in
+            defer { isPublishing = false }
+            if let failure = await NotifyPublishDriver.shared.publishNow() {
+                show(failure, isError: true)
+            } else {
+                show("notify.status.published".localized, isError: false)
+            }
+        }
+    }
+
+    /// Fills the pane in from the store, including the one Keychain read.
+    private func loadFromStore() {
+        enabled = store.isEnabled()
+        deviceId = store.deviceId()
+        token = store.deviceToken() ?? ""
+        liveActivityEnabled = store.isLiveActivityEnabled()
+        widgetEnabled = store.isWidgetEnabled()
+        screenWidgetEnabled = store.isScreenWidgetEnabled()
+
+        let providerId = store.gaugeProviderId()
+        let quotaKey = store.gaugeQuotaKey()
+        gaugeSelectionId = providerId.isEmpty || quotaKey.isEmpty ? "" : "\(providerId)|\(quotaKey)"
+        // From the two values just loaded, so the Keychain is read once here.
+        isLinked = NotifyDeviceLink(deviceId: deviceId, token: token) != nil
+    }
+
+    private func saveGaugeSelection(_ identifier: String) {
+        let parts = identifier.split(separator: "|", maxSplits: 1).map(String.init)
+        guard parts.count == 2 else {
+            store.setGaugeProviderId("")
+            store.setGaugeQuotaKey("")
+            return
+        }
+        store.setGaugeProviderId(parts[0])
+        store.setGaugeQuotaKey(parts[1])
+    }
+
+    private func show(_ message: String, isError: Bool) {
+        statusMessage = message
+        statusIsError = isError
+    }
+
+    /// The link, the switches and the gauge selection all live outside the
+    /// state the driver watches, so it has no other way to notice a save.
+    private func postSettingsChanged() {
+        NotificationCenter.default.post(name: .notifySettingsChanged, object: nil)
+    }
+}
+
+#Preview {
+    NotifySettingsView()
+        .frame(width: 560, height: 620)
+}

--- a/Claude Usage/Views/SettingsView.swift
+++ b/Claude Usage/Views/SettingsView.swift
@@ -308,6 +308,8 @@ struct SettingsView: View {
                     ClaudeCodeView()
                 case .notchHUD:
                     NotchHUDSettingsView()
+                case .notify:
+                    NotifySettingsView()
                 case .shortcuts:
                     ShortcutsSettingsView()
                 case .updates:
@@ -617,6 +619,7 @@ enum SettingsSection: String, CaseIterable {
     case language
     case claudeCode
     case notchHUD
+    case notify
     case shortcuts
     case updates
     case support
@@ -639,6 +642,7 @@ enum SettingsSection: String, CaseIterable {
         case .language: return "language.title".localized
         case .claudeCode: return "settings.claude_cli".localized
         case .notchHUD: return "notch.hud.section_title".localized
+        case .notify: return "notify.title".localized
         case .shortcuts: return "section.shortcuts_title".localized
         case .updates: return "settings.updates".localized
         case .support: return "section.support_title".localized
@@ -663,6 +667,7 @@ enum SettingsSection: String, CaseIterable {
         case .language: return "globe"
         case .claudeCode: return "chevron.left.forwardslash.chevron.right"
         case .notchHUD: return "inset.filled.topthird.rectangle"
+        case .notify: return "bell.badge.fill"
         case .shortcuts: return "keyboard"
         case .updates: return "arrow.down.circle.fill"
         case .support: return "heart.fill"
@@ -687,6 +692,7 @@ enum SettingsSection: String, CaseIterable {
         case .language: return "language.subtitle".localized
         case .claudeCode: return "settings.claude_cli.description".localized
         case .notchHUD: return "notch.hud.section_desc".localized
+        case .notify: return "notify.subtitle".localized
         case .shortcuts: return "section.shortcuts_desc".localized
         case .updates: return "settings.updates.description".localized
         case .support: return "section.support_desc".localized

--- a/Claude UsageTests/NotifyDeviceLinkTests.swift
+++ b/Claude UsageTests/NotifyDeviceLinkTests.swift
@@ -1,0 +1,185 @@
+import XCTest
+@testable import Claude_Usage
+
+/// The id namespaces, what each one can carry, and every shape of credential
+/// the user might paste in.
+///
+/// `@MainActor` because the app target builds with
+/// `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`, so everything under test is
+/// main-actor isolated while the test target's own default is not. Same
+/// reason `NotchHUDCoreTests` and `NotchHookServerTests` carry it.
+@MainActor
+final class NotifyDeviceLinkTests: XCTestCase {
+
+    // MARK: - ID validation
+
+    func testAcceptsIdsBetweenEightAndThirtyTwoCharacters() {
+        XCTAssertTrue(NotifyDeviceLink.isValidDeviceId("ABC12345"))
+        XCTAssertTrue(NotifyDeviceLink.isValidDeviceId("IO12345678901234"))
+        XCTAssertTrue(NotifyDeviceLink.isValidDeviceId(String(repeating: "A", count: 32)))
+    }
+
+    func testRefusesIdsOutsideTheLengthRange() {
+        XCTAssertFalse(NotifyDeviceLink.isValidDeviceId("ABC1234"))
+        XCTAssertFalse(NotifyDeviceLink.isValidDeviceId(String(repeating: "A", count: 33)))
+        XCTAssertFalse(NotifyDeviceLink.isValidDeviceId(""))
+    }
+
+    func testRefusesNonAlphanumericIds() {
+        XCTAssertFalse(NotifyDeviceLink.isValidDeviceId("ABC-1234"))
+        XCTAssertFalse(NotifyDeviceLink.isValidDeviceId("ABC 1234"))
+    }
+
+    func testRefusesAnEmptyToken() {
+        XCTAssertNil(NotifyDeviceLink(deviceId: "ABC12345", token: ""))
+        XCTAssertNil(NotifyDeviceLink(deviceId: "ABC12345", token: "   "))
+    }
+
+    func testTrimsBothHalves() {
+        let link = NotifyDeviceLink(deviceId: "  ABC12345 ", token: " secret ")
+        XCTAssertEqual(link?.deviceId, "ABC12345")
+        XCTAssertEqual(link?.token, "secret")
+    }
+
+    // MARK: - Pasted text
+
+    /// The three shapes a user actually has on the clipboard all have to yield
+    /// the same link, because none of them is wrong.
+    func testAllPastedShapesYieldTheSameLink() {
+        let expected = NotifyDeviceLink(deviceId: "ABC12345", token: "s3cret")
+
+        XCTAssertEqual(NotifyDeviceLink(pastedText: "ABC12345 s3cret"), expected)
+        XCTAssertEqual(NotifyDeviceLink(pastedText: "ABC12345,s3cret"), expected)
+        XCTAssertEqual(
+            NotifyDeviceLink(pastedText: "https://push.getnotifyapp.com/notify/ABC12345?token=s3cret"),
+            expected
+        )
+        XCTAssertEqual(
+            NotifyDeviceLink(pastedText: "https://push.getnotifyapp.com/live-activity/ABC12345?token=s3cret"),
+            expected
+        )
+        XCTAssertEqual(
+            NotifyDeviceLink(pastedText: "https://push.getnotifyapp.com/widgets/ABC12345?token=s3cret"),
+            expected
+        )
+    }
+
+    func testRefusesPastedTextWithNoToken() {
+        XCTAssertNil(NotifyDeviceLink(pastedText: "ABC12345"))
+        XCTAssertNil(NotifyDeviceLink(pastedText: "https://push.getnotifyapp.com/notify/ABC12345"))
+    }
+
+    /// The gateway's own `/link` response hands back a notification URL with the
+    /// token deliberately stripped. Half an answer is still worth having in a
+    /// pane with a field per value.
+    func testReadsTheIdOutOfATokenlessURL() {
+        XCTAssertEqual(
+            NotifyDeviceLink.deviceId(inPastedText: "https://push.getnotifyapp.com/notify/ABC12345"),
+            "ABC12345"
+        )
+        XCTAssertEqual(NotifyDeviceLink.deviceId(inPastedText: "ABC12345"), "ABC12345")
+        XCTAssertNil(NotifyDeviceLink.deviceId(inPastedText: "short"))
+    }
+
+    // MARK: - Namespaces
+
+    func testClassifiesEachNamespace() {
+        XCTAssertEqual(NotifyDeviceKind.kind(ofDeviceId: "GRP12345"), .group)
+        XCTAssertEqual(NotifyDeviceKind.kind(ofDeviceId: "WB12345678901234"), .web)
+        XCTAssertEqual(NotifyDeviceKind.kind(ofDeviceId: "MC12345678901234"), .mac)
+        XCTAssertEqual(NotifyDeviceKind.kind(ofDeviceId: "IO12345678901234"), .appDevice)
+        XCTAssertEqual(NotifyDeviceKind.kind(ofDeviceId: "abc12345"), .appDevice)
+    }
+
+    /// `GRP` plus five is eight characters, exactly the length of a legacy id,
+    /// so the two grammars genuinely overlap. The prefix wins, which is the
+    /// gateway's own tie break.
+    func testGroupPrefixWinsTheEightCharacterOverlap() {
+        XCTAssertEqual(NotifyDeviceKind.kind(ofDeviceId: "GRPABCDE"), .group)
+    }
+
+    /// A prefix that is only a prefix by accident must not steal a real device.
+    func testAPrefixAloneIsNotEnough() {
+        XCTAssertEqual(NotifyDeviceKind.kind(ofDeviceId: "MCABCDEF"), .appDevice)
+        XCTAssertEqual(NotifyDeviceKind.kind(ofDeviceId: "WBABCDEF"), .appDevice)
+    }
+
+    /// The rule names what cannot publish rather than what may, so a format
+    /// Notify! mints after this was written still links.
+    func testAnUnknownNamespaceCarriesEverySurface() {
+        let kind = NotifyDeviceKind.kind(ofDeviceId: "ZZ999999999999999999")
+        XCTAssertEqual(kind, .unrecognized)
+        XCTAssertTrue(kind.supportsLiveActivity)
+        XCTAssertTrue(kind.supportsWidget)
+        XCTAssertTrue(kind.supportsScreenWidget)
+    }
+
+    // MARK: - Surface gating
+
+    func testAMacAndABrowserKeepBothWidgetsAndNoLiveActivity() {
+        for kind in [NotifyDeviceKind.mac, .web] {
+            XCTAssertFalse(kind.supportsLiveActivity, "\(kind)")
+            XCTAssertTrue(kind.supportsWidget, "\(kind)")
+            XCTAssertTrue(kind.supportsScreenWidget, "\(kind)")
+        }
+    }
+
+    func testAGroupKeepsNothing() {
+        XCTAssertFalse(NotifyDeviceKind.group.supportsLiveActivity)
+        XCTAssertFalse(NotifyDeviceKind.group.supportsWidget)
+        XCTAssertFalse(NotifyDeviceKind.group.supportsScreenWidget)
+        XCTAssertFalse(NotifyDeviceKind.group.supportsAnySurface)
+    }
+
+    func testAnAppDeviceKeepsEverything() {
+        XCTAssertTrue(NotifyDeviceKind.appDevice.supportsLiveActivity)
+        XCTAssertTrue(NotifyDeviceKind.appDevice.supportsWidget)
+        XCTAssertTrue(NotifyDeviceKind.appDevice.supportsScreenWidget)
+    }
+
+    /// The two widgets must always answer alike, because the Home Screen rule
+    /// IS the Lock Screen rule rather than a second copy of it.
+    func testTheTwoWidgetsAlwaysAgree() {
+        for kind in NotifyDeviceKind.allCases {
+            XCTAssertEqual(kind.supportsWidget, kind.supportsScreenWidget, "\(kind)")
+            XCTAssertEqual(
+                kind.widgetUnsupportedReason,
+                kind.screenWidgetUnsupportedReason,
+                "\(kind)"
+            )
+        }
+    }
+
+    /// A reason is present exactly when its own surface is unavailable, so no
+    /// working control is explained away and no dead one is left unaccounted for.
+    func testEachReasonIsPresentExactlyWhenItsSurfaceIsUnavailable() {
+        for kind in NotifyDeviceKind.allCases {
+            XCTAssertEqual(kind.liveActivityUnsupportedReason == nil, kind.supportsLiveActivity, "\(kind)")
+            XCTAssertEqual(kind.widgetUnsupportedReason == nil, kind.supportsWidget, "\(kind)")
+        }
+    }
+
+    func testTheLinkForwardsTheKindsAnswers() {
+        let mac = NotifyDeviceLink(deviceId: "MC12345678901234", token: "s")
+        XCTAssertEqual(mac?.supportsLiveActivity, false)
+        XCTAssertEqual(mac?.supportsWidget, true)
+        XCTAssertEqual(mac?.supportsScreenWidget, true)
+    }
+
+    // MARK: - Device info
+
+    func testDeviceInfoDescriptionNamesThePlatformWhenItHasOne() {
+        XCTAssertEqual(
+            NotifyDeviceInfo(deviceId: "ABC12345", name: "Apollo", platform: "iOS").displayDescription,
+            "Apollo (iOS)"
+        )
+        XCTAssertEqual(
+            NotifyDeviceInfo(deviceId: "ABC12345", name: "Apollo", platform: nil).displayDescription,
+            "Apollo"
+        )
+        XCTAssertEqual(
+            NotifyDeviceInfo(deviceId: "ABC12345", name: "Apollo", platform: "").displayDescription,
+            "Apollo"
+        )
+    }
+}

--- a/Claude UsageTests/NotifyGatewayClientTests.swift
+++ b/Claude UsageTests/NotifyGatewayClientTests.swift
@@ -1,0 +1,269 @@
+import XCTest
+@testable import Claude_Usage
+
+/// The wire: how a status code becomes an error with a remedy, what goes into a
+/// body, and how a URL is built around a secret.
+///
+/// `@MainActor` because the app target builds with
+/// `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`, so everything under test is
+/// main-actor isolated while the test target's own default is not. Same
+/// reason `NotchHUDCoreTests` and `NotchHookServerTests` carry it.
+@MainActor
+final class NotifyGatewayClientTests: XCTestCase {
+
+    private func body(_ object: [String: Any]) -> Data {
+        (try? JSONSerialization.data(withJSONObject: object)) ?? Data()
+    }
+
+    // MARK: - Status mapping
+
+    func testEachStatusMapsToTheErrorWhoseRemedyDiffers() {
+        XCTAssertEqual(
+            NotifyGatewayClient.failure(status: 403, data: Data(), retryAfterHeader: nil),
+            .rejectedCredentials
+        )
+        XCTAssertEqual(
+            NotifyGatewayClient.failure(status: 410, data: Data(), retryAfterHeader: nil),
+            .tileGone
+        )
+        XCTAssertEqual(
+            NotifyGatewayClient.failure(status: 418, data: Data(), retryAfterHeader: nil),
+            .unexpectedStatus(418)
+        )
+    }
+
+    func testA400CarriesTheGatewaysOwnSentence() {
+        let error = NotifyGatewayClient.failure(
+            status: 400,
+            data: body(["message": "title is too long"]),
+            retryAfterHeader: nil
+        )
+        XCTAssertEqual(error, .invalidPayload("title is too long"))
+    }
+
+    func testA409NamesWhatTheDeviceIsWaitingOn() {
+        let error = NotifyGatewayClient.failure(
+            status: 409,
+            data: body(["message": "open the Notify! app once"]),
+            retryAfterHeader: nil
+        )
+        XCTAssertEqual(error, .liveActivityUnavailable("open the Notify! app once"))
+    }
+
+    func testA429BecomesAWait() {
+        let error = NotifyGatewayClient.failure(
+            status: 429,
+            data: body(["retryAfterSeconds": 120, "openingTheAppMayHelp": true]),
+            retryAfterHeader: nil
+        )
+        XCTAssertEqual(error, .backoff(retryAfter: 120, openingTheAppMayHelp: true))
+    }
+
+    /// Apple never answered, so a tile may exist. The id is kept and polled
+    /// rather than started again, which could leave two tiles.
+    func testA502UnknownKeepsTheActivityId() {
+        let error = NotifyGatewayClient.failure(
+            status: 502,
+            data: body(["deliveryState": "unknown", "activityId": "LA123456"]),
+            retryAfterHeader: nil
+        )
+        XCTAssertEqual(error, .deliveryUnconfirmed(activityId: "LA123456"))
+    }
+
+    /// No tile exists, so starting again is safe, but every unanswered start
+    /// counts toward the same ladder as a 429, so this is a wait.
+    func testA502NotDeliveredBecomesAWait() {
+        let error = NotifyGatewayClient.failure(
+            status: 502,
+            data: body(["deliveryState": "not-delivered"]),
+            retryAfterHeader: nil
+        )
+        XCTAssertEqual(
+            error,
+            .backoff(retryAfter: NotifyGatewayClient.defaultBackoff, openingTheAppMayHelp: false)
+        )
+    }
+
+    func testA502WithNoDeliveryStateIsJustAStatus() {
+        XCTAssertEqual(
+            NotifyGatewayClient.failure(status: 502, data: Data(), retryAfterHeader: nil),
+            .unexpectedStatus(502)
+        )
+    }
+
+    // MARK: - Wait resolution
+
+    /// The body's own number wins, because the gateway computes it from the
+    /// ladder it is actually enforcing.
+    func testTheBodysSecondsBeatTheHeader() {
+        XCTAssertEqual(NotifyGatewayClient.retryAfter(bodySeconds: 90, header: "300"), 90)
+    }
+
+    func testTheHeaderIsTheFallback() {
+        XCTAssertEqual(NotifyGatewayClient.retryAfter(bodySeconds: nil, header: " 300 "), 300)
+    }
+
+    /// The HTTP date form is deliberately not read: it would need a clock this
+    /// app cannot trust to agree with the server's.
+    func testANonNumericHeaderFallsThroughToTheLaddersFirstRung() {
+        XCTAssertEqual(
+            NotifyGatewayClient.retryAfter(bodySeconds: nil, header: "Wed, 21 Oct 2026 07:28:00 GMT"),
+            NotifyGatewayClient.defaultBackoff
+        )
+        XCTAssertEqual(
+            NotifyGatewayClient.retryAfter(bodySeconds: nil, header: nil),
+            NotifyGatewayClient.defaultBackoff
+        )
+    }
+
+    // MARK: - Bodies
+
+    /// Every field this app drives is present on every write, as an explicit
+    /// null when it has no value. The gateway merges rather than replaces, so
+    /// omitting a field it already holds freezes the old value instead of
+    /// clearing it.
+    func testTheTileBodyStatesANullForEveryFieldItDrives() {
+        let tile = NotifyTile(title: "Claude Usage")!
+        let body = NotifyGatewayClient.tileBody(tile)
+
+        XCTAssertEqual(body["title"] as? String, "Claude Usage")
+        for key in ["body", "symbol", "tint", "progress", "trailing", "metrics"] {
+            XCTAssertTrue(body[key] is NSNull, "\(key) should be an explicit null")
+        }
+    }
+
+    /// The fields this app never drives stay unmentioned, which is what lets an
+    /// update from here share a tile with whatever else the user set up.
+    func testTheTileBodyNeverMentionsTheFieldsItDoesNotDrive() {
+        let body = NotifyGatewayClient.tileBody(NotifyTile(title: "Claude Usage")!)
+        for key in ["status", "endsIn", "steps", "step", "button"] {
+            XCTAssertNil(body[key], "\(key) should not appear at all")
+        }
+    }
+
+    func testTheTileBodyCarriesItsMetrics() {
+        let tile = NotifyTile(
+            title: "Claude Usage",
+            progress: 42,
+            metrics: [NotifyMetric(label: "5h", value: "42", unit: "%", tintHex: "#34C759")!]
+        )!
+        let body = NotifyGatewayClient.tileBody(tile)
+        let metrics = body["metrics"] as? [[String: Any]]
+
+        XCTAssertEqual(metrics?.count, 1)
+        XCTAssertEqual(metrics?.first?["label"] as? String, "5h")
+        XCTAssertEqual(metrics?.first?["value"] as? String, "42")
+        XCTAssertEqual(metrics?.first?["unit"] as? String, "%")
+        XCTAssertEqual(metrics?.first?["color"] as? String, "#34C759")
+        XCTAssertEqual(body["progress"] as? Double, 42)
+    }
+
+    /// The widget is where an unstated field matters most: it lives under its
+    /// id until the user removes it, so anything left unsaid survives forever.
+    func testTheGaugeBodyStatesANullForEveryFieldExceptTheTitle() {
+        let body = NotifyGatewayClient.gaugeBody(NotifyGauge(title: "Claude Usage")!)
+
+        XCTAssertEqual(body["title"] as? String, "Claude Usage")
+        for key in ["value", "unit", "detail", "symbol", "tint", "progress"] {
+            XCTAssertTrue(body[key] is NSNull, "\(key) should be an explicit null")
+        }
+    }
+
+    // MARK: - Request building
+
+    /// Built through `URLComponents` rather than interpolation, because the per
+    /// device token is an opaque secret that can contain characters a query
+    /// string has to escape.
+    func testTheTokenIsPercentEncodedIntoTheQuery() throws {
+        let url = try NotifyGatewayClient.endpoint(
+            host: URL(string: "https://push.getnotifyapp.com")!,
+            path: "/live-activity/ABC12345",
+            queryItems: [URLQueryItem(name: "token", value: "a b+c/d")]
+        )
+        XCTAssertEqual(url.path, "/live-activity/ABC12345")
+        XCTAssertFalse(url.absoluteString.contains("a b+c/d"))
+        let token = URLComponents(url: url, resolvingAgainstBaseURL: false)?
+            .queryItems?.first { $0.name == "token" }?.value
+        XCTAssertEqual(token, "a b+c/d")
+    }
+
+    func testAHostWithATrailingSlashDoesNotDoubleTheSeparator() throws {
+        let url = try NotifyGatewayClient.endpoint(
+            host: URL(string: "https://example.com/")!,
+            path: "/widgets/ABC12345",
+            queryItems: []
+        )
+        XCTAssertEqual(url.path, "/widgets/ABC12345")
+    }
+
+    /// The gateway accepts 0 to 14400 seconds and rejects anything else, so a
+    /// caller's preference is clamped rather than allowed to fail the end call
+    /// it is only decorating.
+    func testKeepForIsClamped() {
+        XCTAssertEqual(NotifyGatewayClient.clampedKeepFor(-10), 0)
+        XCTAssertEqual(NotifyGatewayClient.clampedKeepFor(600), 600)
+        XCTAssertEqual(
+            NotifyGatewayClient.clampedKeepFor(99_999),
+            Int(NotifyGatewayClient.maximumKeepFor)
+        )
+        XCTAssertEqual(NotifyGatewayClient.clampedKeepFor(.nan), 0)
+    }
+
+    // MARK: - Refusals that cost no request
+
+    /// A Live Activity aimed at a Mac, a browser or a group fails before a
+    /// request exists, with the sentence that names what to paste instead.
+    func testALiveActivityAimedAtADeviceThatCannotShowOneFailsLocally() async {
+        let client = NotifyGatewayClient(networkClient: NeverCalledClient())
+        let link = NotifyDeviceLink(deviceId: "MC12345678901234", token: "s")!
+        let tile = NotifyTile(title: "Claude Usage")!
+
+        do {
+            _ = try await client.publishTile(tile, link: link, activityId: nil)
+            XCTFail("a Mac cannot show a Live Activity")
+        } catch let error as NotifyPublishError {
+            guard case .liveActivityUnavailable = error else {
+                return XCTFail("expected liveActivityUnavailable, got \(error)")
+            }
+        } catch {
+            XCTFail("unexpected error \(error)")
+        }
+    }
+
+    func testEitherWidgetAimedAtAGroupFailsLocally() async {
+        let client = NotifyGatewayClient(networkClient: NeverCalledClient())
+        let link = NotifyDeviceLink(deviceId: "GRP12345", token: "s")!
+
+        do {
+            _ = try await client.publishGauge(NotifyGauge(title: "Claude Usage")!, link: link, widgetId: nil)
+            XCTFail("a group owns no widget list")
+        } catch let error as NotifyPublishError {
+            guard case .invalidPayload = error else {
+                return XCTFail("expected invalidPayload, got \(error)")
+            }
+        } catch {
+            XCTFail("unexpected error \(error)")
+        }
+
+        do {
+            _ = try await client.publishScreenTile(NotifyTile(title: "Claude Usage")!, link: link, screenWidgetId: nil)
+            XCTFail("a group owns no widget list")
+        } catch let error as NotifyPublishError {
+            guard case .invalidPayload = error else {
+                return XCTFail("expected invalidPayload, got \(error)")
+            }
+        } catch {
+            XCTFail("unexpected error \(error)")
+        }
+    }
+}
+
+/// A transport that fails the test if anything reaches it. Used where the point
+/// of the assertion is that no request was ever made.
+@MainActor
+private struct NeverCalledClient: NotifyHTTPClient {
+    func request(_ request: URLRequest) async throws -> (Data, URLResponse) {
+        XCTFail("no request should have been sent")
+        throw URLError(.badURL)
+    }
+}

--- a/Claude UsageTests/NotifyLimitsTests.swift
+++ b/Claude UsageTests/NotifyLimitsTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+@testable import Claude_Usage
+
+/// The gateway's field limits, enforced at construction so a long label
+/// shortens rather than failing the whole publish.
+///
+/// `@MainActor` because the app target builds with
+/// `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`, so everything under test is
+/// main-actor isolated while the test target's own default is not. Same
+/// reason `NotchHUDCoreTests` and `NotchHookServerTests` carry it.
+@MainActor
+final class NotifyLimitsTests: XCTestCase {
+
+    // MARK: - Text
+
+    func testShortensRatherThanFailing() {
+        let long = String(repeating: "a", count: 40)
+        XCTAssertEqual(NotifyLimits.text(long, maximum: 24)?.count, 24)
+    }
+
+    func testReportsAnEmptyResultAsNil() {
+        XCTAssertNil(NotifyLimits.text("", maximum: 24))
+        XCTAssertNil(NotifyLimits.text("   ", maximum: 24))
+        XCTAssertNil(NotifyLimits.text(nil, maximum: 24))
+    }
+
+    func testTrimsAndDropsNul() {
+        XCTAssertEqual(NotifyLimits.text("  5h  ", maximum: 24), "5h")
+        XCTAssertEqual(NotifyLimits.text("5\0h", maximum: 24), "5h")
+    }
+
+    func testLeavesTextInsideTheLimitAlone() {
+        XCTAssertEqual(NotifyLimits.text("Opus 7d", maximum: 24), "Opus 7d")
+    }
+
+    // MARK: - Progress
+
+    /// A quota can legitimately report a negative remainder when the user is
+    /// over the limit, and that reads as an empty bar rather than an error.
+    func testClampsRatherThanRejecting() {
+        XCTAssertEqual(NotifyLimits.progress(-15), 0)
+        XCTAssertEqual(NotifyLimits.progress(140), 100)
+        XCTAssertEqual(NotifyLimits.progress(42), 42)
+    }
+
+    func testDropsNonFiniteProgress() {
+        XCTAssertNil(NotifyLimits.progress(.nan))
+        XCTAssertNil(NotifyLimits.progress(.infinity))
+        XCTAssertNil(NotifyLimits.progress(nil))
+    }
+
+    // MARK: - Tint
+
+    func testNormalizesBothHexLengths() {
+        XCTAssertEqual(NotifyLimits.tint("34c759"), "#34C759")
+        XCTAssertEqual(NotifyLimits.tint("#34c759"), "#34C759")
+        XCTAssertEqual(NotifyLimits.tint("ff34c759"), "#FF34C759")
+    }
+
+    /// A bad color is dropped rather than failing the publish: a tile with the
+    /// wrong accent still tells the user their percentage.
+    func testDropsAnythingThatIsNotSixOrEightHexDigits() {
+        XCTAssertNil(NotifyLimits.tint("34c75"))
+        XCTAssertNil(NotifyLimits.tint("nothex"))
+        XCTAssertNil(NotifyLimits.tint("#zzzzzz"))
+        XCTAssertNil(NotifyLimits.tint(nil))
+    }
+
+    // MARK: - Values built on the limits
+
+    func testAMetricNeedsALabelAndAValue() {
+        XCTAssertNil(NotifyMetric(label: "", value: "42"))
+        XCTAssertNil(NotifyMetric(label: "5h", value: "  "))
+        XCTAssertNotNil(NotifyMetric(label: "5h", value: "42"))
+    }
+
+    func testATileKeepsAtMostSixMetrics() {
+        let metrics = (0..<9).compactMap { NotifyMetric(label: "w\($0)", value: "\($0)") }
+        let tile = NotifyTile(title: "Claude Usage", metrics: metrics)
+        XCTAssertEqual(tile?.metrics.count, 6)
+    }
+
+    func testATileNeedsATitle() {
+        XCTAssertNil(NotifyTile(title: "   "))
+        XCTAssertNotNil(NotifyTile(title: "Claude Usage"))
+    }
+
+    func testAGaugeNeedsATitle() {
+        XCTAssertNil(NotifyGauge(title: ""))
+        XCTAssertNotNil(NotifyGauge(title: "Claude Usage"))
+    }
+}

--- a/Claude UsageTests/NotifyPayloadBuilderTests.swift
+++ b/Claude UsageTests/NotifyPayloadBuilderTests.swift
@@ -1,0 +1,262 @@
+import XCTest
+@testable import Claude_Usage
+
+/// The whole decision layer of the Notify! feature: what to show, in what
+/// order, in what words, and in what color.
+///
+/// `@MainActor` because the app target builds with
+/// `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`, so everything under test is
+/// main-actor isolated while the test target's own default is not. Same
+/// reason `NotchHUDCoreTests` and `NotchHookServerTests` carry it.
+@MainActor
+final class NotifyPayloadBuilderTests: XCTestCase {
+
+    /// Fixed on purpose, so every countdown below is an explicit arithmetic
+    /// answer rather than whatever the machine's clock happened to say.
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+    private let builder = NotifyPayloadBuilder(title: "Claude Usage")
+
+    private func reading(
+        provider: String = "anthropic",
+        name: String = "Anthropic",
+        key: String,
+        label: String,
+        remaining: Double? = nil,
+        dollars: Double? = nil,
+        resetsIn: TimeInterval? = nil
+    ) -> NotifyQuotaReading {
+        NotifyQuotaReading(
+            providerId: provider,
+            providerName: name,
+            quota: NotifyQuota(
+                key: key,
+                label: label,
+                percentRemaining: remaining,
+                dollarRemaining: dollars,
+                currencyCode: dollars == nil ? nil : "USD",
+                resetsAt: resetsIn.map { now.addingTimeInterval($0) }
+            )
+        )
+    }
+
+    // MARK: - Ordering
+
+    /// The worst quota leads, and the tile takes its tint and countdown from
+    /// that one.
+    func testTheWorstQuotaLeads() {
+        let payload = builder.payload(
+            readings: [
+                reading(key: "weekly", label: "7d", remaining: 80),
+                reading(key: "session", label: "5h", remaining: 5, resetsIn: 3600),
+            ],
+            now: now
+        )
+
+        XCTAssertEqual(payload.tile?.metrics.first?.label, "5h")
+        XCTAssertEqual(payload.tile?.tintHex, NotifyQuotaStatus.critical.notifyTintHex)
+        XCTAssertEqual(payload.tile?.trailing, "1:00")
+    }
+
+    /// Two payloads built from the same readings must compare equal, or the
+    /// driver would republish forever.
+    func testOrderingIsDeterministicDownToTheLastTieBreak() {
+        let readings = [
+            reading(provider: "b", name: "Same", key: "weekly", label: "7d", remaining: 50),
+            reading(provider: "a", name: "Same", key: "weekly", label: "7d", remaining: 50),
+        ]
+
+        let first = NotifyPayloadBuilder.ordered(readings)
+        let second = NotifyPayloadBuilder.ordered(readings.reversed())
+
+        XCTAssertEqual(first.map { $0.providerId }, ["a", "b"])
+        XCTAssertEqual(second.map { $0.providerId }, ["a", "b"])
+    }
+
+    /// A seventh reading is dropped rather than failing the whole tile.
+    func testAtMostSixMetricsReachTheTile() {
+        let readings = (0..<9).map {
+            reading(key: "w\($0)", label: "w\($0)", remaining: Double($0 * 10))
+        }
+        let payload = builder.payload(readings: readings, now: now)
+        XCTAssertEqual(payload.tile?.metrics.count, 6)
+    }
+
+    // MARK: - Labels
+
+    func testLabelsOmitTheProviderNameWhenEveryReadingSharesOne() {
+        let payload = builder.payload(
+            readings: [
+                reading(key: "session", label: "5h", remaining: 20),
+                reading(key: "weekly", label: "7d", remaining: 60),
+            ],
+            now: now
+        )
+        XCTAssertEqual(payload.tile?.metrics.map { $0.label }, ["5h", "7d"])
+    }
+
+    func testLabelsRegainTheProviderNameWhenASecondAppears() {
+        let payload = builder.payload(
+            readings: [
+                reading(key: "session", label: "5h", remaining: 20),
+                reading(provider: "codex", name: "OpenAI Codex", key: "session", label: "5h", remaining: 60),
+            ],
+            now: now
+        )
+        XCTAssertEqual(
+            payload.tile?.metrics.map { $0.label },
+            ["Anthropic 5h", "OpenAI Codex 5h"]
+        )
+    }
+
+    // MARK: - Numbers
+
+    /// A 42% quota publishes 42, never 58. Every surface in this app reads as
+    /// remaining, and a full bar meaning a full quota is the only intuitive
+    /// mapping a gauge has.
+    func testAPercentageIsRemainingNotUsed() {
+        let payload = builder.payload(
+            readings: [reading(key: "session", label: "5h", remaining: 42)],
+            now: now
+        )
+        XCTAssertEqual(payload.tile?.progress, 42)
+        XCTAssertEqual(payload.gauge?.progress, 42)
+        XCTAssertEqual(payload.tile?.metrics.first?.value, "42")
+        XCTAssertEqual(payload.tile?.metrics.first?.unit, "%")
+    }
+
+    func testAMoneyQuotaPublishesItsBalanceAndNoUnit() {
+        let payload = builder.payload(
+            readings: [reading(key: "credits", label: "Credits", dollars: 12.5)],
+            now: now
+        )
+        XCTAssertEqual(payload.gauge?.value, NotifyQuota.formatCurrency(12.5, code: "USD"))
+        XCTAssertNil(payload.gauge?.unit)
+        XCTAssertNil(payload.gauge?.progress)
+    }
+
+    /// A whole balance drops its cents: the widget has forty characters and
+    /// "$120" reads faster than "$120.00".
+    ///
+    /// Asserted on the digits rather than on a whole formatted string, because
+    /// the balance is written in the user's own locale and the CI runner's is
+    /// not something to pin a test to.
+    func testAWholeBalanceDropsItsCentsAndAFractionalOneKeepsThem() {
+        let locale = Locale(identifier: "en_US")
+        let whole = NotifyQuota.formatCurrency(120, code: "USD", locale: locale)
+        let fractional = NotifyQuota.formatCurrency(120.5, code: "USD", locale: locale)
+
+        XCTAssertEqual(whole, "$120")
+        XCTAssertEqual(fractional, "$120.50")
+    }
+
+    /// The tile's bar falls through to the worst quota that has a percentage,
+    /// rather than vanishing whenever a credit balance is the headline.
+    func testTheBarFallsThroughPastAMoneyHeadline() {
+        let payload = builder.payload(
+            readings: [
+                reading(key: "credits", label: "Credits", dollars: 0),
+                reading(key: "session", label: "5h", remaining: 65),
+            ],
+            now: now
+        )
+        // The depleted balance leads and colors the tile...
+        XCTAssertEqual(payload.tile?.tintHex, NotifyQuotaStatus.depleted.notifyTintHex)
+        // ...but the bar comes from the window that actually has a percentage.
+        XCTAssertEqual(payload.tile?.progress, 65)
+    }
+
+    // MARK: - Countdown
+
+    func testTheCountdownUsesTheGatewaysCompactShapes() {
+        XCTAssertEqual(
+            NotifyQuota(key: "k", label: "l", resetsAt: now.addingTimeInterval(3 * 86400)).compactResetTime(now: now),
+            "3d"
+        )
+        XCTAssertEqual(
+            NotifyQuota(key: "k", label: "l", resetsAt: now.addingTimeInterval(4 * 3600 + 40 * 60)).compactResetTime(now: now),
+            "4:40"
+        )
+        XCTAssertEqual(
+            NotifyQuota(key: "k", label: "l", resetsAt: now.addingTimeInterval(12 * 60)).compactResetTime(now: now),
+            "12m"
+        )
+        XCTAssertEqual(
+            NotifyQuota(key: "k", label: "l", resetsAt: now.addingTimeInterval(30)).compactResetTime(now: now),
+            "soon"
+        )
+        XCTAssertNil(NotifyQuota(key: "k", label: "l").compactResetTime(now: now))
+    }
+
+    // MARK: - Gauge selection
+
+    func testTheGaugeShowsTheWindowTheUserPicked() {
+        let payload = builder.payload(
+            readings: [
+                reading(key: "session", label: "5h", remaining: 12),
+                reading(key: "weekly", label: "7d", remaining: 88),
+            ],
+            gaugeSelection: NotifyGaugeSelection(providerId: "anthropic", quotaKey: "weekly"),
+            now: now
+        )
+        XCTAssertEqual(payload.gauge?.progress, 88)
+    }
+
+    /// A selection naming a window that has stopped reporting falls back to the
+    /// worst quota rather than publishing nothing.
+    func testAStaleSelectionFallsBackToTheWorstQuota() {
+        let payload = builder.payload(
+            readings: [reading(key: "session", label: "5h", remaining: 12)],
+            gaugeSelection: NotifyGaugeSelection(providerId: "anthropic", quotaKey: "opus_weekly"),
+            now: now
+        )
+        XCTAssertEqual(payload.gauge?.progress, 12)
+    }
+
+    func testAnEmptySelectionIsAutomatic() {
+        XCTAssertTrue(NotifyGaugeSelection().isAutomatic)
+        XCTAssertTrue(NotifyGaugeSelection(providerId: "anthropic", quotaKey: "").isAutomatic)
+        XCTAssertFalse(NotifyGaugeSelection(providerId: "anthropic", quotaKey: "session").isAutomatic)
+    }
+
+    // MARK: - Surfaces
+
+    /// The Live Activity and the Home Screen tile are one built value, so the
+    /// two can never disagree about the same quota.
+    func testBothTilesCarryTheIdenticalValue() {
+        let payload = builder.payload(
+            readings: [reading(key: "session", label: "5h", remaining: 42, resetsIn: 3600)],
+            now: now
+        )
+        XCTAssertNotNil(payload.tile)
+        XCTAssertEqual(payload.tile, payload.screenTile)
+    }
+
+    func testASwitchedOffSurfaceIsNil() {
+        let payload = builder.payload(
+            readings: [reading(key: "session", label: "5h", remaining: 42)],
+            includesTile: false,
+            includesGauge: true,
+            includesScreenTile: false,
+            now: now
+        )
+        XCTAssertNil(payload.tile)
+        XCTAssertNil(payload.screenTile)
+        XCTAssertNotNil(payload.gauge)
+    }
+
+    func testNoReadingsMeansAnEmptyPayload() {
+        XCTAssertTrue(builder.payload(readings: [], now: now).isEmpty)
+    }
+
+    // MARK: - Status
+
+    func testStatusThresholdsMatchTheMenuBarsRemainingMode() {
+        XCTAssertEqual(NotifyQuotaStatus.forRemaining(100), .healthy)
+        XCTAssertEqual(NotifyQuotaStatus.forRemaining(30), .healthy)
+        XCTAssertEqual(NotifyQuotaStatus.forRemaining(29), .warning)
+        XCTAssertEqual(NotifyQuotaStatus.forRemaining(10), .warning)
+        XCTAssertEqual(NotifyQuotaStatus.forRemaining(9), .critical)
+        XCTAssertEqual(NotifyQuotaStatus.forRemaining(0), .depleted)
+    }
+}

--- a/Claude UsageTests/NotifyPublishGateTests.swift
+++ b/Claude UsageTests/NotifyPublishGateTests.swift
@@ -1,0 +1,191 @@
+import XCTest
+@testable import Claude_Usage
+
+/// When a payload is worth a request. Pure and clock free: `now` is a
+/// parameter, so every rule is a direct arithmetic assertion.
+///
+/// `@MainActor` because the app target builds with
+/// `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`, so everything under test is
+/// main-actor isolated while the test target's own default is not. Same
+/// reason `NotchHUDCoreTests` and `NotchHookServerTests` carry it.
+@MainActor
+final class NotifyPublishGateTests: XCTestCase {
+
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+    /// The shipping intervals, spelled out so a test reads as "thirty seconds
+    /// is inside the minute" without a lookup elsewhere.
+    private let gate = NotifyPublishGate(
+        tileInterval: 60,
+        gaugeInterval: 900,
+        screenTileInterval: 900,
+        keepAliveInterval: 5400
+    )
+
+    private func payload(
+        tile body: String? = nil,
+        gauge value: String? = nil,
+        screenTile screenBody: String? = nil
+    ) -> NotifyPayload {
+        NotifyPayload(
+            tile: body.flatMap { NotifyTile(title: "Claude Usage", body: $0, progress: 42) },
+            gauge: value.flatMap { NotifyGauge(title: "Claude Usage", value: $0, progress: 42) },
+            screenTile: screenBody.flatMap { NotifyTile(title: "Claude Usage", body: $0, progress: 42) }
+        )
+    }
+
+    // MARK: - First publish
+
+    func testWithNoRecordEverySurfaceIsDue() {
+        let decision = gate.decide(
+            payload: payload(tile: "a", gauge: "42", screenTile: "a"),
+            since: nil,
+            now: now
+        )
+        XCTAssertTrue(decision.publishesTile)
+        XCTAssertTrue(decision.publishesGauge)
+        XCTAssertTrue(decision.publishesScreenTile)
+    }
+
+    /// Nil means the user switched that surface off, and the gate must never
+    /// write one the payload left out.
+    func testASurfaceThePayloadLeftNilIsNeverWritten() {
+        let decision = gate.decide(payload: payload(gauge: "42"), since: nil, now: now)
+        XCTAssertFalse(decision.publishesTile)
+        XCTAssertTrue(decision.publishesGauge)
+        XCTAssertFalse(decision.publishesScreenTile)
+    }
+
+    func testAnEmptyPayloadPublishesNothing() {
+        XCTAssertTrue(gate.decide(payload: .empty, since: nil, now: now).publishesNothing)
+    }
+
+    // MARK: - Minimum intervals
+
+    func testAChangedTileIsHeldBackInsideItsMinute() {
+        let sent = payload(tile: "a", gauge: "42")
+        let record = NotifyPublishRecord(payload: sent, tileAt: now, gaugeAt: now)
+
+        let decision = gate.decide(
+            payload: payload(tile: "b", gauge: "42"),
+            since: record,
+            now: now.addingTimeInterval(30)
+        )
+        XCTAssertFalse(decision.publishesTile)
+    }
+
+    func testAChangedTileGoesOutOnceTheMinuteHasPassed() {
+        let sent = payload(tile: "a", gauge: "42")
+        let record = NotifyPublishRecord(payload: sent, tileAt: now, gaugeAt: now)
+
+        let decision = gate.decide(
+            payload: payload(tile: "b", gauge: "42"),
+            since: record,
+            now: now.addingTimeInterval(61)
+        )
+        XCTAssertTrue(decision.publishesTile)
+    }
+
+    /// iOS decides when a widget redraws, roughly every quarter hour, so
+    /// pushing faster buys nothing.
+    func testTheGaugeWaitsItsQuarterHour() {
+        let record = NotifyPublishRecord(payload: payload(gauge: "42"), gaugeAt: now)
+
+        XCTAssertFalse(
+            gate.decide(payload: payload(gauge: "41"), since: record, now: now.addingTimeInterval(600))
+                .publishesGauge
+        )
+        XCTAssertTrue(
+            gate.decide(payload: payload(gauge: "41"), since: record, now: now.addingTimeInterval(901))
+                .publishesGauge
+        )
+    }
+
+    func testAnUnchangedPayloadCostsNoRequest() {
+        let sent = payload(tile: "a", gauge: "42", screenTile: "a")
+        let record = NotifyPublishRecord(payload: sent, tileAt: now, gaugeAt: now, screenTileAt: now)
+
+        let decision = gate.decide(payload: sent, since: record, now: now.addingTimeInterval(300))
+        XCTAssertTrue(decision.publishesNothing)
+    }
+
+    // MARK: - Keep alive
+
+    /// The gateway ends a progress-only Live Activity after two hours without
+    /// an update, so an unchanged tile still has to be re-sent.
+    func testAnUnchangedTileIsRepublishedAfterTheKeepAlive() {
+        let sent = payload(tile: "a", gauge: "42", screenTile: "a")
+        let record = NotifyPublishRecord(payload: sent, tileAt: now, gaugeAt: now, screenTileAt: now)
+
+        XCTAssertFalse(
+            gate.decide(payload: sent, since: record, now: now.addingTimeInterval(5399)).publishesTile
+        )
+        XCTAssertTrue(
+            gate.decide(payload: sent, since: record, now: now.addingTimeInterval(5401)).publishesTile
+        )
+    }
+
+    /// The Home Screen tile takes the keep alive too: past its `staleAt` the
+    /// phone dims the tile rather than presenting old numbers as current.
+    func testTheHomeScreenTileTakesTheKeepAliveAsWell() {
+        let sent = payload(tile: "a", gauge: "42", screenTile: "a")
+        let record = NotifyPublishRecord(payload: sent, tileAt: now, gaugeAt: now, screenTileAt: now)
+
+        XCTAssertTrue(
+            gate.decide(payload: sent, since: record, now: now.addingTimeInterval(5401)).publishesScreenTile
+        )
+    }
+
+    /// The gauge is the one surface with no keep alive: the gateway documents
+    /// neither a reaper nor a freshness deadline for it, so a heartbeat there
+    /// would prevent nothing.
+    func testTheGaugeHasNoKeepAlive() {
+        let sent = payload(gauge: "42")
+        let record = NotifyPublishRecord(payload: sent, gaugeAt: now)
+
+        XCTAssertFalse(
+            gate.decide(payload: sent, since: record, now: now.addingTimeInterval(86_400)).publishesGauge
+        )
+    }
+
+    // MARK: - The record
+
+    /// The record merges one surface at a time, so a surface the gate held back
+    /// still remembers what it is actually showing rather than being filed as
+    /// having sent the payload that was built.
+    func testTheRecordMergesPerSurface() {
+        let first = payload(tile: "a", gauge: "42", screenTile: "a")
+        let record = NotifyPublishRecord(payload: first, tileAt: now, gaugeAt: now, screenTileAt: now)
+
+        let second = payload(tile: "b", gauge: "41", screenTile: "b")
+        let later = now.addingTimeInterval(61)
+        let merged = record.updated(
+            with: second,
+            decision: NotifyPublishDecision(publishesTile: true, publishesGauge: false, publishesScreenTile: false),
+            at: later
+        )
+
+        // The tile moved on; the gauge still remembers what the phone shows.
+        XCTAssertEqual(merged.payload.tile, second.tile)
+        XCTAssertEqual(merged.payload.gauge, first.gauge)
+        XCTAssertEqual(merged.tileAt, later)
+        XCTAssertEqual(merged.gaugeAt, now)
+    }
+
+    /// The gauge held back above must still go out once its own interval
+    /// arrives, which is only true because the record kept the old content.
+    func testAHeldBackGaugeStillGoesOutLater() {
+        let first = payload(tile: "a", gauge: "42")
+        var record = NotifyPublishRecord(payload: first, tileAt: now, gaugeAt: now)
+
+        let second = payload(tile: "b", gauge: "41")
+        record = record.updated(
+            with: second,
+            decision: NotifyPublishDecision(publishesTile: true, publishesGauge: false),
+            at: now.addingTimeInterval(61)
+        )
+
+        let decision = gate.decide(payload: second, since: record, now: now.addingTimeInterval(901))
+        XCTAssertTrue(decision.publishesGauge)
+    }
+}

--- a/Claude UsageTests/NotifySettingsStoreTests.swift
+++ b/Claude UsageTests/NotifySettingsStoreTests.swift
@@ -1,0 +1,215 @@
+import XCTest
+@testable import Claude_Usage
+
+/// The switches, the gauge selection and the surface handles.
+///
+/// The device token is deliberately not exercised here: it lives in the
+/// Keychain, and these assertions are about the defaults-backed half of the
+/// store, which is where all the actual rules are.
+///
+/// `@MainActor` because the app target builds with
+/// `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`, so everything under test is
+/// main-actor isolated while the test target's own default is not. Same
+/// reason `NotchHUDCoreTests` and `NotchHookServerTests` carry it.
+@MainActor
+final class NotifySettingsStoreTests: XCTestCase {
+
+    private var suiteName = ""
+    private var defaults: UserDefaults!
+    private var store: NotifySettingsStore!
+
+    /// The token this machine had linked before the suite ran, if any.
+    ///
+    /// The switches and handles live in a throwaway defaults suite, but the
+    /// token store is app-wide on a build with a reachable Keychain. Running
+    /// these tests must never cost a developer the device they had linked, so
+    /// whatever was there is put back in tearDown.
+    private var preexistingToken: String?
+
+    // The `async throws` overrides rather than the synchronous ones: this class
+    // is `@MainActor`, and only the async variants can carry isolation an
+    // override adds on top of XCTestCase's own. Same shape as
+    // `NotchHookServerTests`.
+    override func setUp() async throws {
+        suiteName = "notify.tests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+        store = NotifySettingsStore(defaults: defaults)
+        preexistingToken = store.deviceToken()
+    }
+
+    override func tearDown() async throws {
+        store.deleteDeviceToken()
+        if let preexistingToken {
+            _ = store.saveDeviceToken(preexistingToken)
+        }
+        preexistingToken = nil
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        store = nil
+    }
+
+    // MARK: - Defaults
+
+    /// A feature that talks to someone else's server cannot ship enabled.
+    func testPublishingIsOffUntilTheUserTurnsItOn() {
+        XCTAssertFalse(store.isEnabled())
+    }
+
+    /// Every surface is on once the feature itself is on: a user who linked a
+    /// device wants to see their usage.
+    func testEverySurfaceIsOnByDefault() {
+        XCTAssertTrue(store.isLiveActivityEnabled())
+        XCTAssertTrue(store.isWidgetEnabled())
+        XCTAssertTrue(store.isScreenWidgetEnabled())
+    }
+
+    func testTheGaugeStartsAutomatic() {
+        XCTAssertTrue(store.gaugeSelection().isAutomatic)
+    }
+
+    // MARK: - Round trips
+
+    func testTheSwitchesRoundTrip() {
+        store.setEnabled(true)
+        store.setLiveActivityEnabled(false)
+        store.setWidgetEnabled(false)
+        store.setScreenWidgetEnabled(false)
+
+        XCTAssertTrue(store.isEnabled())
+        XCTAssertFalse(store.isLiveActivityEnabled())
+        XCTAssertFalse(store.isWidgetEnabled())
+        XCTAssertFalse(store.isScreenWidgetEnabled())
+    }
+
+    func testTheGaugeSelectionRoundTrips() {
+        store.setGaugeProviderId("anthropic")
+        store.setGaugeQuotaKey("opus_weekly")
+
+        let selection = store.gaugeSelection()
+        XCTAssertFalse(selection.isAutomatic)
+        XCTAssertEqual(selection.providerId, "anthropic")
+        XCTAssertEqual(selection.quotaKey, "opus_weekly")
+    }
+
+    /// Half a selection is no selection: the builder falls back to the worst
+    /// window rather than looking for a provider with no window named.
+    func testHalfASelectionReadsAsAutomatic() {
+        store.setGaugeProviderId("anthropic")
+        XCTAssertTrue(store.gaugeSelection().isAutomatic)
+    }
+
+    // MARK: - Handles
+
+    func testTheHandlesRoundTripAndClear() {
+        store.setActivityId("LA123456")
+        store.setWidgetId("WG123456")
+        store.setScreenWidgetId("SW123456")
+
+        XCTAssertEqual(store.activityId(), "LA123456")
+        XCTAssertEqual(store.widgetId(), "WG123456")
+        XCTAssertEqual(store.screenWidgetId(), "SW123456")
+
+        store.setActivityId(nil)
+        store.setWidgetId(nil)
+        store.setScreenWidgetId(nil)
+
+        XCTAssertNil(store.activityId())
+        XCTAssertNil(store.widgetId())
+        XCTAssertNil(store.screenWidgetId())
+    }
+
+    /// An empty string is not a handle. Storing one would make the next publish
+    /// address `/live-activity/?token=`, which is not a route.
+    func testAnEmptyHandleReadsAsNoHandle() {
+        store.setActivityId("")
+        XCTAssertNil(store.activityId())
+    }
+
+    func testTheDeviceIdRoundTrips() {
+        store.setDeviceId("IO12345678901234")
+        XCTAssertEqual(store.deviceId(), "IO12345678901234")
+    }
+
+    // MARK: - The token
+
+    /// The regression this file exists for. A token that reports itself saved
+    /// and then cannot be read back leaves the pane saying "linked" while every
+    /// publish answers "add your device ID and token".
+    ///
+    /// Skipped rather than failed where no Keychain is reachable, which is CI
+    /// and any unsigned local build. That case is not a bug, it is the
+    /// documented outcome: `saveDeviceToken` returns false and nothing is
+    /// stored, which is exactly what the skip condition reads.
+    func testASavedTokenReadsBackAgain() throws {
+        try XCTSkipUnless(store.saveDeviceToken("s3cret-token"), Self.noKeychain)
+        XCTAssertEqual(store.deviceToken(), "s3cret-token")
+    }
+
+    func testSavingALinkReportsThatItLandedAndTheLinkIsReadable() throws {
+        let link = NotifyDeviceLink(deviceId: "493F9D2A", token: "s3cret-token")!
+
+        try XCTSkipUnless(store.saveDeviceLink(link), Self.noKeychain)
+        XCTAssertEqual(store.deviceLink(), link)
+        XCTAssertTrue(store.hasDeviceToken())
+    }
+
+    func testDeletingTheTokenLeavesNothingLinked() throws {
+        try XCTSkipUnless(store.saveDeviceToken("s3cret-token"), Self.noKeychain)
+        store.deleteDeviceToken()
+
+        XCTAssertNil(store.deviceToken())
+        XCTAssertNil(store.deviceLink())
+    }
+
+    /// A token never reaches UserDefaults, whichever way the save went. The
+    /// README promises every credential in this app stays out of cleartext on
+    /// disk, and this is the assertion that keeps that true for this one.
+    func testATokenIsNeverWrittenToAppSettings() {
+        store.saveDeviceToken("s3cret-token")
+
+        let plist = defaults.dictionaryRepresentation()
+        for (key, value) in plist {
+            XCTAssertFalse(
+                "\(value)".contains("s3cret-token"),
+                "the device token leaked into UserDefaults under \(key)"
+            )
+        }
+    }
+
+    private static let noKeychain =
+        "this build has no reachable Keychain (unsigned), so the token cannot be stored"
+
+
+    /// The handles name surfaces standing on a particular phone, so a link
+    /// pointing somewhere else invalidates them.
+    func testLinkingADifferentDeviceClearsTheSurfaceHandles() {
+        store.setActivityId("LA123456")
+        store.setWidgetId("WG123456")
+        store.setScreenWidgetId("SW123456")
+
+        // The return value is deliberately ignored: clearing the handles
+        // happens before the token is written, so this rule holds even where
+        // the Keychain would not take the token.
+        _ = store.saveDeviceLink(NotifyDeviceLink(deviceId: "493F9D2A", token: "s3cret")!)
+
+        XCTAssertNil(store.activityId())
+        XCTAssertNil(store.widgetId())
+        XCTAssertNil(store.screenWidgetId())
+    }
+
+    /// A rotated token is the same phone, and the tile and widgets already
+    /// standing on it are still ours. Clearing their handles would orphan them
+    /// and put a duplicate beside each on the next publish.
+    func testRotatingTheTokenForTheSameDeviceKeepsTheHandles() {
+        _ = store.saveDeviceLink(NotifyDeviceLink(deviceId: "493F9D2A", token: "old")!)
+        store.setActivityId("LA123456")
+        store.setWidgetId("WG123456")
+        store.setScreenWidgetId("SW123456")
+
+        _ = store.saveDeviceLink(NotifyDeviceLink(deviceId: "493F9D2A", token: "new")!)
+
+        XCTAssertEqual(store.activityId(), "LA123456")
+        XCTAssertEqual(store.widgetId(), "WG123456")
+        XCTAssertEqual(store.screenWidgetId(), "SW123456")
+    }
+}

--- a/Claude UsageTests/NotifyUsageReadingsTests.swift
+++ b/Claude UsageTests/NotifyUsageReadingsTests.swift
@@ -1,0 +1,227 @@
+import XCTest
+@testable import Claude_Usage
+
+/// The seam between `ClaudeUsage` and the flat readings the payload builder
+/// takes: which windows a provider actually reports, and what each one says.
+///
+/// `@MainActor` because the app target builds with
+/// `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`, so everything under test is
+/// main-actor isolated while the test target's own default is not. Same
+/// reason `NotchHUDCoreTests` and `NotchHookServerTests` carry it.
+@MainActor
+final class NotifyUsageReadingsTests: XCTestCase {
+
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+    private func usage(_ configure: (inout ClaudeUsage) -> Void = { _ in }) -> ClaudeUsage {
+        var usage = ClaudeUsage.empty
+        usage.sessionResetTime = now.addingTimeInterval(3600)
+        usage.weeklyResetTime = now.addingTimeInterval(4 * 86400)
+        configure(&usage)
+        return usage
+    }
+
+    private func keys(_ readings: [NotifyQuotaReading]) -> [String] {
+        readings.map { $0.quota.key }
+    }
+
+    private func quota(_ readings: [NotifyQuotaReading], _ key: String) -> NotifyQuota? {
+        readings.first { $0.quota.key == key }?.quota
+    }
+
+    // MARK: - The always-present windows
+
+    func testTheSessionAndWeeklyWindowsAreAlwaysReported() {
+        let readings = NotifyUsageReadings.readings(from: usage(), provider: .anthropic, now: now)
+        XCTAssertTrue(keys(readings).contains(NotifyUsageReadings.QuotaKey.session))
+        XCTAssertTrue(keys(readings).contains(NotifyUsageReadings.QuotaKey.weekly))
+    }
+
+    /// The app publishes remaining, not used, so a 30% used window reaches the
+    /// phone as 70.
+    func testPercentagesArriveAsRemaining() {
+        let readings = NotifyUsageReadings.readings(
+            from: usage { $0.sessionPercentage = 30 },
+            provider: .anthropic,
+            now: now
+        )
+        XCTAssertEqual(quota(readings, NotifyUsageReadings.QuotaKey.session)?.percentRemaining, 70)
+    }
+
+    /// A provider that reports more than 100% used should read as an empty
+    /// window rather than as a negative one.
+    func testAnOverrunWindowClampsToEmpty() {
+        let readings = NotifyUsageReadings.readings(
+            from: usage { $0.sessionPercentage = 130 },
+            provider: .anthropic,
+            now: now
+        )
+        XCTAssertEqual(quota(readings, NotifyUsageReadings.QuotaKey.session)?.percentRemaining, 0)
+    }
+
+    /// A window that rolled over while the Mac was asleep is full again, and
+    /// publishing the stale percentage would put a red ring on a phone for a
+    /// limit that no longer applies.
+    func testAnExpiredSessionWindowReadsAsFull() {
+        let readings = NotifyUsageReadings.readings(
+            from: usage {
+                $0.sessionPercentage = 95
+                $0.sessionResetTime = now.addingTimeInterval(-60)
+            },
+            provider: .anthropic,
+            now: now
+        )
+        let session = quota(readings, NotifyUsageReadings.QuotaKey.session)
+        XCTAssertEqual(session?.percentRemaining, 100)
+        XCTAssertNil(session?.resetsAt)
+    }
+
+    // MARK: - Per-model windows
+
+    /// A model the account has never used has no window, and a placeholder
+    /// 100% would take a slot on the tile away from a number that matters.
+    func testAnUnusedModelWindowIsLeftOut() {
+        let readings = NotifyUsageReadings.readings(from: usage(), provider: .anthropic, now: now)
+        XCTAssertFalse(keys(readings).contains(NotifyUsageReadings.QuotaKey.opusWeekly))
+        XCTAssertFalse(keys(readings).contains(NotifyUsageReadings.QuotaKey.sonnetWeekly))
+    }
+
+    func testAReportingModelWindowIsIncluded() {
+        let readings = NotifyUsageReadings.readings(
+            from: usage { $0.opusWeeklyPercentage = 40 },
+            provider: .anthropic,
+            now: now
+        )
+        XCTAssertEqual(quota(readings, NotifyUsageReadings.QuotaKey.opusWeekly)?.percentRemaining, 60)
+    }
+
+    /// A provider without per-model reporting never gets those windows, even if
+    /// the struct happens to carry numbers in those fields.
+    func testAProviderWithoutPerModelReportingGetsNoModelWindows() {
+        let readings = NotifyUsageReadings.readings(
+            from: usage { $0.opusWeeklyPercentage = 40 },
+            provider: .codex,
+            now: now
+        )
+        XCTAssertFalse(keys(readings).contains(NotifyUsageReadings.QuotaKey.opusWeekly))
+    }
+
+    /// A model window with a reset time of its own uses it; one without falls
+    /// back to the shared weekly reset.
+    func testAModelWindowFallsBackToTheSharedWeeklyReset() {
+        let ownReset = now.addingTimeInterval(2 * 86400)
+        let readings = NotifyUsageReadings.readings(
+            from: usage {
+                $0.opusWeeklyPercentage = 10
+                $0.sonnetWeeklyPercentage = 10
+                $0.sonnetWeeklyResetTime = ownReset
+            },
+            provider: .anthropic,
+            now: now
+        )
+        XCTAssertEqual(
+            quota(readings, NotifyUsageReadings.QuotaKey.opusWeekly)?.resetsAt,
+            now.addingTimeInterval(4 * 86400)
+        )
+        XCTAssertEqual(
+            quota(readings, NotifyUsageReadings.QuotaKey.sonnetWeekly)?.resetsAt,
+            ownReset
+        )
+    }
+
+    // MARK: - Money
+
+    /// A spend allowance with a ceiling is a percentage like any other window,
+    /// so it draws a bar.
+    func testASpendAllowanceWithACeilingIsAPercentage() {
+        let readings = NotifyUsageReadings.readings(
+            from: usage {
+                $0.costUsed = 25
+                $0.costLimit = 100
+                $0.costCurrency = "USD"
+            },
+            provider: .anthropic,
+            now: now
+        )
+        XCTAssertEqual(quota(readings, NotifyUsageReadings.QuotaKey.cost)?.percentRemaining, 75)
+    }
+
+    /// Without a ceiling there is nothing to divide by, and a bare "spent so
+    /// far" number answers no question the user is asking a Lock Screen.
+    func testASpendWithNoCeilingIsNotPublished() {
+        let readings = NotifyUsageReadings.readings(
+            from: usage { $0.costUsed = 25 },
+            provider: .anthropic,
+            now: now
+        )
+        XCTAssertFalse(keys(readings).contains(NotifyUsageReadings.QuotaKey.cost))
+    }
+
+    func testAnOverageBalanceIsMoneyWithNoRing() {
+        let readings = NotifyUsageReadings.readings(
+            from: usage {
+                $0.overageBalance = 40
+                $0.overageBalanceCurrency = "USD"
+            },
+            provider: .anthropic,
+            now: now
+        )
+        let overage = quota(readings, NotifyUsageReadings.QuotaKey.overage)
+        XCTAssertEqual(overage?.dollarRemaining, 40)
+        XCTAssertNil(overage?.percentRemaining)
+        XCTAssertTrue(overage?.isDollarBased == true)
+    }
+
+    func testACreditsBalanceIsPublishedForProvidersThatReportOne() {
+        let readings = NotifyUsageReadings.readings(
+            from: usage { $0.creditsBalance = 18.25 },
+            provider: .codex,
+            now: now
+        )
+        XCTAssertEqual(quota(readings, NotifyUsageReadings.QuotaKey.credits)?.dollarRemaining, 18.25)
+    }
+
+    /// "Unlimited" on a ring is not a number, so the window is left out.
+    func testAnUnlimitedPlanPublishesNoCreditsWindow() {
+        let readings = NotifyUsageReadings.readings(
+            from: usage {
+                $0.creditsBalance = 0
+                $0.creditsUnlimited = true
+            },
+            provider: .codex,
+            now: now
+        )
+        XCTAssertFalse(keys(readings).contains(NotifyUsageReadings.QuotaKey.credits))
+    }
+
+    func testCreditsAreNotPublishedForAProviderThatDoesNotReportThem() {
+        let readings = NotifyUsageReadings.readings(
+            from: usage { $0.creditsBalance = 18.25 },
+            provider: .anthropic,
+            now: now
+        )
+        XCTAssertFalse(keys(readings).contains(NotifyUsageReadings.QuotaKey.credits))
+    }
+
+    // MARK: - Identity
+
+    func testEveryReadingCarriesTheProvidersIdAndName() {
+        let readings = NotifyUsageReadings.readings(from: usage(), provider: .anthropic, now: now)
+        XCTAssertTrue(readings.allSatisfy { $0.providerId == "anthropic" })
+        XCTAssertTrue(readings.allSatisfy { $0.providerName == "Anthropic" })
+    }
+
+    /// The keys are persisted in the gauge selection, so renaming one would
+    /// silently drop a user's chosen window back to automatic.
+    func testTheQuotaKeysAreTheOnesTheGaugeSelectionStores() {
+        XCTAssertEqual(NotifyUsageReadings.QuotaKey.session, "session")
+        XCTAssertEqual(NotifyUsageReadings.QuotaKey.weekly, "weekly")
+        XCTAssertEqual(NotifyUsageReadings.QuotaKey.opusWeekly, "opus_weekly")
+        XCTAssertEqual(NotifyUsageReadings.QuotaKey.sonnetWeekly, "sonnet_weekly")
+        XCTAssertEqual(NotifyUsageReadings.QuotaKey.designWeekly, "design_weekly")
+        XCTAssertEqual(NotifyUsageReadings.QuotaKey.fableWeekly, "fable_weekly")
+        XCTAssertEqual(NotifyUsageReadings.QuotaKey.cost, "cost")
+        XCTAssertEqual(NotifyUsageReadings.QuotaKey.overage, "overage")
+        XCTAssertEqual(NotifyUsageReadings.QuotaKey.credits, "credits")
+    }
+}

--- a/docs/features/notify.md
+++ b/docs/features/notify.md
@@ -1,0 +1,292 @@
+# Notify!
+
+Claude Usage Tracker already knows every usage window worth knowing, and the phone is where the user actually looks. [Notify!](https://getnotifyapp.com) already exists, runs on Mac and iOS and reaches anything else through web push, and has a documented gateway API, so this app can put a usage window on a Lock Screen and a Home Screen without shipping an iOS app of its own.
+
+---
+
+## The problem
+
+Every surface this app has is on the Mac, and every one of them needs the Mac awake and in front of you.
+
+| Surface | Failure mode |
+|---|---|
+| **Menu bar icon** | One number, on a screen you have to be looking at. Gone the moment the lid closes. |
+| **Popover** | A click on a target you have to aim for, on a machine you have to be sitting at. |
+| **Notifications** | Transient, and delivered to the Mac. Focus modes swallow them. |
+| **Notch HUD** | The best of the four and still the same machine, the same lid, the same desk. |
+
+The question the app exists to answer is *"can I start another long run?"*, and it gets asked away from the desk as often as at it. A 95% notification firing into a sleeping Mac is a notification nobody reads.
+
+`Views/Settings/App/MobileAppView.swift` is a painted door counting taps on a "Notify Me" button for exactly this. The real iPhone app behind that door is enormous out of proportion to the payload: an App Store presence and review queue, a push service to run, an account system to pair a Mac with a phone, a widget extension, a Live Activity extension, and a second release train alongside the Sparkle one. All of that to render one percentage.
+
+Notify! has already built it. It is a published app covering Mac, iOS and web push, whose entire premise is that a script somewhere else pushes content to a device you carry: it owns the push certificates, the device pairing, and on iOS the extensions that draw a Lock Screen and a Home Screen. What it exposes is a plain HTTP gateway with no SDK and no bearer token, addressed by a device id and a per-device secret the user copies out of the app.
+
+So the whole feature on this side is: turn the usage the app already holds into two small JSON bodies, and POST them to three routes.
+
+## Behavior
+
+Three surfaces, each switchable on its own once the feature itself is on, and two of them carry the identical thing.
+
+That last part is the premise rather than a coincidence, and it is what makes the third surface nearly free. The gateway derives the Home Screen widget's content contract from the same module its Live Activity uses: same fields, same caps, same merge rules. `NotifyPayloadBuilder` builds the tile once, as one `NotifyTile` handed to both surfaces, and `NotifyGatewayClient` encodes it through the same `tileBody` for both routes. Building it twice would only produce two things that were meant to be identical and one day were not, which on a phone reads as two different pictures of one number.
+
+**The metrics Live Activity** is the dense one. It carries the title `Claude Usage`, a progress bar, a compact reset countdown where a timer would sit, and a row of up to six windows, each with its own label, value, unit and color. Six is the gateway's ceiling and also about the point at which a Lock Screen row stops being readable, so the two limits agree.
+
+**The Home Screen widget** carries that same tile, and differs in when the user meets it. A Live Activity appears while something is happening and goes away when it stops; a Home Screen widget stays where it was placed and always shows the latest thing stored for it. Neither is a substitute for the other, which is why both are on by default and either can be switched off alone.
+
+The Home Screen widget is also the newest surface on Notify!'s side, and that shows in two places. It needs a recent Notify!, where it is turned on under Settings then Home Screen Widgets. And creating one over the gateway puts nothing on a screen by itself: it fills a slot the user still has to place through iOS's own widget picker.
+
+**The Lock Screen widget** is the glanceable one, and the only surface with a shape of its own. Its gauge is a single chosen window: a headline value, a unit, a quieter second line naming the provider and the window, and a `progress` the gateway draws as a bar on the rectangular widget and as a ring on the circular one. It shows whichever window needs attention most until the user picks a specific one.
+
+### Which usage reaches the phone
+
+**The active profile's, and only the active profile's.** The phone shows what the menu bar shows. Merging every profile into one tile would need the six metric slots to cover several accounts, and a phone that disagreed with the Mac is worse than one that shows less. Switching profile on the Mac moves the phone with it, because the driver watches `ProfileManager.activeProfile`.
+
+`NotifyUsageReadings` is the seam. `ClaudeUsage` is a wide struct of named windows, some of which a given provider never fills in; `NotifyQuotaReading` is a flat list of windows that are actually reporting something. Only windows the provider genuinely reports are included: a per-model weekly window a provider never fills in would otherwise sort as a healthy 100% and take one of the tile's six slots away from a number that matters.
+
+| Window | Key | Included when |
+|---|---|---|
+| 5h session | `session` | always; an expired window reads as full rather than as its stale percentage |
+| 7d weekly | `weekly` | always |
+| Opus / Sonnet / Design / Fable 7d | `opus_weekly`, … | the provider reports per-model breakdowns **and** some of it has been used |
+| Spend | `cost` | a cost limit exists to divide by |
+| Extra usage | `overage` | an overage balance is reported |
+| Credits | `credits` | the provider reports credits and the plan is not unlimited |
+
+Four rules shape what all of that actually says, and all four live in `NotifyPayloadBuilder`:
+
+- **Percentages are remaining, not used.** A 42% window publishes `progress: 42`. Every other surface in this app reads that way, and a full ring meaning a full window is the only intuitive mapping a gauge has.
+- **The worst window leads.** Readings sort by status severity, then by how little is left. The headline is the first one, and the tile takes its tint, its bar and its countdown from it.
+- **Labels drop the provider name when they can.** A tile covering one provider reads `5h 7d`, not `Anthropic 5h Anthropic 7d`. The name comes back as soon as a second provider is on show.
+- **Ordering is fully deterministic**, down to a name and window-key tiebreak. Two payloads built from the same readings must compare equal, or the driver would republish forever.
+
+Money-based windows have no percentage to draw. Their value is the formatted balance with no unit, and the tile's bar falls through to the worst window that *does* have a percentage, rather than vanishing whenever a credit balance happens to be the headline.
+
+Colors are the menu bar's own, so a window that reads critical in the menu bar reads critical on the Lock Screen. `NotifyQuotaStatus` adds a fourth level the Mac does not have — `depleted` — because on a ring "you have run out" and "you are nearly out" are otherwise a quarter of a degree apart.
+
+### Publish cadence
+
+Usage moves on every refresh and the reset countdown moves every minute, so "publish whenever the payload differs" is a request per refresh, forever. `NotifyPublishGate` adds four rules on top of the difference:
+
+| Rule | Value | Why |
+|---|---|---|
+| Minimum gap, tile | 60 s | The tile is a push, so it can afford to be prompt. |
+| Minimum gap, gauge | 15 min | iOS decides when a widget redraws, roughly every quarter hour. Pushing faster buys nothing. |
+| Minimum gap, Home Screen tile | 15 min | Also a poll, on the same quarter hour and for the same reason. |
+| Keep alive, tile and Home Screen tile | 90 min | Two deadlines, both at **two hours**, both measured from the last write. The gateway ends a progress-only Live Activity that has gone that long without an update; and a Home Screen widget's `staleAt` lands there too, after which the phone dims the tile rather than presenting old numbers as current. Ninety minutes clears both with room to spare. |
+
+The gauge is the one surface with no keep alive. The gateway documents neither a reaper nor a freshness deadline for `/widgets`, so there is nothing a heartbeat there would prevent.
+
+The keep alive is the reason `NotifyPublishDriver` runs a one minute timer at all. Both time-based rules are unreachable from published state alone: a change the gate suppressed for arriving too soon has to be offered again once its interval has passed, and nothing in `@Published` state fires on the mere passage of time.
+
+Saving credentials or pressing **Send Now** in the settings pane bypasses the gate entirely by clearing the record, because waiting a quarter of an hour to find out whether a token works is not an answer. The pane does that through `NotifyPublishDriver.publishNow()` rather than publishing for itself: the driver holds the stored handles and the single in-flight publish, and two publishers racing over one nil activity id is precisely how a phone ends up with two Live Activities.
+
+### Recovery
+
+Each failure mode below has a remedy of its own, and each one is a distinct case on `NotifyPublishError` for exactly that reason.
+
+| What happened | HTTP | What the app does |
+|---|---|---|
+| The user swiped the tile away | 410 | Forget the stored activity id and start a fresh tile, once. A retry loop here is a retry loop against the gateway. |
+| A stored handle is refused | 403 | Forget that one handle, so the next publish creates a replacement for it. The gateway answers a missing token, a wrong token, an unknown id and somebody else's id identically, so a 403 is not evidence the credentials are bad: far more often the user deleted that one tile or widget in the Notify! app. The other surfaces' handles are left alone, because clearing one would abandon something alive and put a duplicate beside it. |
+| Push to start backoff | 429 | Suppress tile writes until the gateway's own wait has passed. Every attempt inside the wait lengthens it. Both widgets keep publishing. |
+| The phone has never opened Notify! | 409 | Report it and stop. No Live Activity can start until the device has a push-to-start credential, which only opening the app once produces. |
+| Apple never answered a start | 502 `unknown` | Keep the activity id the gateway returned and update it on the next tick. Starting again could leave two tiles. |
+| Apple refused a start | 502 `not-delivered` | Wait. No tile exists, so starting again is safe, but every unanswered start counts toward the same ladder as a 429, so the gateway's own `retryAfterSeconds` is honored and 30 minutes assumed when it names none. |
+| Home Screen widgets are not being served | 503 | Pause that one surface for six hours and say so at info level, not as an error. This is the gateway's own kill switch rather than anything wrong here, and nothing on this Mac moves it. The other two surfaces are untouched. |
+
+Some failures are not worth discovering over the wire. A Live Activity aimed at a `GRP`, `MC` or `WB` id is refused locally, before a request exists, because the outcome is already known. Either widget aimed at a `GRP` id is refused for a different reason: a group is not a device and owns no widget list to write into. What the user reads in both cases is the id's own reason, which names the kind of device they linked and tells them what to paste instead, rather than a status code that reads as the app failing at something it should have managed.
+
+The three surfaces are written independently, each addressed by its own stored handle and each failing for its own reasons. A tile the device refuses to start must not cost the user their widgets, which poll happily on a phone that cannot start a Live Activity at all.
+
+### Privacy
+
+Every other network call this app makes fetches usage from the provider that owns it. This one is the first that sends the app's own state outward, to a service that is neither the user's machine nor a provider they already have an account with, so it is worth being explicit.
+
+- **What leaves the machine:** provider names, window labels, remaining percentages or balances, and reset countdowns. No prompts, no repository names, no file paths, no session content.
+- **Where it goes:** `push.getnotifyapp.com`, a third party service, and from there to the user's own phone.
+- **Off by default.** `NotifyConstants.defaultEnabled` is `false`, and the switch stays disabled until a device is linked. A feature that talks to someone else's server cannot ship enabled.
+- **The token is a secret, and it lives in the Keychain or nowhere.** It goes through the same `saveItem`/`loadItem` helpers the per-profile secrets use, so it gets the data-protection keychain on entitled builds and the file-based login keychain on stably-signed ones. It is never logged, and neither is the device id above debug level.
+- **A save is confirmed, not assumed.** `KeychainService.saveNotifyDeviceToken` reads the token back before reporting success, and `saveDeviceToken` and `saveDeviceLink` return that answer. A phantom write would otherwise leave the pane showing a linked device while every publish answered "not linked" — which is exactly what happened before this was checked.
+- **There is no fallback store, deliberately.** The README's promise is that every credential in this app is kept in the Keychain and never in cleartext on disk (GHSA-mfxh-xpwm-23c7), and a push token is not the place to make an exception for convenience. So a build that cannot reach a Keychain cannot link, and the pane says so in as many words.
+
+### The app has to be signed
+
+This is the one requirement the feature adds, and it is worth stating plainly because the failure is otherwise puzzling.
+
+An **ad-hoc signed build has no reachable Keychain at all**. The data-protection keychain wants an application-identifier entitlement such a build has no way to carry, and the file-based login keychain is deliberately gated off for ad-hoc identities, because their designated requirement changes on every rebuild and the next launch would throw a "wants to use your confidential information" password prompt (#292).
+
+That covers every copy built locally in Xcode without a development team set. Linking will fail with a message naming the cause. Setting a team under **Signing & Capabilities**, or using a release download, resolves it. Nothing else about the feature depends on signing.
+
+---
+
+## The gateway
+
+Read from its own OpenAPI document (`https://getnotifyapp.com/apidocs/openapi.json`). Host `https://push.getnotifyapp.com`; `NotifyGatewayClient`'s initializer takes another only so tests can point it at a stub. These routes declare `security: []`: there is no bearer token, and the per-device secret travels in `?token=`.
+
+### The id namespaces, and which of them have a screen
+
+| Id | What it names | Live Activity | Lock Screen widget | Home Screen widget |
+|---|---|---|---|---|
+| `GRP` + 5 | A notification group | no | no | no |
+| `MC` + 14 | A push capable Mac listener | no | yes | yes |
+| `WB` + 14 | A web push browser | no | yes | yes |
+| `IO` + 14 | An iPhone or iPad | yes | yes | yes |
+| 8 characters | The legacy format: an iPhone or iPad, or an older poll-only Mac listener | yes | yes | yes |
+| anything else | A format newer than this document | yes | yes | yes |
+
+Note which way round the Live Activity rule is written. The namespaces that cannot show one are named and everything else is allowed, rather than the reverse, because app device ids are not one fixed shape: the legacy format is 8 characters, `IO` is 16, and more will follow. A list of what *may* pass would refuse a real phone on the day Notify! mints a format this file has never heard of, and a refused phone reads as the app being broken.
+
+Both widgets are the opposite, and identically so. The gateway is explicit that neither route carries a device-type gate. Only a group is refused, and only because a group is not a device. `NotifyDeviceKind.supportsScreenWidget` is therefore written as `supportsWidget` rather than as a second copy of the same switch, so the two can never drift into disagreeing about one id.
+
+One thing cannot be decided locally at all. The legacy 8-character format is shared by iPhones and by older poll-only Mac listeners, and nothing in the id separates them, so such an id is allowed through and the gateway has the last word. Note too that `GRP` plus 5 is itself eight characters, so the two grammars genuinely overlap and the prefix is tested first, which is the gateway's own tie break.
+
+### The fields are the type
+
+**There is no tile type, and no widget display format.** No `activityType`, no `displayFormat`, nothing to select a layout with. Which fields are populated decides how the thing draws, and they compose. A title plus a progress bar plus a metrics row **is** the metrics tile. That is the single most surprising thing about this API, and it is what makes the feature cheap.
+
+Saying nothing is load bearing in a second way, and it cuts both ways. Updates are JSON merge-patch: an absent field is left alone, a value replaces, an explicit `null` deletes. So `NotifyGatewayClient` deliberately never mentions `status`, `endsIn`, `steps`, `step` or `button`, and an update from here can share a tile with whatever else the user configured.
+
+The same rule makes silence dangerous for the fields the app does drive. Omitting one it previously set does not clear it, it freezes it. A reset countdown would keep ticking beside a window that no longer reports one, and a gauge would keep the last percentage after the shown reading became a credit balance with no percentage at all. So every field the app owns is stated on every write, as an explicit `null` when it has no value. `title` is the one exception: the gateway treats it as an identity and refuses to clear it.
+
+`POST /live-activity/{id}?token=`
+
+| Field | Type | Limit | Notes |
+|---|---|---|---|
+| `title` | string | 120 | Required to start. The tile's identity. |
+| `body` | string | 300 | Second line, shown only when there are no metrics in its place. |
+| `symbol` | string | 64 | SF Symbol name. |
+| `tint` | string | hex | `#RRGGBB` or `#AARRGGBB`, leading `#` optional. |
+| `progress` | number | 0 to 100 | The bar. Clamped, not rejected. `null` removes it. |
+| `trailing` | string | 40 | Static text where a timer would go. |
+| `metrics` | array | 6 items | JSON body only, no query spelling. Replaces wholesale. |
+
+`metrics[]` is `{label (1 to 24, required), value (1 to 16 or a number, required), unit (8), color (hex)}`. An absent color inherits the tile tint.
+
+`POST /widgets/{id}?token=`
+
+| Field | Type | Limit | Notes |
+|---|---|---|---|
+| `title` | string | 120 | Required to create. The identity in the phone's widget picker. Can be replaced, never cleared. |
+| `value` | string | 40 | Headline text, pre-formatted by the caller. |
+| `unit` | string | 12 | Small label beside the value. |
+| `detail` | string | 120 | Quieter second line. |
+| `symbol` | string | 64 | SF Symbol name. |
+| `tint` | string | hex | Accent color. |
+| `progress` | number | 0 to 100 | The gauge: a bar on the rectangular widget, a ring on the circular one. |
+
+`POST /screenwidgets/{id}?token=`
+
+No third table, because there is nothing new to put in one. This route's content contract is derived from the Live Activity's, field for field and cap for cap, so the tile table above describes it exactly and `NotifyGatewayClient` sends it through the same `tileBody`. What differs on the wire is the path and the id namespace: `SW` plus six characters, alongside `LA` and `WG`.
+
+`NotifyLimits` enforces every length above at construction, shortening rather than failing, because a window label that happens to be long should shorten, never fail to reach the phone.
+
+Two statuses mean something on `/screenwidgets` that they mean nowhere else, so `publishScreenTile` translates them where that difference is known rather than inside the shared mapping every other route would then have to reason about: a **503** is the server-side kill switch and becomes `surfaceSwitchedOff`, and a **409** here means the device dialect found several screen widgets and cannot say which was meant, so it becomes `invalidPayload` rather than the Live Activity's "open the Notify! app".
+
+### Two dialects, and why only one of them is used
+
+All three write routes take either a **device id** or a **handle**, and the handler decides by looking the id up rather than by its shape.
+
+- Device id, the *upsert* dialect: the first call starts the device's single live tile and later calls update it in place.
+- `LA######` / `WG######` / `SW######`, the *precise* dialect: always that exact tile or widget.
+
+The upsert dialect is the shorter code and it is wrong here. A user who has a Notify! tile running from some other script of their own would find this app had taken it over, silently, with a percentage. So the app always creates its own: the first write carries `"new": true` against the device id, the returned handle is persisted, and every write after that addresses the handle. `new` never appears on an update, where it would leave the device with two tiles. It earns its keep twice over: it is also the gateway's documented override for the sticky-dismissal 410.
+
+### The one call that is rate limited
+
+`GET /link?id=&token=` validates a pair and describes the device it names, and the gateway allows **five calls a minute per IP**. It sits behind the pane's **Verify Device** button and nothing else. Nothing on a timer may call it. It answers **404**, not the 403 every other route uses, for a pair it does not recognise, giving that same 404 for a wrong token and for an id that does not exist so it cannot be used to enumerate ids.
+
+---
+
+## Architecture
+
+Notify! is a **destination**, not a provider. Nothing in this feature reads usage from anywhere: it reads what the active profile already holds.
+
+```
+Claude Usage/Shared/Notify/
+├── NotifyLimits.swift              # the gateway's field limits, enforced at construction
+├── NotifyDeviceLink.swift          # device id + token; NotifyDeviceKind; NotifyDeviceInfo
+├── NotifyQuota.swift               # NotifyQuotaStatus, NotifyQuota, NotifyQuotaReading
+├── NotifyTile.swift                # NotifyMetric, NotifyTile: the content both tiles carry
+├── NotifyGauge.swift               # the Lock Screen widget's content; progress is the gauge
+├── NotifyPayload.swift             # NotifyGaugeSelection, NotifyPayload
+├── NotifyPayloadBuilder.swift      # readings to one tile + a gauge; pure, the whole decision layer
+├── NotifyPublishGate.swift         # whether a payload is worth a request; pure, clock free
+├── NotifyPublishError.swift        # every way a publish fails, and the remedy each implies
+├── NotifyPublishing.swift          # the protocol; the app's only view of the API
+├── NotifyHTTPClient.swift          # the seam that lets the client be tested without a network
+├── NotifyTint.swift                # NotifyQuotaStatus.notifyTintHex, NotifySymbol.quota
+├── NotifySettingsStore.swift       # NotifyConstants + notify.* keys, token to the Keychain
+├── NotifyUsageReadings.swift       # ClaudeUsage to readings; the one provider-aware file
+├── NotifyGatewayClient.swift       # the only file that knows HTTP exists
+└── NotifyPublishDriver.swift       # the Combine subscription, the tick, and the writes
+
+Claude Usage/Views/Settings/App/
+└── NotifySettingsView.swift        # link, verify, surface switches, gauge picker, send now
+```
+
+Settings keys, all under `notify.` in UserDefaults:
+
+| Key | Holds |
+|---|---|
+| `notify.enabled` | Whether the app publishes at all. Default `false`. |
+| `notify.deviceId` | The linked device id. |
+| `notify.liveActivityEnabled` | Whether the tile is published. Default `true`. |
+| `notify.widgetEnabled` | Whether the gauge is published. Default `true`. |
+| `notify.screenWidgetEnabled` | Whether the Home Screen tile is published. Default `true`, because a 503 is handled as "not yet" rather than as an error, and shipping it off would mean nobody saw the surface on the day Notify! switched it on. |
+| `notify.gauge.providerId`, `notify.gauge.quotaKey` | Which window the gauge shows. Both empty means automatic. |
+| `notify.activityId`, `notify.widgetId`, `notify.screenWidgetId` | The handles of the three surfaces this app created. |
+
+The device token never appears here. It goes to the Keychain through `KeychainService.saveNotifyDeviceToken`, or it is not stored at all.
+
+### The testable core
+
+Everything that decides anything is a pure value type with no clock, no network and no settings lookups of its own. `NotifyPayloadBuilder` takes readings and a selection and returns a payload; `NotifyPublishGate` takes a payload, the last record and a `now` and returns one boolean per surface; `NotifyDeviceLink` and `NotifyLimits` are parsers; `NotifyGatewayClient.failure(status:data:retryAfterHeader:)` is static and takes the raw body, so every status code can be driven through it without a network stub.
+
+`NotifyPublishDriver` is deliberately free of judgement. It gathers state, asks the builder and the gate, and performs the writes the answer implies.
+
+Rules under test, in `Claude UsageTests/Notify*Tests.swift`:
+
+- the worst window leads, and the tile takes its tint, bar and countdown from that one
+- ordering is deterministic to the last tiebreak, so two payloads from the same readings compare equal
+- at most six metrics reach the tile, and a seventh reading is dropped rather than failing the whole tile
+- labels omit the provider name when every reading is from the same provider, and regain it when a second appears
+- a percentage is remaining: a 42% window publishes `progress: 42`, never 58
+- a money window publishes its formatted balance with no unit, and the tile's bar falls through to the worst window that has a percentage
+- a gauge selection naming a window that has stopped reporting falls back to the worst window rather than publishing nothing
+- the Live Activity and the Home Screen tile are one built value, so the two can never disagree about the same number
+- the gate holds a changed tile back inside its minimum interval, and releases it once the interval has passed
+- the gate republishes an unchanged tile after the keep alive, and only then; the gauge takes the interval and no keep alive
+- the record merges the three surfaces one at a time, so a surface the gate held back still remembers what it is actually showing
+- the gate never writes a surface the payload left nil, because nil means the user switched that surface off
+- a bare `id token` pair, a whole pasted notification URL, and the two fields all yield the same link
+- an id outside 8 to 32 alphanumeric characters is refused locally, before any request exists
+- `GRP` plus 5 reads as a group, `WB` plus 14 as a browser, `MC` plus 14 as a Mac, `IO` plus 14 and a bare 8 characters as an app device, with the group prefix winning the overlap at eight characters
+- a Mac and a browser keep both widgets and cannot show a Live Activity, a group keeps none of the three, and an id from a namespace that does not exist yet can do everything
+- the two widgets always answer alike for the same id, and each reason is present exactly when its own surface is unavailable
+- a Live Activity aimed at a Mac, a browser or a group fails before a request exists, and so does either widget aimed at a group
+- an over-long label shortens; an empty one is refused; a tint that is not 6 or 8 hex digits is dropped rather than failing the publish
+- a percentage outside 0 to 100 clamps, because a window can legitimately report a negative remainder
+- each status maps to the one error whose remedy differs, and a 429's wait comes from the body's own seconds first, the `Retry-After` header second, and 30 minutes when neither is present
+- every field the app drives is present in the body on every write, as an explicit null when it has no value, while the fields it never drives stay unmentioned
+- an expired session window reads as full rather than as its stale percentage, and an unused per-model window is left out entirely
+- a saved token reads back again, and saving a link reports whether it actually landed
+- a token never reaches UserDefaults, whichever way the save went
+- a link naming a different device clears the three surface handles, while rotating the token for the same device keeps them
+
+## Prior art
+
+The design is a port of the same feature in [ClaudeBar](https://github.com/simplytoast1/ClaudeBar) (`feat/notify-lock-screen-publishing` and `feat/notify-home-screen-widget`), whose `docs/features/notify.md` read the gateway's OpenAPI document end to end. The decision layer, the gate, the error mapping and the client are ports of that work. What is new here is `NotifyUsageReadings`, because this app's `ClaudeUsage` is a fixed set of named windows rather than a generic list, and `NotifyPublishDriver`, which is rebuilt on Combine and a delegate-free singleton because this app does not use `@Observable`.
+
+## Considered and rejected
+
+**Send `endsIn` for a live countdown to the reset.** The gateway will happily tick a countdown locally on the device, which sounds strictly better than the static `trailing` text sent here. It was cut because the countdown claims the tile's progress rendering, and the percentage needs that bar: a tile cannot show both how much is left and how long until it refills, and the percentage is the thing the app exists for.
+
+**Use the device-scoped upsert URL instead of storing handles.** One line shorter and needs nothing persisted. It also takes over whichever tile the device last had, which for a Notify! user is very likely one of their own scripts.
+
+**Publish every profile at once.** The six metric slots get tight with two accounts, and a phone that disagreed with the Mac's menu bar is worse than one that shows less. Worth revisiting if somebody asks for it.
+
+## Open questions
+
+- **More than one gauge.** The gateway allows 10 widgets per device, so a widget per provider is possible. Unresolved: the widget title is its identity in the phone's picker, so several widgets need distinguishable titles that are still recognizably this app.
+- **Should an exhausted window end the tile?** `endTile(link:activityId:keepFor:)` is implemented and the driver never calls it. Proposal: no. A depleted window is precisely when the number matters most, and a tile that vanishes at 0% is a tile that disappeared exactly when the user went looking for it.
+- **Notify! groups.** `GET /link` already reports `type: "device"` or `"group"`, and the client rejects a group because a group carries none of the three surfaces. Publishing to a phone and an iPad at once therefore means a list of device links rather than one, with per-device handles and per-device backoff state.


### PR DESCRIPTION
## Description

Puts the active profile's usage on the user's phone, without this app shipping an iOS app of its own.

Every surface we have today is on the Mac and needs the Mac awake and in front of you: the menu bar icon, the popover, notifications, the Dynamic Island. The question the app exists to answer is *"can I start another long run?"*, and it gets asked away from the desk as often as at it. `Views/Settings/App/MobileAppView.swift` is a painted door counting taps for exactly this.

[Notify!](https://getnotifyapp.com) already built the hard part: a published app on Mac, iOS and web push that owns the push certificates, the device pairing, and the iOS Live Activity and widget extensions. It exposes a plain HTTP gateway with no SDK and no bearer token, addressed by a device ID and a per-device secret the user copies out of the app. So the whole feature on our side is turning usage we already hold into two small JSON bodies and POSTing them to three routes.

Off by default, behind its own settings pane, and it stays off until a device is linked.

## ⚠️ The app must be signed to link a device

Worth stating up front, because the failure is otherwise puzzling.

The device token is a secret, so it goes in the Keychain, and nowhere else. **An ad-hoc signed build has no reachable Keychain at all**: the data-protection keychain wants an application-identifier entitlement such a build cannot carry, and the file-based login keychain is deliberately gated off for ad-hoc identities because their designated requirement changes on every rebuild and the next launch would throw an ACL password prompt (#292).

That covers every copy built locally in Xcode without a development team set. **Linking fails there, with a message naming the cause and the fix.** Setting a Team under Signing & Capabilities, or using a release build, resolves it. Nothing else about the feature depends on signing.

The alternative (falling back to `UserDefaults` so local builds work) was implemented and then removed. It contradicts what the README promises for every other credential in this app: kept in the Keychain, never in cleartext on disk (GHSA-mfxh-xpwm-23c7). A push token is not the place to make an exception for convenience.

## Changes

**Three surfaces, each switchable on its own**

- **Live Activity tile**: up to six windows side by side, a progress bar, a compact reset countdown. iPhone/iPad only; the gateway refuses a start aimed at a Mac, a browser or a group.
- **Lock Screen widget**: one window as a ring or a bar. Shows whichever needs attention most until the user picks a specific one.
- **Home Screen widget**: carries the identical tile, but stays where it is placed. Still behind Notify!'s server-side kill switch, so it may render nothing until they switch it on; a 503 there is handled as "not yet", not as an error.

**The decision layer is pure and clock-free** (`Claude Usage/Shared/Notify/`)

- `NotifyPayloadBuilder`: worst window leads, percentages are remaining not used, labels drop the provider name when every reading shares one, ordering deterministic down to a provider-ID tiebreak so two payloads from the same state compare equal.
- `NotifyPublishGate`: a minimum gap per surface (60 s tile, 15 min widgets) plus a 90-minute keep-alive that clears both of the gateway's two-hour deadlines.
- `NotifyGatewayClient`: the only file that knows HTTP exists. Always creates its own tile and widgets with `new: true` and addresses them by handle afterwards, so we never take over a tile the user is driving from their own script.
- `NotifyPublishError`: every status code mapped to the error whose remedy differs (410 restart once, 403 forget that one handle, 429 back off, 409 open the app, 502 keep or wait, 503 pause six hours).

**New for this app**

- `NotifyUsageReadings` flattens `ClaudeUsage` into the windows a provider actually reports. An unused per-model window would otherwise sort as a healthy 100% and take one of the tile's six slots from a number that matters. An expired session window reads as full rather than as its stale percentage.
- `NotifyPublishDriver` follows `ProfileManager.$activeProfile`, so the phone shows what the menu bar shows and switching profile moves both. Combine plus a one-minute tick; brought up and down from `AppDelegate` like `NotchHUDController`.

**Storage**

- `notify.*` keys in UserDefaults for the switches, the gauge selection and the three surface handles.
- The token uses the same hardened `saveItem`/`loadItem` helpers as the per-profile secrets, **not** the older `save(_:for:)` API. That one attaches a `kSecAttrAccessControl` and routes to the data-protection keychain with no fallback. The save is confirmed by reading it back, and `saveDeviceLink` returns whether it landed, so the pane can never report a link that did not save.

**Privacy**

What leaves the Mac: provider names, window labels, remaining percentages or balances, reset countdowns. No prompts, no repository names, no file paths, no session content. It goes to `push.getnotifyapp.com` and from there to the user's own phone.

**Tests**: 7 files, ~1,400 lines, no mocks needed. Everything that decides something takes its `now` as a parameter. Rules pinned include: the worst window leads; ordering is deterministic; at most six metrics; a percentage is remaining; a money window falls the bar through to the worst window that has one; the gate holds a change back inside its interval and republishes an unchanged tile after the keep-alive; the record merges per surface so a held-back surface still remembers what it shows; every id namespace and which surfaces it carries; every status → error mapping; a saved token reads back again; and a token never reaches UserDefaults.

**Localization**: 91 new keys across all 15 `.lproj` files, `validate_localizations.sh` passing at 911 each. The 14 non-English files carry the English text under a note marking them for translation.

## Screenshots / Screen Recordings

<img width="1401" height="547" alt="image" src="https://github.com/user-attachments/assets/0b18f188-334d-4f74-a39d-daf1bfe7a78a" />

## Notes for review

- **Multi-profile is deliberately narrow.** The active profile only, so the phone agrees with the menu bar. Merging every profile into one tile would need the six metric slots to cover several accounts. Easy to widen later if anyone asks.
- **The tile republishes about once a minute** while a window is under 24 h out, because the reset countdown ticks at minute granularity and the tile's minimum gap is 60 s. That is ClaudeBar's accepted trade (the tile is a push, so it can afford to be prompt), kept rather than quietly changed. Happy to make the countdown coarser if it reads as too chatty.
- `NotifyPublishDriver` is explicitly `@MainActor` even though `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor` already supplies it, so flipping that setting later cannot silently unisolate a class that drives timers, `ProfileManager` and UI state. Its dependencies are supplied from a convenience initializer rather than as parameter defaults, since default argument expressions are evaluated in a nonisolated context.

## Important Guidelines

- **No App Groups Keychain, no group identifiers.** The token uses the standard Keychain path this app already uses for per-profile secrets. No `kSecAttrAccessGroup`, no App Group entitlement, nothing new in the entitlements files.
- Follows the existing architecture: pure value types for decisions, a service for I/O, the settings pane alongside the others.
- Localization keys added for every user-facing string.
- Targets macOS 14.0+.

## Checklist

- [x] I have tested these changes on a running build, including publishing to a linked device
- [x] I have attached screenshots/recordings for any visual changes
- [x] I have not introduced App Group or grouped Keychain usage
- [x] I have added localization keys for any new user-facing strings
